### PR TITLE
refactor: isolate xml tags to separate module

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -78,6 +78,7 @@ primary_domain = "py"
 nitpicky = True  # warn if cross-references are missing
 nitpick_ignore = [
     ("py:class", "StateTransitionGraph"),
+    ("py:class", "expertsystem.io.xml.LabelConstants"),
     ("py:class", "expertsystem.solvers.constraint.Constraint"),
     ("py:class", "expertsystem.state.propagation.GraphElementTypes"),
 ]

--- a/expertsystem/__init__.py
+++ b/expertsystem/__init__.py
@@ -18,6 +18,7 @@ parameters so that they resemble the data set as good as possible.
 
 __all__ = [
     "amplitude",
+    "io",
     "state",
     "topology",
     "ui",

--- a/expertsystem/amplitude/helicitydecay.py
+++ b/expertsystem/amplitude/helicitydecay.py
@@ -5,11 +5,11 @@ from copy import deepcopy
 
 import xmltodict
 
+from expertsystem.io import xml
 from .abstractgenerator import (
     AbstractAmplitudeNameGenerator,
     AbstractAmplitudeGenerator,
 )
-
 from ..topology.graph import (
     get_initial_state_edges,
     get_final_state_edges,
@@ -19,8 +19,6 @@ from ..topology.graph import (
 from ..state.particle import (
     StateQuantumNumberNames,
     InteractionQuantumNumberNames,
-    XMLLabelConstants,
-    get_xml_label,
     get_interaction_property,
     get_particle_property,
 )
@@ -70,10 +68,10 @@ def get_graph_group_unique_label(graph_group):
 
 
 def get_helicity_from_edge_props(edge_props):
-    qns_label = get_xml_label(XMLLabelConstants.QuantumNumber)
-    type_label = get_xml_label(XMLLabelConstants.Type)
+    qns_label = xml.get_label(xml.CONSTANTS.QuantumNumber)
+    type_label = xml.get_label(xml.CONSTANTS.Type)
     spin_label = StateQuantumNumberNames.Spin
-    proj_label = get_xml_label(XMLLabelConstants.Projection)
+    proj_label = xml.get_label(xml.CONSTANTS.Projection)
     for qn in edge_props[qns_label]:
         if qn[type_label] == spin_label.name:
             return qn[proj_label]
@@ -229,7 +227,7 @@ def generate_particle_list(graphs):
     for g in graphs:
         for edge_props in g.edge_props.values():
             new_edge_props = remove_spin_projection(edge_props)
-            par_name = new_edge_props[get_xml_label(XMLLabelConstants.Name)]
+            par_name = new_edge_props[xml.get_label(xml.CONSTANTS.Name)]
             if par_name not in temp_particle_names:
                 particles.append(new_edge_props)
                 temp_particle_names.append(par_name)
@@ -237,10 +235,10 @@ def generate_particle_list(graphs):
 
 
 def remove_spin_projection(edge_props):
-    qns_label = get_xml_label(XMLLabelConstants.QuantumNumber)
-    type_label = get_xml_label(XMLLabelConstants.Type)
+    qns_label = xml.get_label(xml.CONSTANTS.QuantumNumber)
+    type_label = xml.get_label(xml.CONSTANTS.Type)
     spin_label = StateQuantumNumberNames.Spin
-    proj_label = get_xml_label(XMLLabelConstants.Projection)
+    proj_label = xml.get_label(xml.CONSTANTS.Projection)
 
     new_edge_props = deepcopy(edge_props)
 
@@ -267,7 +265,7 @@ def generate_particles_string(
 
 
 def _get_name_hel_list(graph, edge_ids):
-    name_label = get_xml_label(XMLLabelConstants.Name)
+    name_label = xml.get_label(xml.CONSTANTS.Name)
     name_hel_list = []
     for i in edge_ids:
         temp_hel = float(get_helicity_from_edge_props(graph.edge_props[i]))
@@ -322,7 +320,7 @@ class HelicityAmplitudeNameGenerator(AbstractAmplitudeNameGenerator):
                     seq_par_suffix += coeff_suffix + ";"
                     self.partial_amp_coefficient_infos.add(coeff_suffix)
 
-        par_label = get_xml_label(XMLLabelConstants.Parameter)
+        par_label = xml.get_label(xml.CONSTANTS.Parameter)
         amplitude_coefficient_infos = {
             par_label: [
                 {
@@ -346,7 +344,7 @@ class HelicityAmplitudeNameGenerator(AbstractAmplitudeNameGenerator):
         if self.use_parity_conservation and use_prefactor:
             prefactor = get_prefactor(graph)
             if prefactor != 1.0 and prefactor is not None:
-                prefactor_label = get_xml_label(XMLLabelConstants.PreFactor)
+                prefactor_label = xml.get_label(xml.CONSTANTS.PreFactor)
                 amplitude_coefficient_infos[prefactor_label] = {
                     "@Real": prefactor
                 }
@@ -428,8 +426,8 @@ class HelicityAmplitudeGeneratorXML(AbstractAmplitudeGenerator):
                 "Number of solution graphs is not larger than zero!"
             )
 
-        decay_info = {get_xml_label(XMLLabelConstants.Type): "nonResonant"}
-        decay_info_label = get_xml_label(XMLLabelConstants.DecayInfo)
+        decay_info = {xml.get_label(xml.CONSTANTS.Type): "nonResonant"}
+        decay_info_label = xml.get_label(xml.CONSTANTS.DecayInfo)
         for g in graphs:
             if self.top_node_no_dynamics:
                 init_edges = get_initial_state_edges(g)
@@ -459,11 +457,11 @@ class HelicityAmplitudeGeneratorXML(AbstractAmplitudeGenerator):
         pass
 
     def generate_amplitude_info(self, graph_groups):
-        class_label = get_xml_label(XMLLabelConstants.Class)
-        name_label = get_xml_label(XMLLabelConstants.Name)
-        component_label = get_xml_label(XMLLabelConstants.Component)
-        type_label = get_xml_label(XMLLabelConstants.Type)
-        parameter_label = get_xml_label(XMLLabelConstants.Parameter)
+        class_label = xml.get_label(xml.CONSTANTS.Class)
+        name_label = xml.get_label(xml.CONSTANTS.Name)
+        component_label = xml.get_label(xml.CONSTANTS.Component)
+        type_label = xml.get_label(xml.CONSTANTS.Type)
+        parameter_label = xml.get_label(xml.CONSTANTS.Parameter)
 
         # for each graph group we create a coherent amplitude
         coherent_intensites = []
@@ -517,12 +515,12 @@ class HelicityAmplitudeGeneratorXML(AbstractAmplitudeGenerator):
         }
 
     def generate_sequential_decay(self, graph):
-        class_label = get_xml_label(XMLLabelConstants.Class)
-        name_label = get_xml_label(XMLLabelConstants.Name)
-        component_label = get_xml_label(XMLLabelConstants.Component)
+        class_label = xml.get_label(xml.CONSTANTS.Class)
+        name_label = xml.get_label(xml.CONSTANTS.Name)
+        component_label = xml.get_label(xml.CONSTANTS.Component)
         spin_label = StateQuantumNumberNames.Spin
-        decay_info_label = get_xml_label(XMLLabelConstants.DecayInfo)
-        type_label = get_xml_label(XMLLabelConstants.Type)
+        decay_info_label = xml.get_label(xml.CONSTANTS.DecayInfo)
+        type_label = xml.get_label(xml.CONSTANTS.Type)
         partial_decays = []
         for node_id in graph.nodes:
             # in case a scalar without dynamics decays into daughters with no
@@ -566,7 +564,7 @@ class HelicityAmplitudeGeneratorXML(AbstractAmplitudeGenerator):
             "Amplitude": partial_decays,
         }
 
-        par_label = get_xml_label(XMLLabelConstants.Parameter)
+        par_label = xml.get_label(xml.CONSTANTS.Parameter)
         coefficient_amplitude_dict = {
             class_label: "CoefficientAmplitude",
             component_label: amp_name,
@@ -574,7 +572,7 @@ class HelicityAmplitudeGeneratorXML(AbstractAmplitudeGenerator):
             "Amplitude": sequential_amplitude_dict,
         }
 
-        prefactor_label = get_xml_label(XMLLabelConstants.PreFactor)
+        prefactor_label = xml.get_label(xml.CONSTANTS.PreFactor)
         if prefactor_label in amp_coeff_infos:
             coefficient_amplitude_dict.update(
                 {prefactor_label: amp_coeff_infos[prefactor_label]}
@@ -586,8 +584,8 @@ class HelicityAmplitudeGeneratorXML(AbstractAmplitudeGenerator):
         return coefficient_amplitude_dict
 
     def generate_partial_decay(self, graph, node_id):
-        class_label = get_xml_label(XMLLabelConstants.Class)
-        name_label = get_xml_label(XMLLabelConstants.Name)
+        class_label = xml.get_label(xml.CONSTANTS.Class)
+        name_label = xml.get_label(xml.CONSTANTS.Name)
         decay_products = []
         for out_edge_id in get_edges_outgoing_to_node(graph, node_id):
             decay_products.append(

--- a/expertsystem/io/__init__.py
+++ b/expertsystem/io/__init__.py
@@ -1,5 +1,4 @@
-"""This is a collection of helpers for file representations of the
-`expertsystem` input/output."""
+"""Collection of parsers and related tools for input/output."""
 
 
 __all__ = [

--- a/expertsystem/io/__init__.py
+++ b/expertsystem/io/__init__.py
@@ -1,0 +1,10 @@
+"""This is a collection of helpers for file representations of the
+`expertsystem` input/output."""
+
+
+__all__ = [
+    "xml",
+]
+
+
+from . import xml

--- a/expertsystem/io/xml.py
+++ b/expertsystem/io/xml.py
@@ -35,8 +35,9 @@ TAGS = [
 
 def get_label(enum: Enum) -> str:
     """
-    Return the the correctly formatted XML label as required by ComPWA and
-    ``xmltodict``.
+    Return the correctly formatted XML label.
+
+    The labels agree with what ComPWA expects and are used by ``xmltodict``.
     """
     attribute_prefix = "@"
     if enum in TAGS:

--- a/expertsystem/io/xml.py
+++ b/expertsystem/io/xml.py
@@ -1,0 +1,38 @@
+"""Tags used when writing to and from XML files."""
+
+
+from enum import Enum
+
+
+CONSTANTS = Enum(
+    "LabelConstants",
+    "Name "
+    "Pid "
+    "Type "
+    "Value "
+    "QuantumNumber "
+    "Class "
+    "Projection "
+    "Component "
+    "Parameter "
+    "PreFactor "
+    "DecayInfo",
+)
+
+Tags = [
+    CONSTANTS.QuantumNumber,
+    CONSTANTS.Parameter,
+    CONSTANTS.PreFactor,
+    CONSTANTS.DecayInfo,
+]
+
+
+def get_label(enum):
+    """
+    Return the the correctly formatted XML label as required by ComPWA and
+    ``xmltodict``.
+    """
+    attribute_prefix = "@"
+    if enum in Tags:
+        return enum.name
+    return attribute_prefix + enum.name

--- a/expertsystem/io/xml.py
+++ b/expertsystem/io/xml.py
@@ -1,6 +1,12 @@
 """Tags used when writing to and from XML files."""
 
 
+__all__ = [
+    "CONSTANTS",
+    "get_label",
+]
+
+
 from enum import Enum
 
 
@@ -27,7 +33,7 @@ TAGS = [
 ]
 
 
-def get_label(enum):
+def get_label(enum: Enum) -> str:
     """
     Return the the correctly formatted XML label as required by ComPWA and
     ``xmltodict``.

--- a/expertsystem/io/xml.py
+++ b/expertsystem/io/xml.py
@@ -19,7 +19,7 @@ CONSTANTS = Enum(
     "DecayInfo",
 )
 
-Tags = [
+TAGS = [
     CONSTANTS.QuantumNumber,
     CONSTANTS.Parameter,
     CONSTANTS.PreFactor,
@@ -33,6 +33,6 @@ def get_label(enum):
     ``xmltodict``.
     """
     attribute_prefix = "@"
-    if enum in Tags:
+    if enum in TAGS:
         return enum.name
     return attribute_prefix + enum.name

--- a/expertsystem/state/propagation.py
+++ b/expertsystem/state/propagation.py
@@ -11,6 +11,8 @@ from enum import Enum
 from abc import ABC, abstractmethod
 import logging
 
+from expertsystem.io import xml
+
 from ..solvers.constraint import (
     Problem,
     Constraint,
@@ -27,8 +29,6 @@ from ..topology.graph import (
 )
 from ..state.conservationrules import AbstractRule
 from ..state.particle import (
-    get_xml_label,
-    XMLLabelConstants,
     StateQuantumNumberNames,
     InteractionQuantumNumberNames,
     ParticlePropertyNames,
@@ -269,9 +269,9 @@ class ParticleStateTransitionGraphValidator(AbstractPropagator):
         Creates variables for the quantum numbers of the specified node.
         """
         variables = {}
-        type_label = get_xml_label(XMLLabelConstants.Type)
+        type_label = xml.get_label(xml.CONSTANTS.Type)
         if node_id in self.graph.node_props:
-            qns_label = get_xml_label(XMLLabelConstants.QuantumNumber)
+            qns_label = xml.get_label(xml.CONSTANTS.QuantumNumber)
             for qn_name in qn_list:
                 converter = QNClassConverterMapping[
                     QNNameClassMapping[qn_name]
@@ -627,7 +627,7 @@ class CSPPropagator(AbstractPropagator):
 def add_qn_to_graph_element(graph, var_info, value):
     if value is None:
         return
-    qns_label = get_xml_label(XMLLabelConstants.QuantumNumber)
+    qns_label = xml.get_label(xml.CONSTANTS.QuantumNumber)
 
     element_id = var_info.element_id
     qn_name = var_info.qn_name

--- a/expertsystem/ui/system_control.py
+++ b/expertsystem/ui/system_control.py
@@ -9,6 +9,7 @@ from os import path
 
 from progress.bar import IncrementalBar
 
+from expertsystem.io import xml
 from ..topology.graph import (
     StateTransitionGraph,
     InteractionNode,
@@ -25,8 +26,6 @@ from ..state.particle import (
     initialize_graph,
     get_particle_property,
     get_interaction_property,
-    XMLLabelConstants,
-    get_xml_label,
     StateQuantumNumberNames,
     InteractionQuantumNumberNames,
     ParticlePropertyNames,
@@ -92,7 +91,7 @@ class InteractionDeterminationFunctorInterface(ABC):
 
 
 class GammaCheck(InteractionDeterminationFunctorInterface):
-    name_label = get_xml_label(XMLLabelConstants.Name)
+    name_label = xml.get_label(xml.CONSTANTS.Name)
 
     def check(self, in_edge_props, out_edge_props, node_props):
         int_types = [x for x in InteractionTypes]
@@ -110,8 +109,8 @@ class LeptonCheck(InteractionDeterminationFunctorInterface):
         StateQuantumNumberNames.MuonLN,
         StateQuantumNumberNames.TauLN,
     ]
-    name_label = get_xml_label(XMLLabelConstants.Name)
-    qns_label = get_xml_label(XMLLabelConstants.QuantumNumber)
+    name_label = xml.get_label(xml.CONSTANTS.Name)
+    qns_label = xml.get_label(xml.CONSTANTS.QuantumNumber)
 
     def check(self, in_edge_props, out_edge_props, node_props):
         node_interaction_types = [x for x in InteractionTypes]
@@ -178,8 +177,8 @@ def remove_duplicate_solutions(
 
 
 def remove_qns_from_graph(graph, qn_list):
-    qns_label = get_xml_label(XMLLabelConstants.QuantumNumber)
-    type_label = get_xml_label(XMLLabelConstants.Type)
+    qns_label = xml.get_label(xml.CONSTANTS.QuantumNumber)
+    type_label = xml.get_label(xml.CONSTANTS.Type)
 
     int_qns = [
         x for x in qn_list if isinstance(x, InteractionQuantumNumberNames)
@@ -327,7 +326,7 @@ def require_interaction_property(
 
 
 def _find_node_ids_with_ingoing_particle_name(graph, ingoing_particle_name):
-    name_label = get_xml_label(XMLLabelConstants.Name)
+    name_label = xml.get_label(xml.CONSTANTS.Name)
     found_node_ids = []
     for node_id in graph.nodes:
         edge_ids = get_edges_ingoing_to_node(graph, node_id)
@@ -444,7 +443,7 @@ def calculate_swappings(id_mapping):
 
 
 def create_edge_id_particle_mapping(graph, external_edge_getter_function):
-    name_label = get_xml_label(XMLLabelConstants.Name)
+    name_label = xml.get_label(xml.CONSTANTS.Name)
     return {
         i: graph.edge_props[i][name_label]
         for i in external_edge_getter_function(graph)

--- a/tests/canonical-formalism/test_LSCoupling.py
+++ b/tests/canonical-formalism/test_LSCoupling.py
@@ -1,5 +1,6 @@
 import pytest
 
+from expertsystem.io import xml
 from expertsystem.ui.system_control import (
     StateTransitionManager,
     InteractionTypes,
@@ -12,7 +13,6 @@ from expertsystem.state.particle import (
     InteractionQuantumNumberNames,
     SpinQNConverter,
     Spin,
-    XMLLabelConstants,
 )
 from expertsystem.state.conservationrules import ParityConservationHelicity
 
@@ -131,7 +131,7 @@ def test_canonical_clebsch_gordan_ls_coupling(
 
     l_label = InteractionQuantumNumberNames.L
     s_label = InteractionQuantumNumberNames.S
-    qn_label = XMLLabelConstants.QuantumNumber
+    qn_label = xml.CONSTANTS.QuantumNumber
 
     spin_converter = SpinQNConverter()
     node_props = {

--- a/tests/ui/test_systemcontrol.py
+++ b/tests/ui/test_systemcontrol.py
@@ -1,5 +1,6 @@
 import pytest
 
+from expertsystem.io import xml
 from expertsystem.ui.system_control import (
     StateTransitionManager,
     InteractionTypes,
@@ -19,8 +20,6 @@ from expertsystem.topology.graph import (
 from expertsystem.state.particle import (
     create_spin_domain,
     InteractionQuantumNumberNames,
-    get_xml_label,
-    XMLLabelConstants,
 )
 
 
@@ -228,8 +227,8 @@ class TestSolutionFilter(object):
         self, input_values, filter_parameters, result
     ):
         graphs = []
-        name_label = get_xml_label(XMLLabelConstants.Name)
-        value_label = get_xml_label(XMLLabelConstants.Value)
+        name_label = xml.get_label(xml.CONSTANTS.Name)
+        value_label = xml.get_label(xml.CONSTANTS.Value)
         for x in input_values:
             tempgraph = make_ls_test_graph(x[1][0], x[1][1])
             tempgraph.add_edges([0])


### PR DESCRIPTION
Closes https://github.com/ComPWA/expertsystem/issues/4

This is a simple first step towards isolating the XML tags to a different submodule. There are still classes like `HelicityAmplitudeGeneratorXML` that should become more general (and work with an XML parser argument, for example), but that's for a follow-up PR.