### PR TITLE
refactor!: remove XML attributes

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -6,7 +6,13 @@
 init-import=yes
 
 [MESSAGES CONTROL]
-disable=C0116, C0330, RST203, RST301
+disable=
+    C0114, # done by pydocstyle
+    C0115, # done by pydocstyle
+    C0116, # done by pydocstyle
+    C0330, # https://github.com/psf/black/issues/48
+    RST203, # unexpected indentation
+    RST301, # related to google style docstring
 
 [MASTER]
 ignore=conf.py

--- a/examples/python/EpEmToChicPipPim.py
+++ b/examples/python/EpEmToChicPipPim.py
@@ -28,4 +28,4 @@ if len(solutions) == 0:
 
 print("intermediate states:")
 for g in solutions:
-    print(g.edge_props[1]["@Name"])
+    print(g.edge_props[1]["Name"])

--- a/examples/python/EpEmToD0D0barPipPim.py
+++ b/examples/python/EpEmToD0D0barPipPim.py
@@ -23,4 +23,4 @@ print("found " + str(len(solutions)) + " solutions!")
 for g in solutions:
     # print(g.node_props[0])
     # print(g.node_props[1])
-    print(g.edge_props[1]["@Name"])
+    print(g.edge_props[1]["Name"])

--- a/examples/python/JPsiToPi0PipPim.py
+++ b/examples/python/JPsiToPi0PipPim.py
@@ -11,6 +11,7 @@ from expertsystem.ui.system_control import (
 from expertsystem.amplitude.helicitydecay import (
     HelicityDecayAmplitudeGeneratorXML,
 )
+from expertsystem.state import particle
 
 logging.basicConfig(level=logging.INFO)
 
@@ -32,7 +33,7 @@ print("found " + str(len(solutions)) + " solutions!")
 
 print("intermediate states:")
 for g in solutions:
-    print(g.edge_props[1]["@Name"])
+    print(g.edge_props[1][particle.LABELS.Name.name])
 
 xml_generator = HelicityDecayAmplitudeGeneratorXML()
 xml_generator.generate(solutions)

--- a/expertsystem/amplitude/canonicaldecay.py
+++ b/expertsystem/amplitude/canonicaldecay.py
@@ -122,7 +122,7 @@ class CanonicalAmplitudeGeneratorXML(HelicityAmplitudeGeneratorXML):
                 daughter_spins[0].projection() - daughter_spins[1].projection()
             )
             cg_ls = OrderedDict()
-            cg_ls["@Type"] = "LS"
+            cg_ls["Type"] = "LS"
             cg_ls["@j1"] = L.magnitude()
             if L.projection() != 0.0:
                 raise ValueError(
@@ -131,20 +131,20 @@ class CanonicalAmplitudeGeneratorXML(HelicityAmplitudeGeneratorXML):
             cg_ls["@m1"] = L.projection()
             cg_ls["@j2"] = S.magnitude()
             cg_ls["@m2"] = decay_particle_lambda
-            cg_ls["@J"] = parent_spin.magnitude()
-            cg_ls["@M"] = decay_particle_lambda
+            cg_ls["J"] = parent_spin.magnitude()
+            cg_ls["M"] = decay_particle_lambda
             cg_ss = OrderedDict()
-            cg_ss["@Type"] = "s2s3"
+            cg_ss["Type"] = "s2s3"
             cg_ss["@j1"] = daughter_spins[0].magnitude()
             cg_ss["@m1"] = daughter_spins[0].projection()
             cg_ss["@j2"] = daughter_spins[1].magnitude()
             cg_ss["@m2"] = -daughter_spins[1].projection()
-            cg_ss["@J"] = S.magnitude()
-            cg_ss["@M"] = decay_particle_lambda
+            cg_ss["J"] = S.magnitude()
+            cg_ss["M"] = decay_particle_lambda
             cg_dict = {
                 "CanonicalSum": {
-                    "@L": int(L.magnitude()),
-                    "@S": S.magnitude(),
+                    "L": int(L.magnitude()),
+                    "S": S.magnitude(),
                     "ClebschGordan": [cg_ls, cg_ss],
                 }
             }

--- a/expertsystem/amplitude/helicitydecay.py
+++ b/expertsystem/amplitude/helicitydecay.py
@@ -16,11 +16,10 @@ from ..topology.graph import (
     get_edges_ingoing_to_node,
     get_edges_outgoing_to_node,
 )
+from ..state import particle
 from ..state.particle import (
     StateQuantumNumberNames,
     InteractionQuantumNumberNames,
-    XMLLabelConstants,
-    get_xml_label,
     get_interaction_property,
     get_particle_property,
 )
@@ -70,12 +69,12 @@ def get_graph_group_unique_label(graph_group):
 
 
 def get_helicity_from_edge_props(edge_props):
-    qns_label = get_xml_label(XMLLabelConstants.QuantumNumber)
-    type_label = get_xml_label(XMLLabelConstants.Type)
-    spin_label = StateQuantumNumberNames.Spin
-    proj_label = get_xml_label(XMLLabelConstants.Projection)
+    qns_label = particle.LABELS.QuantumNumber.name
+    type_label = particle.LABELS.Type.name
+    spin_label = StateQuantumNumberNames.Spin.name
+    proj_label = particle.LABELS.Projection.name
     for qn in edge_props[qns_label]:
-        if qn[type_label] == spin_label.name:
+        if qn[type_label] == spin_label:
             return qn[proj_label]
     logging.error(edge_props[qns_label])
     raise ValueError("Could not find spin projection quantum number!")
@@ -202,9 +201,9 @@ def generate_kinematics(graphs):
     for x in is_edge_ids:
         tempdict["InitialState"]["Particle"].append(
             {
-                "@Name": graphs[0].edge_props[x]["@Name"],
-                "@Id": x,
-                "@PositionIndex": counter,
+                "Name": graphs[0].edge_props[x]["Name"],
+                "Id": x,
+                "PositionIndex": counter,
             }
         )
         counter += 1
@@ -213,9 +212,9 @@ def generate_kinematics(graphs):
     for x in fs_edge_ids:
         tempdict["FinalState"]["Particle"].append(
             {
-                "@Name": graphs[0].edge_props[x]["@Name"],
-                "@Id": x,
-                "@PositionIndex": counter,
+                "Name": graphs[0].edge_props[x]["Name"],
+                "Id": x,
+                "PositionIndex": counter,
             }
         )
         counter += 1
@@ -229,7 +228,7 @@ def generate_particle_list(graphs):
     for g in graphs:
         for edge_props in g.edge_props.values():
             new_edge_props = remove_spin_projection(edge_props)
-            par_name = new_edge_props[get_xml_label(XMLLabelConstants.Name)]
+            par_name = new_edge_props[particle.LABELS.Name.name]
             if par_name not in temp_particle_names:
                 particles.append(new_edge_props)
                 temp_particle_names.append(par_name)
@@ -237,10 +236,10 @@ def generate_particle_list(graphs):
 
 
 def remove_spin_projection(edge_props):
-    qns_label = get_xml_label(XMLLabelConstants.QuantumNumber)
-    type_label = get_xml_label(XMLLabelConstants.Type)
-    spin_label = StateQuantumNumberNames.Spin
-    proj_label = get_xml_label(XMLLabelConstants.Projection)
+    qns_label = particle.LABELS.QuantumNumber.name
+    type_label = particle.LABELS.Type.name
+    spin_label = StateQuantumNumberNames.Spin.name
+    proj_label = particle.LABELS.Projection.name
 
     new_edge_props = deepcopy(edge_props)
 
@@ -267,7 +266,7 @@ def generate_particles_string(
 
 
 def _get_name_hel_list(graph, edge_ids):
-    name_label = get_xml_label(XMLLabelConstants.Name)
+    name_label = particle.LABELS.Name.name
     name_hel_list = []
     for i in edge_ids:
         temp_hel = float(get_helicity_from_edge_props(graph.edge_props[i]))
@@ -322,20 +321,20 @@ class HelicityAmplitudeNameGenerator(AbstractAmplitudeNameGenerator):
                     seq_par_suffix += coeff_suffix + ";"
                     self.partial_amp_coefficient_infos.add(coeff_suffix)
 
-        par_label = get_xml_label(XMLLabelConstants.Parameter)
+        par_label = particle.LABELS.Parameter.name
         amplitude_coefficient_infos = {
             par_label: [
                 {
-                    "@Class": "Double",
-                    "@Type": "Magnitude",
-                    "@Name": "Magnitude_" + seq_par_suffix,
+                    "Class": "Double",
+                    "Type": "Magnitude",
+                    "Name": "Magnitude_" + seq_par_suffix,
                     "Value": 1.0,
                     "Fix": False,
                 },
                 {
-                    "@Class": "Double",
-                    "@Type": "Phase",
-                    "@Name": "Phase_" + seq_par_suffix,
+                    "Class": "Double",
+                    "Type": "Phase",
+                    "Name": "Phase_" + seq_par_suffix,
                     "Value": 0.0,
                     "Fix": False,
                 },
@@ -346,9 +345,9 @@ class HelicityAmplitudeNameGenerator(AbstractAmplitudeNameGenerator):
         if self.use_parity_conservation and use_prefactor:
             prefactor = get_prefactor(graph)
             if prefactor != 1.0 and prefactor is not None:
-                prefactor_label = get_xml_label(XMLLabelConstants.PreFactor)
+                prefactor_label = particle.LABELS.PreFactor.name
                 amplitude_coefficient_infos[prefactor_label] = {
-                    "@Real": prefactor
+                    "Real": prefactor
                 }
         return amplitude_coefficient_infos
 
@@ -428,8 +427,8 @@ class HelicityAmplitudeGeneratorXML(AbstractAmplitudeGenerator):
                 "Number of solution graphs is not larger than zero!"
             )
 
-        decay_info = {get_xml_label(XMLLabelConstants.Type): "nonResonant"}
-        decay_info_label = get_xml_label(XMLLabelConstants.DecayInfo)
+        decay_info = {particle.LABELS.Type.name: "nonResonant"}
+        decay_info_label = particle.LABELS.DecayInfo.name
         for g in graphs:
             if self.top_node_no_dynamics:
                 init_edges = get_initial_state_edges(g)
@@ -459,11 +458,11 @@ class HelicityAmplitudeGeneratorXML(AbstractAmplitudeGenerator):
         pass
 
     def generate_amplitude_info(self, graph_groups):
-        class_label = get_xml_label(XMLLabelConstants.Class)
-        name_label = get_xml_label(XMLLabelConstants.Name)
-        component_label = get_xml_label(XMLLabelConstants.Component)
-        type_label = get_xml_label(XMLLabelConstants.Type)
-        parameter_label = get_xml_label(XMLLabelConstants.Parameter)
+        class_label = particle.LABELS.Class.name
+        name_label = particle.LABELS.Name.name
+        component_label = particle.LABELS.Component.name
+        type_label = particle.LABELS.Type.name
+        parameter_label = particle.LABELS.Parameter.name
 
         # for each graph group we create a coherent amplitude
         coherent_intensites = []
@@ -517,12 +516,12 @@ class HelicityAmplitudeGeneratorXML(AbstractAmplitudeGenerator):
         }
 
     def generate_sequential_decay(self, graph):
-        class_label = get_xml_label(XMLLabelConstants.Class)
-        name_label = get_xml_label(XMLLabelConstants.Name)
-        component_label = get_xml_label(XMLLabelConstants.Component)
+        class_label = particle.LABELS.Class.name
+        name_label = particle.LABELS.Name.name
+        component_label = particle.LABELS.Component.name
         spin_label = StateQuantumNumberNames.Spin
-        decay_info_label = get_xml_label(XMLLabelConstants.DecayInfo)
-        type_label = get_xml_label(XMLLabelConstants.Type)
+        decay_info_label = particle.LABELS.DecayInfo.name
+        type_label = particle.LABELS.Type.name
         partial_decays = []
         for node_id in graph.nodes:
             # in case a scalar without dynamics decays into daughters with no
@@ -566,7 +565,7 @@ class HelicityAmplitudeGeneratorXML(AbstractAmplitudeGenerator):
             "Amplitude": partial_decays,
         }
 
-        par_label = get_xml_label(XMLLabelConstants.Parameter)
+        par_label = particle.LABELS.Parameter.name
         coefficient_amplitude_dict = {
             class_label: "CoefficientAmplitude",
             component_label: amp_name,
@@ -574,7 +573,7 @@ class HelicityAmplitudeGeneratorXML(AbstractAmplitudeGenerator):
             "Amplitude": sequential_amplitude_dict,
         }
 
-        prefactor_label = get_xml_label(XMLLabelConstants.PreFactor)
+        prefactor_label = particle.LABELS.PreFactor.name
         if prefactor_label in amp_coeff_infos:
             coefficient_amplitude_dict.update(
                 {prefactor_label: amp_coeff_infos[prefactor_label]}
@@ -586,17 +585,17 @@ class HelicityAmplitudeGeneratorXML(AbstractAmplitudeGenerator):
         return coefficient_amplitude_dict
 
     def generate_partial_decay(self, graph, node_id):
-        class_label = get_xml_label(XMLLabelConstants.Class)
-        name_label = get_xml_label(XMLLabelConstants.Name)
+        class_label = particle.LABELS.Class.name
+        name_label = particle.LABELS.Name.name
         decay_products = []
         for out_edge_id in get_edges_outgoing_to_node(graph, node_id):
             decay_products.append(
                 {
                     name_label: graph.edge_props[out_edge_id][name_label],
-                    "@FinalState": determine_attached_final_state_string(
+                    "FinalState": determine_attached_final_state_string(
                         graph, out_edge_id
                     ),
-                    "@Helicity": get_helicity_from_edge_props(
+                    "Helicity": get_helicity_from_edge_props(
                         graph.edge_props[out_edge_id]
                     ),
                 }
@@ -612,14 +611,14 @@ class HelicityAmplitudeGeneratorXML(AbstractAmplitudeGenerator):
         recoil_system_dict = {}
         if recoil_edge_id is not None:
             tempdict = {
-                "@RecoilFinalState": determine_attached_final_state_string(
+                "RecoilFinalState": determine_attached_final_state_string(
                     graph, recoil_edge_id
                 )
             }
             if parent_recoil_edge_id is not None:
                 tempdict.update(
                     {
-                        "@ParentRecoilFinalState": determine_attached_final_state_string(
+                        "ParentRecoilFinalState": determine_attached_final_state_string(
                             graph, parent_recoil_edge_id
                         )
                     }
@@ -630,7 +629,7 @@ class HelicityAmplitudeGeneratorXML(AbstractAmplitudeGenerator):
             class_label: "HelicityDecay",
             "DecayParticle": {
                 name_label: dec_part[name_label],
-                "@Helicity": get_helicity_from_edge_props(dec_part),
+                "Helicity": get_helicity_from_edge_props(dec_part),
             },
             "DecayProducts": {"Particle": decay_products},
         }

--- a/expertsystem/state/particle.py
+++ b/expertsystem/state/particle.py
@@ -22,30 +22,22 @@ from ..topology.graph import (
 )
 
 
-XMLLabelConstants = Enum(
-    "XMLLabelConstants",
-    "Name Pid Type Value QuantumNumber Class Projection \
-                          Component Parameter PreFactor DecayInfo",
+LABELS = Enum(
+    "Labels",
+    [
+        "Class",
+        "Component",
+        "DecayInfo",
+        "Name",
+        "Parameter",
+        "Pid",
+        "PreFactor",
+        "Projection",
+        "QuantumNumber",
+        "Type",
+        "Value",
+    ],
 )
-
-XMLLabelTags = [
-    XMLLabelConstants.QuantumNumber,
-    XMLLabelConstants.Parameter,
-    XMLLabelConstants.PreFactor,
-    XMLLabelConstants.DecayInfo,
-]
-
-
-def get_xml_label(enum):
-    """
-    Return the the correctly formatted XML label as required by ComPWA and
-    ``xmltodict``.
-    """
-    attribute_prefix = "@"
-    if enum in XMLLabelTags:
-        return enum.name
-    else:
-        return attribute_prefix + enum.name
 
 
 class Spin:
@@ -117,24 +109,38 @@ def create_spin_domain(list_of_magnitudes, set_projection_zero=False):
     return domain_list
 
 
-QuantumNumberClasses = Enum("QuantumNumberClasses", "Int Float Spin")
+QuantumNumberClasses = Enum("QuantumNumberClasses", ["Int", "Float", "Spin"])
 
-"""definition of quantum number names for states"""
+"""Definition of quantum number names for states."""
 StateQuantumNumberNames = Enum(
     "StateQuantumNumberNames",
-    "Charge Spin Parity Cparity Gparity IsoSpin\
-    Strangeness Charm Bottomness Topness BaryonNumber ElectronLN MuonLN TauLN",
+    [
+        "BaryonNumber",
+        "Bottomness",
+        "Charge",
+        "Charm",
+        "Cparity",
+        "ElectronLN",
+        "Gparity",
+        "IsoSpin",
+        "MuonLN",
+        "Parity",
+        "Spin",
+        "Strangeness",
+        "TauLN",
+        "Topness",
+    ],
 )
 
 """definition of properties names of particles"""
-ParticlePropertyNames = Enum("ParticlePropertyNames", "Pid Mass")
+ParticlePropertyNames = Enum("ParticlePropertyNames", ["Pid", "Mass"])
 
 """definition of decay properties names of particles"""
-ParticleDecayPropertyNames = Enum("ParticleDecayPropertyNames", "Width")
+ParticleDecayPropertyNames = Enum("ParticleDecayPropertyNames", ["Width"])
 
 """definition of quantum number names for interaction nodes"""
 InteractionQuantumNumberNames = Enum(
-    "InteractionQuantumNumberNames", "L S ParityPrefactor"
+    "InteractionQuantumNumberNames", ["L", "S", "ParityPrefactor",]
 )
 
 QNDefaultValues = {
@@ -185,9 +191,9 @@ class AbstractQNConverter(ABC):
 
 
 class IntQNConverter(AbstractQNConverter):
-    value_label = get_xml_label(XMLLabelConstants.Value)
-    type_label = get_xml_label(XMLLabelConstants.Type)
-    class_label = get_xml_label(XMLLabelConstants.Class)
+    value_label = LABELS.Value.name
+    type_label = LABELS.Type.name
+    class_label = LABELS.Class.name
 
     def parse_from_dict(self, data_dict):
         return int(data_dict[self.value_label])
@@ -201,9 +207,9 @@ class IntQNConverter(AbstractQNConverter):
 
 
 class FloatQNConverter(AbstractQNConverter):
-    value_label = get_xml_label(XMLLabelConstants.Value)
-    type_label = get_xml_label(XMLLabelConstants.Type)
-    class_label = get_xml_label(XMLLabelConstants.Class)
+    value_label = LABELS.Value.name
+    type_label = LABELS.Type.name
+    class_label = LABELS.Class.name
 
     def parse_from_dict(self, data_dict):
         return float(data_dict[self.value_label])
@@ -217,10 +223,10 @@ class FloatQNConverter(AbstractQNConverter):
 
 
 class SpinQNConverter(AbstractQNConverter):
-    type_label = get_xml_label(XMLLabelConstants.Type)
-    class_label = get_xml_label(XMLLabelConstants.Class)
-    value_label = get_xml_label(XMLLabelConstants.Value)
-    proj_label = get_xml_label(XMLLabelConstants.Projection)
+    type_label = LABELS.Type.name
+    class_label = LABELS.Class.name
+    value_label = LABELS.Value.name
+    proj_label = LABELS.Projection.name
 
     def __init__(self, parse_projection=True):
         self.parse_projection = parse_projection
@@ -271,12 +277,12 @@ def load_particle_list_from_xml(file_path):
     If a particle name in the loaded XML file already exists in the
     ``particle_list``, the one in the ``particle_list`` will be overwritten.
     """
-    name_label = get_xml_label(XMLLabelConstants.Name)
+    name_label = LABELS.Name.name
     with open(file_path, "rb") as xmlfile:
         full_dict = xmltodict.parse(xmlfile)
-        for p in full_dict["ParticleList"]["Particle"]:
-            entry = dict(p)
-            particle_list[entry[name_label]] = entry
+        for particle_definition in full_dict["ParticleList"]["Particle"]:
+            particle_name = particle_definition[name_label]
+            particle_list[particle_name] = particle_definition
 
 
 def write_particle_list_to_xml(file_path: str):
@@ -299,7 +305,7 @@ def add_to_particle_list(particle):
     if not isinstance(particle, dict):
         logging.warning("Can only add dictionary entries to particle_list")
         return
-    particle_name = particle[get_xml_label(XMLLabelConstants.Name)]
+    particle_name = particle[LABELS.Name.name]
     particle_list[particle_name] = particle
 
 
@@ -321,9 +327,9 @@ def get_particle_copy_by_name(particle_name):
 
 
 def get_particle_property(particle_properties, qn_name, converter=None):
-    qns_label = get_xml_label(XMLLabelConstants.QuantumNumber)
-    type_label = get_xml_label(XMLLabelConstants.Type)
-    value_label = get_xml_label(XMLLabelConstants.Value)
+    qns_label = LABELS.QuantumNumber.name
+    type_label = LABELS.Type.name
+    value_label = LABELS.Value.name
 
     found_prop = None
     if isinstance(qn_name, StateQuantumNumberNames):
@@ -339,10 +345,10 @@ def get_particle_property(particle_properties, qn_name, converter=None):
                 break
             if key == "Parameter" and val[type_label] == qn_name.name:
                 # parameters have a separate value tag
-                tagname = XMLLabelConstants.Value.name
+                tagname = LABELS.Value.name
                 found_prop = {value_label: val[tagname]}
                 break
-            if key == XMLLabelConstants.DecayInfo.name:
+            if key == LABELS.DecayInfo.name:
                 for decinfo_key, decinfo_val in val.items():
                     if decinfo_key == qn_name.name:
                         found_prop = {value_label: decinfo_val}
@@ -353,7 +359,7 @@ def get_particle_property(particle_properties, qn_name, converter=None):
                         for parval in decinfo_val:
                             if parval[type_label] == qn_name.name:
                                 # parameters have a separate value tag
-                                tagname = XMLLabelConstants.Value.name
+                                tagname = LABELS.Value.name
                                 found_prop = {value_label: parval[tagname]}
                                 break
                         if found_prop:
@@ -373,8 +379,8 @@ def get_particle_property(particle_properties, qn_name, converter=None):
 
 
 def get_interaction_property(interaction_properties, qn_name, converter=None):
-    qns_label = get_xml_label(XMLLabelConstants.QuantumNumber)
-    type_label = get_xml_label(XMLLabelConstants.Type)
+    qns_label = LABELS.QuantumNumber.name
+    type_label = LABELS.Type.name
 
     found_prop = None
     if isinstance(qn_name, InteractionQuantumNumberNames):
@@ -417,7 +423,7 @@ class CompareGraphElementPropertiesFunctor:
     def compare_qn_numbers(self, qns1, qns2):
         new_qns1 = {}
         new_qns2 = {}
-        type_label = get_xml_label(XMLLabelConstants.Type)
+        type_label = LABELS.Type.name
         for x in qns1:
             if x[type_label] not in self.ignored_qn_list:
                 temp_qn_dict = dict(x)
@@ -439,7 +445,7 @@ class CompareGraphElementPropertiesFunctor:
     def __call__(self, props1, props2):
         # for more speed first compare the names (if they exist)
 
-        name_label = get_xml_label(XMLLabelConstants.Name)
+        name_label = LABELS.Name.name
         names1 = {
             k: v[name_label] for k, v in props1.items() if name_label in v
         }
@@ -453,7 +459,7 @@ class CompareGraphElementPropertiesFunctor:
                 return False
 
         # then compare the qn lists (if they exist)
-        qns_label = get_xml_label(XMLLabelConstants.QuantumNumber)
+        qns_label = LABELS.QuantumNumber.name
         for ele_id, props in props1.items():
             qns1 = []
             qns2 = []
@@ -467,7 +473,7 @@ class CompareGraphElementPropertiesFunctor:
         copy_props1 = deepcopy(props1)
         copy_props2 = deepcopy(props2)
         # remove the qn dicts
-        qns_label = get_xml_label(XMLLabelConstants.QuantumNumber)
+        qns_label = LABELS.QuantumNumber.name
         for ele_id in props1.keys():
             if qns_label in copy_props1[ele_id]:
                 del copy_props1[ele_id][qns_label]
@@ -645,9 +651,9 @@ def initialize_edges(graph, edge_particle_dict):
 
 
 def populate_edge_with_spin_projections(graph, edge_id, spin_projections):
-    qns_label = get_xml_label(XMLLabelConstants.QuantumNumber)
-    type_label = get_xml_label(XMLLabelConstants.Type)
-    class_label = get_xml_label(XMLLabelConstants.Class)
+    qns_label = LABELS.QuantumNumber.name
+    type_label = LABELS.Type.name
+    class_label = LABELS.Class.name
     type_value = StateQuantumNumberNames.Spin
     class_value = QNNameClassMapping[type_value]
 
@@ -667,7 +673,7 @@ def populate_edge_with_spin_projections(graph, edge_id, spin_projections):
         for spin_proj in spin_projections:
             graph_copy = deepcopy(graph)
             graph_copy.edge_props[edge_id][qns_label][index_list[0]][
-                get_xml_label(XMLLabelConstants.Projection)
+                LABELS.Projection.name
             ] = spin_proj
             new_graphs.append(graph_copy)
 
@@ -722,7 +728,7 @@ def initialize_allowed_particle_list(allowed_particle_list):
 
 def get_particle_candidates_for_state(state, allowed_particle_list):
     particle_edges = []
-    qns_label = get_xml_label(XMLLabelConstants.QuantumNumber)
+    qns_label = LABELS.QuantumNumber.name
 
     for allowed_state in allowed_particle_list:
         if check_qns_equal(state[qns_label], allowed_state[qns_label]):
@@ -736,8 +742,8 @@ def get_particle_candidates_for_state(state, allowed_particle_list):
 
 def check_qns_equal(qns_state, qns_particle):
     equal = True
-    class_label = get_xml_label(XMLLabelConstants.Class)
-    type_label = get_xml_label(XMLLabelConstants.Type)
+    class_label = LABELS.Class.name
+    type_label = LABELS.Type.name
     for qn_entry in qns_state:
         qn_found = False
         qn_value_match = False
@@ -769,10 +775,8 @@ def check_qns_equal(qns_state, qns_particle):
 
 
 def compare_qns(qn_dict, qn_dict2):
-    qn_class = QuantumNumberClasses[
-        qn_dict[get_xml_label(XMLLabelConstants.Class)]
-    ]
-    value_label = get_xml_label(XMLLabelConstants.Value)
+    qn_class = QuantumNumberClasses[qn_dict[LABELS.Class.name]]
+    value_label = LABELS.Value.name
 
     val1 = None
     val2 = qn_dict2
@@ -785,7 +789,7 @@ def compare_qns(qn_dict, qn_dict2):
         if isinstance(qn_dict2, dict):
             val2 = float(qn_dict2[value_label])
     elif qn_class is QuantumNumberClasses.Spin:
-        spin_proj_label = get_xml_label(XMLLabelConstants.Projection)
+        spin_proj_label = LABELS.Projection.name
         if isinstance(qn_dict2, dict):
             if spin_proj_label in qn_dict and spin_proj_label in qn_dict2:
                 val1 = Spin(qn_dict[value_label], qn_dict[spin_proj_label])
@@ -802,8 +806,8 @@ def compare_qns(qn_dict, qn_dict2):
 
 
 def merge_qn_props(qns_state, qns_particle):
-    class_label = get_xml_label(XMLLabelConstants.Class)
-    type_label = get_xml_label(XMLLabelConstants.Type)
+    class_label = LABELS.Class.name
+    type_label = LABELS.Type.name
     qns = deepcopy(qns_particle)
     for qn_entry in qns_state:
         qn_found = False

--- a/expertsystem/state/particle.py
+++ b/expertsystem/state/particle.py
@@ -23,7 +23,7 @@ from ..topology.graph import (
 
 
 LABELS = Enum(
-    "Labels",
+    "LABELS",
     [
         "Class",
         "Component",

--- a/expertsystem/state/particle.py
+++ b/expertsystem/state/particle.py
@@ -268,14 +268,15 @@ def is_boson(qn_dict):
 particle_list = dict()
 
 
-def load_particle_list_from_xml(file_path):
+def load_particle_list_from_xml(file_path: str) -> None:
     """
     By default, the expert system loads the ``particle_list``
     from the XML file ``particle_list.xml`` located in the ComPWA module.
     Use `.load_particle_list_from_xml` to append to the ``particle_list``.
+
     .. note::
-    If a particle name in the loaded XML file already exists in the
-    ``particle_list``, the one in the ``particle_list`` will be overwritten.
+        If a particle name in the loaded XML file already exists in the
+        ``particle_list``, the one in the ``particle_list`` will be overwritten.
     """
     name_label = LABELS.Name.name
     with open(file_path, "rb") as xmlfile:
@@ -285,11 +286,13 @@ def load_particle_list_from_xml(file_path):
             particle_list[particle_name] = particle_definition
 
 
-def write_particle_list_to_xml(file_path: str):
+def write_particle_list_to_xml(
+    file_path: str = "new_particle_list.xml",
+) -> None:
     """Write ``particle_list`` instance to XML file."""
-    entries = [entry for entry in particle_list.values()]
+    entries = list(particle_list.values())
     particle_dict = {"ParticleList": {"Particle": entries}}
-    with open("new_particle_list.xml", "w") as output_file:
+    with open(file_path, "w") as output_file:
         output_file.write(
             xmltodict.unparse(particle_dict, full_document=False, pretty=True)
         )

--- a/expertsystem/state/propagation.py
+++ b/expertsystem/state/propagation.py
@@ -26,9 +26,8 @@ from ..topology.graph import (
     get_intermediate_state_edges,
 )
 from ..state.conservationrules import AbstractRule
+from ..state import particle
 from ..state.particle import (
-    get_xml_label,
-    XMLLabelConstants,
     StateQuantumNumberNames,
     InteractionQuantumNumberNames,
     ParticlePropertyNames,
@@ -269,9 +268,9 @@ class ParticleStateTransitionGraphValidator(AbstractPropagator):
         Creates variables for the quantum numbers of the specified node.
         """
         variables = {}
-        type_label = get_xml_label(XMLLabelConstants.Type)
+        type_label = particle.LABELS.Type.name
         if node_id in self.graph.node_props:
-            qns_label = get_xml_label(XMLLabelConstants.QuantumNumber)
+            qns_label = particle.LABELS.QuantumNumber.name
             for qn_name in qn_list:
                 converter = QNClassConverterMapping[
                     QNNameClassMapping[qn_name]
@@ -627,7 +626,7 @@ class CSPPropagator(AbstractPropagator):
 def add_qn_to_graph_element(graph, var_info, value):
     if value is None:
         return
-    qns_label = get_xml_label(XMLLabelConstants.QuantumNumber)
+    qns_label = particle.LABELS.QuantumNumber.name
 
     element_id = var_info.element_id
     qn_name = var_info.qn_name

--- a/expertsystem/ui/default_settings.py
+++ b/expertsystem/ui/default_settings.py
@@ -24,10 +24,8 @@ from ..state.conservationrules import (
 )
 
 default_particle_list_search_paths = [
-    "../../../../Physics",
-    "../../../..",
-    "../../",
-    "../",
+    ".",
+    "..",
 ]
 default_particle_list_search_paths += [sys.prefix + "/share"]
 default_particle_list_search_paths += [path + "/share" for path in sys.path]

--- a/expertsystem/ui/system_control.py
+++ b/expertsystem/ui/system_control.py
@@ -6,8 +6,11 @@ from abc import ABC, abstractmethod
 from multiprocessing import Pool
 import inspect
 from os import path
+from typing import Callable
 
 from progress.bar import IncrementalBar
+
+import expertsystem
 
 from ..topology.graph import (
     StateTransitionGraph,
@@ -568,31 +571,7 @@ class StateTransitionManager:
                 )
         self.topology_builder = SimpleStateTransitionTopologyBuilder(int_nodes)
 
-        # load default particles from database/file
-        if len(particle_list) == 0:
-            for search_path in default_particle_list_search_paths:
-                if search_path.startswith("/"):  # absolute path
-                    file_path = search_path
-                else:  # relative path
-                    file_path = (
-                        path.dirname(inspect.getfile(StateTransitionManager))
-                        + "/"
-                        + search_path
-                    )
-                file_path += "/particle_list.xml"
-                if path.exists(file_path):
-                    load_particle_list_from_xml(file_path)
-                    logging.info(
-                        "loaded "
-                        + str(len(particle_list))
-                        + " particles from xml file!"
-                    )
-                    break
-        if len(particle_list) == 0:
-            raise FileNotFoundError(
-                "\n  Failed to load particle_list.xml from search paths!"
-                "\n  Please contact the developers: https://github.com/ComPWA"
-            )
+        load_default_particle_list()
 
     def set_topology_builder(self, topology_builder):
         self.topology_builder = topology_builder
@@ -822,3 +801,31 @@ class StateTransitionManager:
         )
 
         return propagator
+
+
+def load_default_particle_list(
+    method: Callable = particle.load_particle_list_from_xml,
+) -> None:
+    """Load the default particle list that comes with the expertsystem."""
+    if len(particle_list) == 0:
+        for search_path in default_particle_list_search_paths:
+            if search_path.startswith("/"):  # absolute path
+                file_path = search_path
+            else:  # relative path
+                file_path = (
+                    path.dirname(expertsystem.__file__) + "/" + search_path
+                )
+            file_path += "/particle_list.xml"
+            if path.exists(file_path):
+                method(file_path)
+                logging.info(
+                    "loaded "
+                    + str(len(particle_list))
+                    + " particles from xml file!"
+                )
+                break
+    if len(particle_list) == 0:
+        raise FileNotFoundError(
+            "\n  Failed to load particle_list.xml from search paths!"
+            "\n  Please contact the developers: https://github.com/ComPWA"
+        )

--- a/expertsystem/ui/system_control.py
+++ b/expertsystem/ui/system_control.py
@@ -19,14 +19,13 @@ from ..topology.graph import (
 )
 from ..topology.topologybuilder import SimpleStateTransitionTopologyBuilder
 
+from ..state import particle
 from ..state.particle import (
     load_particle_list_from_xml,
     particle_list,
     initialize_graph,
     get_particle_property,
     get_interaction_property,
-    XMLLabelConstants,
-    get_xml_label,
     StateQuantumNumberNames,
     InteractionQuantumNumberNames,
     ParticlePropertyNames,
@@ -92,7 +91,7 @@ class InteractionDeterminationFunctorInterface(ABC):
 
 
 class GammaCheck(InteractionDeterminationFunctorInterface):
-    name_label = get_xml_label(XMLLabelConstants.Name)
+    name_label = particle.LABELS.Name.name
 
     def check(self, in_edge_props, out_edge_props, node_props):
         int_types = [x for x in InteractionTypes]
@@ -110,8 +109,8 @@ class LeptonCheck(InteractionDeterminationFunctorInterface):
         StateQuantumNumberNames.MuonLN,
         StateQuantumNumberNames.TauLN,
     ]
-    name_label = get_xml_label(XMLLabelConstants.Name)
-    qns_label = get_xml_label(XMLLabelConstants.QuantumNumber)
+    name_label = particle.LABELS.Name.name
+    qns_label = particle.LABELS.QuantumNumber.name
 
     def check(self, in_edge_props, out_edge_props, node_props):
         node_interaction_types = [x for x in InteractionTypes]
@@ -178,8 +177,8 @@ def remove_duplicate_solutions(
 
 
 def remove_qns_from_graph(graph, qn_list):
-    qns_label = get_xml_label(XMLLabelConstants.QuantumNumber)
-    type_label = get_xml_label(XMLLabelConstants.Type)
+    qns_label = particle.LABELS.QuantumNumber.name
+    type_label = particle.LABELS.Type.name
 
     int_qns = [
         x for x in qn_list if isinstance(x, InteractionQuantumNumberNames)
@@ -327,7 +326,7 @@ def require_interaction_property(
 
 
 def _find_node_ids_with_ingoing_particle_name(graph, ingoing_particle_name):
-    name_label = get_xml_label(XMLLabelConstants.Name)
+    name_label = particle.LABELS.Name.name
     found_node_ids = []
     for node_id in graph.nodes:
         edge_ids = get_edges_ingoing_to_node(graph, node_id)
@@ -444,7 +443,7 @@ def calculate_swappings(id_mapping):
 
 
 def create_edge_id_particle_mapping(graph, external_edge_getter_function):
-    name_label = get_xml_label(XMLLabelConstants.Name)
+    name_label = particle.LABELS.Name.name
     return {
         i: graph.edge_props[i][name_label]
         for i in external_edge_getter_function(graph)

--- a/particle_list.xml
+++ b/particle_list.xml
@@ -1,279 +1,890 @@
 <ParticleList>
-  <Particle Name="gamma">
+  <Particle>
+    <Name>gamma</Name>
     <Pid>22</Pid>
-    <Parameter Type="Mass" Name="Mass_gamma">
+    <Parameter>
+      <Type>Mass</Type>
+      <Name>Mass_gamma</Name>
       <Value>0.0</Value>
     </Parameter>
-    <QuantumNumber Class="Spin" Type="Spin" Value="1" />
-    <QuantumNumber Class="Int" Type="Charge" Value="0" />
-    <QuantumNumber Class="Int" Type="Parity" Value="-1" />
-    <QuantumNumber Class="Int" Type="Cparity" Value="-1" />
-    <QuantumNumber Class="Spin" Type="IsoSpin" Value="0" Projection="0" />
-    <QuantumNumber Class="Int" Type="BaryonNumber" Value="0" />
-    <QuantumNumber Class="Int" Type="Charm" Value="0" />
-    <QuantumNumber Class="Int" Type="Strangeness" Value="0" />
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>Spin</Type>
+      <Value>1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charge</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Parity</Type>
+      <Value>-1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Cparity</Type>
+      <Value>-1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>IsoSpin</Type>
+      <Value>0</Value>
+      <Projection>0</Projection>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>BaryonNumber</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charm</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Strangeness</Type>
+      <Value>0</Value>
+    </QuantumNumber>
   </Particle>
-  <Particle Name="W-">
+  <Particle>
+    <Name>W-</Name>
     <Pid>-24</Pid>
-    <Parameter Type="Mass" Name="Mass_W-">
+    <Parameter>
+      <Type>Mass</Type>
+      <Name>Mass_W-</Name>
       <Value>80.385</Value>
     </Parameter>
-    <QuantumNumber Class="Spin" Type="Spin" Value="1" />
-    <QuantumNumber Class="Int" Type="Charge" Value="-1" />
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>Spin</Type>
+      <Value>1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charge</Type>
+      <Value>-1</Value>
+    </QuantumNumber>
   </Particle>
-  <Particle Name="W+">
+  <Particle>
+    <Name>W+</Name>
     <Pid>24</Pid>
-    <Parameter Type="Mass" Name="Mass_W+">
+    <Parameter>
+      <Type>Mass</Type>
+      <Name>Mass_W+</Name>
       <Value>80.385</Value>
     </Parameter>
-    <QuantumNumber Class="Spin" Type="Spin" Value="1" />
-    <QuantumNumber Class="Int" Type="Charge" Value="1" />
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>Spin</Type>
+      <Value>1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charge</Type>
+      <Value>1</Value>
+    </QuantumNumber>
   </Particle>
-  <Particle Name="EpEm">
+  <Particle>
+    <Name>EpEm</Name>
     <Pid>2299</Pid>
-    <Parameter Type="Mass" Name="Mass_epem">
+    <Parameter>
+      <Type>Mass</Type>
+      <Name>Mass_epem</Name>
       <Value>4.230</Value>
       <Fix>true</Fix>
     </Parameter>
-    <QuantumNumber Class="Spin" Type="Spin" Value="1" />
-    <QuantumNumber Class="Int" Type="Charge" Value="0" />
-    <QuantumNumber Class="Int" Type="Parity" Value="-1" />
-    <QuantumNumber Class="Int" Type="Cparity" Value="-1" />
-    <QuantumNumber Class="Spin" Type="IsoSpin" Value="0" Projection="0" />
-    <QuantumNumber Class="Int" Type="Charm" Value="0" />
-    <QuantumNumber Class="Int" Type="Strangeness" Value="0" />
-    <QuantumNumber Class="Int" Type="BaryonNumber" Value="0" />
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>Spin</Type>
+      <Value>1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charge</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Parity</Type>
+      <Value>-1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Cparity</Type>
+      <Value>-1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>IsoSpin</Type>
+      <Value>0</Value>
+      <Projection>0</Projection>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charm</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Strangeness</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>BaryonNumber</Type>
+      <Value>0</Value>
+    </QuantumNumber>
   </Particle>
 
+
   <!-- ==================== Leptons ==================== -->
-  <Particle Name="e+">
+  <Particle>
+    <Name>e+</Name>
     <Pid>11</Pid>
-    <Parameter Type="Mass" Name="Mass_electron">
+    <Parameter>
+      <Type>Mass</Type>
+      <Name>Mass_electron</Name>
       <Value>0.0005109989461</Value>
     </Parameter>
-    <QuantumNumber Class="Spin" Type="Spin" Value="0.5" />
-    <QuantumNumber Class="Int" Type="Charge" Value="1" />
-    <QuantumNumber Class="Int" Type="Parity" Value="-1" />
-    <QuantumNumber Class="Int" Type="ElectronLN" Value="-1" />
-    <QuantumNumber Class="Int" Type="MuonLN" Value="0" />
-    <QuantumNumber Class="Int" Type="TauLN" Value="0" />
-    <QuantumNumber Class="Int" Type="BaryonNumber" Value="0" />
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>Spin</Type>
+      <Value>0.5</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charge</Type>
+      <Value>1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Parity</Type>
+      <Value>-1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>ElectronLN</Type>
+      <Value>-1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>MuonLN</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>TauLN</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>BaryonNumber</Type>
+      <Value>0</Value>
+    </QuantumNumber>
   </Particle>
-  <Particle Name="e-">
+  <Particle>
+    <Name>e-</Name>
     <Pid>-11</Pid>
-    <Parameter Type="Mass" Name="Mass_electron">
+    <Parameter>
+      <Type>Mass</Type>
+      <Name>Mass_electron</Name>
       <Value>0.0005109989461</Value>
     </Parameter>
-    <QuantumNumber Class="Spin" Type="Spin" Value="0.5" />
-    <QuantumNumber Class="Int" Type="Charge" Value="-1" />
-    <QuantumNumber Class="Int" Type="Parity" Value="+1" />
-    <QuantumNumber Class="Int" Type="ElectronLN" Value="1" />
-    <QuantumNumber Class="Int" Type="MuonLN" Value="0" />
-    <QuantumNumber Class="Int" Type="TauLN" Value="0" />
-    <QuantumNumber Class="Int" Type="BaryonNumber" Value="0" />
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>Spin</Type>
+      <Value>0.5</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charge</Type>
+      <Value>-1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Parity</Type>
+      <Value>+1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>ElectronLN</Type>
+      <Value>1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>MuonLN</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>TauLN</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>BaryonNumber</Type>
+      <Value>0</Value>
+    </QuantumNumber>
   </Particle>
-  <Particle Name="mu+">
+  <Particle>
+    <Name>mu+</Name>
     <Pid>13</Pid>
-    <Parameter Type="Mass" Name="Mass_muon">
+    <Parameter>
+      <Type>Mass</Type>
+      <Name>Mass_muon</Name>
       <Value>0.1056583745</Value>
     </Parameter>
-    <QuantumNumber Class="Spin" Type="Spin" Value="0.5" />
-    <QuantumNumber Class="Int" Type="Charge" Value="1" />
-    <QuantumNumber Class="Int" Type="Parity" Value="-1" />
-    <QuantumNumber Class="Int" Type="ElectronLN" Value="0" />
-    <QuantumNumber Class="Int" Type="MuonLN" Value="-1" />
-    <QuantumNumber Class="Int" Type="TauLN" Value="0" />
-    <QuantumNumber Class="Int" Type="BaryonNumber" Value="0" />
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>Spin</Type>
+      <Value>0.5</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charge</Type>
+      <Value>1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Parity</Type>
+      <Value>-1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>ElectronLN</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>MuonLN</Type>
+      <Value>-1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>TauLN</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>BaryonNumber</Type>
+      <Value>0</Value>
+    </QuantumNumber>
   </Particle>
-  <Particle Name="mu-">
+  <Particle>
+    <Name>mu-</Name>
     <Pid>-13</Pid>
-    <Parameter Type="Mass" Name="Mass_muon">
+    <Parameter>
+      <Type>Mass</Type>
+      <Name>Mass_muon</Name>
       <Value>0.1056583745</Value>
     </Parameter>
-    <QuantumNumber Class="Spin" Type="Spin" Value="0.5" />
-    <QuantumNumber Class="Int" Type="Charge" Value="-1" />
-    <QuantumNumber Class="Int" Type="Parity" Value="+1" />
-    <QuantumNumber Class="Int" Type="ElectronLN" Value="0" />
-    <QuantumNumber Class="Int" Type="MuonLN" Value="1" />
-    <QuantumNumber Class="Int" Type="TauLN" Value="0" />
-    <QuantumNumber Class="Int" Type="BaryonNumber" Value="0" />
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>Spin</Type>
+      <Value>0.5</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charge</Type>
+      <Value>-1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Parity</Type>
+      <Value>+1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>ElectronLN</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>MuonLN</Type>
+      <Value>1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>TauLN</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>BaryonNumber</Type>
+      <Value>0</Value>
+    </QuantumNumber>
   </Particle>
-  <Particle Name="tau+">
+  <Particle>
+    <Name>tau+</Name>
     <Pid>15</Pid>
-    <Parameter Type="Mass" Name="Mass_tau">
+    <Parameter>
+      <Type>Mass</Type>
+      <Name>Mass_tau</Name>
       <Value>1.77686</Value>
     </Parameter>
-    <QuantumNumber Class="Spin" Type="Spin" Value="0.5" />
-    <QuantumNumber Class="Int" Type="Charge" Value="1" />
-    <QuantumNumber Class="Int" Type="Parity" Value="-1" />
-    <QuantumNumber Class="Int" Type="ElectronLN" Value="0" />
-    <QuantumNumber Class="Int" Type="MuonLN" Value="0" />
-    <QuantumNumber Class="Int" Type="TauLN" Value="-1" />
-    <QuantumNumber Class="Int" Type="BaryonNumber" Value="0" />
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>Spin</Type>
+      <Value>0.5</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charge</Type>
+      <Value>1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Parity</Type>
+      <Value>-1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>ElectronLN</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>MuonLN</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>TauLN</Type>
+      <Value>-1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>BaryonNumber</Type>
+      <Value>0</Value>
+    </QuantumNumber>
   </Particle>
-  <Particle Name="tau-">
+  <Particle>
+    <Name>tau-</Name>
     <Pid>-15</Pid>
-    <Parameter Type="Mass" Name="Mass_tau">
+    <Parameter>
+      <Type>Mass</Type>
+      <Name>Mass_tau</Name>
       <Value>1.77686</Value>
     </Parameter>
-    <QuantumNumber Class="Spin" Type="Spin" Value="0.5" />
-    <QuantumNumber Class="Int" Type="Charge" Value="-1" />
-    <QuantumNumber Class="Int" Type="Parity" Value="+1" />
-    <QuantumNumber Class="Int" Type="ElectronLN" Value="0" />
-    <QuantumNumber Class="Int" Type="MuonLN" Value="0" />
-    <QuantumNumber Class="Int" Type="TauLN" Value="1" />
-    <QuantumNumber Class="Int" Type="BaryonNumber" Value="0" />
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>Spin</Type>
+      <Value>0.5</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charge</Type>
+      <Value>-1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Parity</Type>
+      <Value>+1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>ElectronLN</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>MuonLN</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>TauLN</Type>
+      <Value>1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>BaryonNumber</Type>
+      <Value>0</Value>
+    </QuantumNumber>
   </Particle>
+
   <!-- Neutrinos -->
-  <Particle Name="ve">
+  <Particle>
+    <Name>ve</Name>
     <Pid>12</Pid>
-    <Parameter Type="Mass" Name="Mass_electron">
+    <Parameter>
+      <Type>Mass</Type>
+      <Name>Mass_electron</Name>
       <Value>1e-9</Value>
     </Parameter>
-    <QuantumNumber Class="Spin" Type="Spin" Value="0.5" />
-    <QuantumNumber Class="Int" Type="Charge" Value="0" />
-    <QuantumNumber Class="Int" Type="Parity" Value="1" />
-    <QuantumNumber Class="Int" Type="ElectronLN" Value="1" />
-    <QuantumNumber Class="Int" Type="MuonLN" Value="0" />
-    <QuantumNumber Class="Int" Type="TauLN" Value="0" />
-    <QuantumNumber Class="Int" Type="BaryonNumber" Value="0" />
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>Spin</Type>
+      <Value>0.5</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charge</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Parity</Type>
+      <Value>1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>ElectronLN</Type>
+      <Value>1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>MuonLN</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>TauLN</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>BaryonNumber</Type>
+      <Value>0</Value>
+    </QuantumNumber>
   </Particle>
-  <Particle Name="vebar">
+  <Particle>
+    <Name>vebar</Name>
     <Pid>-12</Pid>
-    <Parameter Type="Mass" Name="Mass_electron">
+    <Parameter>
+      <Type>Mass</Type>
+      <Name>Mass_electron</Name>
       <Value>1e-9</Value>
     </Parameter>
-    <QuantumNumber Class="Spin" Type="Spin" Value="0.5" />
-    <QuantumNumber Class="Int" Type="Charge" Value="0" />
-    <QuantumNumber Class="Int" Type="Parity" Value="-1" />
-    <QuantumNumber Class="Int" Type="ElectronLN" Value="-1" />
-    <QuantumNumber Class="Int" Type="MuonLN" Value="0" />
-    <QuantumNumber Class="Int" Type="TauLN" Value="0" />
-    <QuantumNumber Class="Int" Type="BaryonNumber" Value="0" />
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>Spin</Type>
+      <Value>0.5</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charge</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Parity</Type>
+      <Value>-1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>ElectronLN</Type>
+      <Value>-1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>MuonLN</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>TauLN</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>BaryonNumber</Type>
+      <Value>0</Value>
+    </QuantumNumber>
   </Particle>
-  <Particle Name="vmu">
+  <Particle>
+    <Name>vmu</Name>
     <Pid>14</Pid>
-    <Parameter Type="Mass" Name="Mass_muon">
+    <Parameter>
+      <Type>Mass</Type>
+      <Name>Mass_muon</Name>
       <Value>1e-9</Value>
     </Parameter>
-    <QuantumNumber Class="Spin" Type="Spin" Value="0.5" />
-    <QuantumNumber Class="Int" Type="Charge" Value="0" />
-    <QuantumNumber Class="Int" Type="Parity" Value="1" />
-    <QuantumNumber Class="Int" Type="ElectronLN" Value="0" />
-    <QuantumNumber Class="Int" Type="MuonLN" Value="1" />
-    <QuantumNumber Class="Int" Type="TauLN" Value="0" />
-    <QuantumNumber Class="Int" Type="BaryonNumber" Value="0" />
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>Spin</Type>
+      <Value>0.5</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charge</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Parity</Type>
+      <Value>1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>ElectronLN</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>MuonLN</Type>
+      <Value>1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>TauLN</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>BaryonNumber</Type>
+      <Value>0</Value>
+    </QuantumNumber>
   </Particle>
-  <Particle Name="vmubar">
+  <Particle>
+    <Name>vmubar</Name>
     <Pid>-14</Pid>
-    <Parameter Type="Mass" Name="Mass_muon">
+    <Parameter>
+      <Type>Mass</Type>
+      <Name>Mass_muon</Name>
       <Value>1e-9</Value>
     </Parameter>
-    <QuantumNumber Class="Spin" Type="Spin" Value="0.5" />
-    <QuantumNumber Class="Int" Type="Charge" Value="0" />
-    <QuantumNumber Class="Int" Type="Parity" Value="-1" />
-    <QuantumNumber Class="Int" Type="ElectronLN" Value="0" />
-    <QuantumNumber Class="Int" Type="MuonLN" Value="-1" />
-    <QuantumNumber Class="Int" Type="TauLN" Value="0" />
-    <QuantumNumber Class="Int" Type="BaryonNumber" Value="0" />
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>Spin</Type>
+      <Value>0.5</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charge</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Parity</Type>
+      <Value>-1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>ElectronLN</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>MuonLN</Type>
+      <Value>-1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>TauLN</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>BaryonNumber</Type>
+      <Value>0</Value>
+    </QuantumNumber>
   </Particle>
-  <Particle Name="vtau">
+  <Particle>
+    <Name>vtau</Name>
     <Pid>16</Pid>
-    <Parameter Type="Mass" Name="Mass_tau">
+    <Parameter>
+      <Type>Mass</Type>
+      <Name>Mass_tau</Name>
       <Value>1e-9</Value>
     </Parameter>
-    <QuantumNumber Class="Spin" Type="Spin" Value="0.5" />
-    <QuantumNumber Class="Int" Type="Charge" Value="0" />
-    <QuantumNumber Class="Int" Type="Parity" Value="1" />
-    <QuantumNumber Class="Int" Type="ElectronLN" Value="0" />
-    <QuantumNumber Class="Int" Type="MuonLN" Value="0" />
-    <QuantumNumber Class="Int" Type="TauLN" Value="1" />
-    <QuantumNumber Class="Int" Type="BaryonNumber" Value="0" />
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>Spin</Type>
+      <Value>0.5</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charge</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Parity</Type>
+      <Value>1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>ElectronLN</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>MuonLN</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>TauLN</Type>
+      <Value>1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>BaryonNumber</Type>
+      <Value>0</Value>
+    </QuantumNumber>
   </Particle>
-  <Particle Name="vtaubar">
+  <Particle>
+    <Name>vtaubar</Name>
     <Pid>-16</Pid>
-    <Parameter Type="Mass" Name="Mass_tau">
+    <Parameter>
+      <Type>Mass</Type>
+      <Name>Mass_tau</Name>
       <Value>1e-9</Value>
     </Parameter>
-    <QuantumNumber Class="Spin" Type="Spin" Value="0.5" />
-    <QuantumNumber Class="Int" Type="Charge" Value="0" />
-    <QuantumNumber Class="Int" Type="Parity" Value="-1" />
-    <QuantumNumber Class="Int" Type="ElectronLN" Value="0" />
-    <QuantumNumber Class="Int" Type="MuonLN" Value="0" />
-    <QuantumNumber Class="Int" Type="TauLN" Value="-1" />
-    <QuantumNumber Class="Int" Type="BaryonNumber" Value="0" />
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>Spin</Type>
+      <Value>0.5</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charge</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Parity</Type>
+      <Value>-1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>ElectronLN</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>MuonLN</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>TauLN</Type>
+      <Value>-1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>BaryonNumber</Type>
+      <Value>0</Value>
+    </QuantumNumber>
   </Particle>
 
 
   <!-- ==================== Mesons ==================== -->
+
   <!-- Light flavoured mesons -->
-  <Particle Name="pi0">
+  <Particle>
+    <Name>pi0</Name>
     <Pid>111</Pid>
-    <Parameter Type="Mass" Name="Mass_neutralPion">
+    <Parameter>
+      <Type>Mass</Type>
+      <Name>Mass_neutralPion</Name>
       <Value>0.1349766</Value>
       <Error>0.000006</Error>
     </Parameter>
-    <QuantumNumber Class="Spin" Type="Spin" Value="0" />
-    <QuantumNumber Class="Int" Type="Charge" Value="0" />
-    <QuantumNumber Class="Int" Type="Parity" Value="-1" />
-    <QuantumNumber Class="Int" Type="Cparity" Value="1" />
-    <QuantumNumber Class="Int" Type="Gparity" Value="-1" />
-    <QuantumNumber Class="Spin" Type="IsoSpin" Value="1" Projection="0" />
-    <QuantumNumber Class="Int" Type="BaryonNumber" Value="0" />
-    <QuantumNumber Class="Int" Type="Charm" Value="0" />
-    <QuantumNumber Class="Int" Type="Strangeness" Value="0" />
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>Spin</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charge</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Parity</Type>
+      <Value>-1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Cparity</Type>
+      <Value>1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Gparity</Type>
+      <Value>-1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>IsoSpin</Type>
+      <Value>1</Value>
+      <Projection>0</Projection>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>BaryonNumber</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charm</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Strangeness</Type>
+      <Value>0</Value>
+    </QuantumNumber>
   </Particle>
-  <Particle Name="pi+">
+  <Particle>
+    <Name>pi+</Name>
     <Pid>211</Pid>
-    <Parameter Type="Mass" Name="Mass_chargedPion">
+    <Parameter>
+      <Type>Mass</Type>
+      <Name>Mass_chargedPion</Name>
       <Value>0.13957018</Value>
       <Error>0.00000035</Error>
       <Fix>true</Fix>
     </Parameter>
-    <QuantumNumber Class="Spin" Type="Spin" Value="0" />
-    <QuantumNumber Class="Int" Type="Charge" Value="+1" />
-    <QuantumNumber Class="Int" Type="Parity" Value="-1" />
-    <QuantumNumber Class="Int" Type="Gparity" Value="-1" />
-    <QuantumNumber Class="Spin" Type="IsoSpin" Value="1" Projection="1" />
-    <QuantumNumber Class="Int" Type="Charm" Value="0" />
-    <QuantumNumber Class="Int" Type="Strangeness" Value="0" />
-    <QuantumNumber Class="Int" Type="BaryonNumber" Value="0" />
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>Spin</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charge</Type>
+      <Value>+1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Parity</Type>
+      <Value>-1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Gparity</Type>
+      <Value>-1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>IsoSpin</Type>
+      <Value>1</Value>
+      <Projection>1</Projection>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charm</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Strangeness</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>BaryonNumber</Type>
+      <Value>0</Value>
+    </QuantumNumber>
   </Particle>
-  <Particle Name="pi-">
+  <Particle>
+    <Name>pi-</Name>
     <Pid>-211</Pid>
-    <Parameter Type="Mass" Name="Mass_chargedPion">
+    <Parameter>
+      <Type>Mass</Type>
+      <Name>Mass_chargedPion</Name>
       <Value>0.13957018</Value>
       <Error>0.00000035</Error>
       <Fix>true</Fix>
     </Parameter>
-    <QuantumNumber Class="Spin" Type="Spin" Value="0" />
-    <QuantumNumber Class="Int" Type="Charge" Value="-1" />
-    <QuantumNumber Class="Int" Type="Parity" Value="-1" />
-    <QuantumNumber Class="Int" Type="Gparity" Value="-1" />
-    <QuantumNumber Class="Spin" Type="IsoSpin" Value="1" Projection="-1" />
-    <QuantumNumber Class="Int" Type="Charm" Value="0" />
-    <QuantumNumber Class="Int" Type="Strangeness" Value="0" />
-    <QuantumNumber Class="Int" Type="BaryonNumber" Value="0" />
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>Spin</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charge</Type>
+      <Value>-1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Parity</Type>
+      <Value>-1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Gparity</Type>
+      <Value>-1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>IsoSpin</Type>
+      <Value>1</Value>
+      <Projection>-1</Projection>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charm</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Strangeness</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>BaryonNumber</Type>
+      <Value>0</Value>
+    </QuantumNumber>
   </Particle>
-  <Particle Name="eta">
+  <Particle>
+    <Name>eta</Name>
     <Pid>221</Pid>
-    <Parameter Type="Mass" Name="Mass_eta">
+    <Parameter>
+      <Type>Mass</Type>
+      <Name>Mass_eta</Name>
       <Value>0.547862</Value>
       <Error>0.000017</Error>
     </Parameter>
-    <QuantumNumber Class="Spin" Type="Spin" Value="0" />
-    <QuantumNumber Class="Int" Type="Charge" Value="0" />
-    <QuantumNumber Class="Int" Type="Parity" Value="-1" />
-    <QuantumNumber Class="Int" Type="Cparity" Value="1" />
-    <QuantumNumber Class="Spin" Type="IsoSpin" Value="0" />
-    <DecayInfo Type="relativisticBreitWigner">
-      <FormFactor Type="BlattWeisskopf" />
-      <Parameter Type="Width" Name="Width_eta">
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>Spin</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charge</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Parity</Type>
+      <Value>-1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Cparity</Type>
+      <Value>1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>IsoSpin</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <DecayInfo>
+      <Type>relativisticBreitWigner</Type>
+      <FormFactor>
+        <Type>BlattWeisskopf</Type>
+      </FormFactor>
+      <Parameter>
+        <Type>Width</Type>
+        <Name>Width_eta</Name>
         <Value>0.00000131</Value>
         <Error>0.00000005</Error>
         <Fix>true</Fix>
       </Parameter>
-      <Parameter Type="MesonRadius" Name="Radius_eta">
+      <Parameter>
+        <Type>MesonRadius</Type>
+        <Name>Radius_eta</Name>
         <Value>2.5</Value>
         <Fix>true</Fix>
         <Min>2.0</Min>
@@ -281,24 +892,59 @@
       </Parameter>
     </DecayInfo>
   </Particle>
-  <Particle Name="rho(770)0">
+  <Particle>
+    <Name>rho(770)0</Name>
     <Pid>113</Pid>
-    <Parameter Type="Mass" Name="Mass_rho770">
+    <Parameter>
+      <Type>Mass</Type>
+      <Name>Mass_rho770</Name>
       <Value>0.77526</Value>
       <Error>0.00025</Error>
     </Parameter>
-    <QuantumNumber Class="Spin" Type="Spin" Value="1" />
-    <QuantumNumber Class="Int" Type="Charge" Value="0" />
-    <QuantumNumber Class="Int" Type="Parity" Value="-1" />
-    <QuantumNumber Class="Int" Type="Cparity" Value="-1" />
-    <QuantumNumber Class="Int" Type="Gparity" Value="1" />
-    <QuantumNumber Class="Spin" Type="IsoSpin" Value="1" Projection="0" />
-    <DecayInfo Type="relativisticBreitWigner">
-      <FormFactor Type="BlattWeisskopf" />
-      <Parameter Type="Width" Name="Width_rho">
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>Spin</Type>
+      <Value>1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charge</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Parity</Type>
+      <Value>-1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Cparity</Type>
+      <Value>-1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Gparity</Type>
+      <Value>1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>IsoSpin</Type>
+      <Value>1</Value>
+      <Projection>0</Projection>
+    </QuantumNumber>
+    <DecayInfo>
+      <Type>relativisticBreitWigner</Type>
+      <FormFactor>
+        <Type>BlattWeisskopf</Type>
+      </FormFactor>
+      <Parameter>
+        <Type>Width</Type>
+        <Name>Width_rho</Name>
         <Value>0.1491</Value>
       </Parameter>
-      <Parameter Type="MesonRadius" Name="Radius_rho">
+      <Parameter>
+        <Type>MesonRadius</Type>
+        <Name>Radius_rho</Name>
         <Value>2.5</Value>
         <Fix>true</Fix>
         <Min>2.0</Min>
@@ -306,23 +952,54 @@
       </Parameter>
     </DecayInfo>
   </Particle>
-  <Particle Name="rho(770)+">
+  <Particle>
+    <Name>rho(770)+</Name>
     <Pid>213</Pid>
-    <Parameter Type="Mass" Name="Mass_rho770">
+    <Parameter>
+      <Type>Mass</Type>
+      <Name>Mass_rho770</Name>
       <Value>0.77526</Value>
       <Error>0.00025</Error>
     </Parameter>
-    <QuantumNumber Class="Spin" Type="Spin" Value="1" />
-    <QuantumNumber Class="Int" Type="Charge" Value="+1" />
-    <QuantumNumber Class="Int" Type="Parity" Value="-1" />
-    <QuantumNumber Class="Int" Type="Cparity" Value="-1" />
-    <QuantumNumber Class="Spin" Type="IsoSpin" Value="1" Projection="+1" />
-    <DecayInfo Type="relativisticBreitWigner">
-      <FormFactor Type="BlattWeisskopf" />
-      <Parameter Type="Width" Name="Width_rho">
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>Spin</Type>
+      <Value>1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charge</Type>
+      <Value>+1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Parity</Type>
+      <Value>-1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Cparity</Type>
+      <Value>-1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>IsoSpin</Type>
+      <Value>1</Value>
+      <Projection>+1</Projection>
+    </QuantumNumber>
+    <DecayInfo>
+      <Type>relativisticBreitWigner</Type>
+      <FormFactor>
+        <Type>BlattWeisskopf</Type>
+      </FormFactor>
+      <Parameter>
+        <Type>Width</Type>
+        <Name>Width_rho</Name>
         <Value>0.1491</Value>
       </Parameter>
-      <Parameter Type="MesonRadius" Name="Radius_rho">
+      <Parameter>
+        <Type>MesonRadius</Type>
+        <Name>Radius_rho</Name>
         <Value>2.5</Value>
         <Fix>true</Fix>
         <Min>2.0</Min>
@@ -330,24 +1007,59 @@
       </Parameter>
     </DecayInfo>
   </Particle>
-  <Particle Name="rho(770)-">
+  <Particle>
+    <Name>rho(770)-</Name>
     <Pid>-213</Pid>
-    <Parameter Type="Mass" Name="Mass_rho770">
+    <Parameter>
+      <Type>Mass</Type>
+      <Name>Mass_rho770</Name>
       <Value>0.77526</Value>
       <Error>0.00025</Error>
     </Parameter>
-    <QuantumNumber Class="Spin" Type="Spin" Value="1" />
-    <QuantumNumber Class="Int" Type="Charge" Value="-1" />
-    <QuantumNumber Class="Int" Type="Parity" Value="-1" />
-    <QuantumNumber Class="Int" Type="Cparity" Value="-1" />
-    <QuantumNumber Class="Spin" Type="IsoSpin" Value="1" Projection="-1" />
-    <QuantumNumber Class="Int" Type="Charm" Value="0" />
-    <DecayInfo Type="relativisticBreitWigner">
-      <FormFactor Type="BlattWeisskopf" />
-      <Parameter Type="Width" Name="Width_rho">
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>Spin</Type>
+      <Value>1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charge</Type>
+      <Value>-1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Parity</Type>
+      <Value>-1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Cparity</Type>
+      <Value>-1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>IsoSpin</Type>
+      <Value>1</Value>
+      <Projection>-1</Projection>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charm</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <DecayInfo>
+      <Type>relativisticBreitWigner</Type>
+      <FormFactor>
+        <Type>BlattWeisskopf</Type>
+      </FormFactor>
+      <Parameter>
+        <Type>Width</Type>
+        <Name>Width_rho</Name>
         <Value>0.1491</Value>
       </Parameter>
-      <Parameter Type="MesonRadius" Name="Radius_rho">
+      <Parameter>
+        <Type>MesonRadius</Type>
+        <Name>Radius_rho</Name>
         <Value>2.5</Value>
         <Fix>true</Fix>
         <Min>2.0</Min>
@@ -355,24 +1067,58 @@
       </Parameter>
     </DecayInfo>
   </Particle>
-  <Particle Name="omega(782)">
+  <Particle>
+    <Name>omega(782)</Name>
     <Pid>223</Pid>
-    <Parameter Type="Mass" Name="Mass_omega782">
+    <Parameter>
+      <Type>Mass</Type>
+      <Name>Mass_omega782</Name>
       <Value>0.78265</Value>
       <Error>0.00012</Error>
     </Parameter>
-    <QuantumNumber Class="Spin" Type="Spin" Value="1" />
-    <QuantumNumber Class="Int" Type="Charge" Value="0" />
-    <QuantumNumber Class="Int" Type="Parity" Value="-1" />
-    <QuantumNumber Class="Int" Type="Cparity" Value="-1" />
-    <QuantumNumber Class="Spin" Type="IsoSpin" Value="0" />
-    <QuantumNumber Class="Int" Type="Gparity" Value="-1" />
-    <DecayInfo Type="relativisticBreitWigner">
-      <FormFactor Type="BlattWeisskopf" />
-      <Parameter Type="Width" Name="Width_omega782">
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>Spin</Type>
+      <Value>1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charge</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Parity</Type>
+      <Value>-1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Cparity</Type>
+      <Value>-1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>IsoSpin</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Gparity</Type>
+      <Value>-1</Value>
+    </QuantumNumber>
+    <DecayInfo>
+      <Type>relativisticBreitWigner</Type>
+      <FormFactor>
+        <Type>BlattWeisskopf</Type>
+      </FormFactor>
+      <Parameter>
+        <Type>Width</Type>
+        <Name>Width_omega782</Name>
         <Value>0.000001491</Value>
       </Parameter>
-      <Parameter Type="MesonRadius" Name="Radius_omega782">
+      <Parameter>
+        <Type>MesonRadius</Type>
+        <Name>Radius_omega782</Name>
         <Value>2.5</Value>
         <Fix>true</Fix>
         <Min>2.0</Min>
@@ -380,26 +1126,59 @@
       </Parameter>
     </DecayInfo>
   </Particle>
-
-  <Particle Name="f0(980)">
+  <Particle>
+    <Name>f0(980)</Name>
     <Pid>9010221</Pid>
-    <Parameter Type="Mass" Name="mass_f0980">
+    <Parameter>
+      <Type>Mass</Type>
+      <Name>mass_f0980</Name>
       <Value>0.994</Value>
       <Error>0.001</Error>
       <Fix>true</Fix>
     </Parameter>
-    <QuantumNumber Class="Spin" Type="Spin" Value="0" />
-    <QuantumNumber Class="Int" Type="Charge" Value="0" />
-    <QuantumNumber Class="Int" Type="Parity" Value="1" />
-    <QuantumNumber Class="Int" Type="Cparity" Value="1" />
-    <QuantumNumber Class="Spin" Type="IsoSpin" Value="0" />
-    <QuantumNumber Class="Int" Type="Gparity" Value="1" />
-    <DecayInfo Type="relativisticBreitWigner">
-      <FormFactor Type="BlattWeisskopf" />
-      <Parameter Type="Width" Name="width_f0980">
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>Spin</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charge</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Parity</Type>
+      <Value>1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Cparity</Type>
+      <Value>1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>IsoSpin</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Gparity</Type>
+      <Value>1</Value>
+    </QuantumNumber>
+    <DecayInfo>
+      <Type>relativisticBreitWigner</Type>
+      <FormFactor>
+        <Type>BlattWeisskopf</Type>
+      </FormFactor>
+      <Parameter>
+        <Type>Width</Type>
+        <Name>width_f0980</Name>
         <Value>0.070</Value>
       </Parameter>
-      <Parameter Type="MesonRadius" Name="Radius_f0980">
+      <Parameter>
+        <Type>MesonRadius</Type>
+        <Name>Radius_f0980</Name>
         <Value>1</Value>
         <Fix>true</Fix>
         <Min>0.0</Min>
@@ -407,24 +1186,54 @@
       </Parameter>
     </DecayInfo>
   </Particle>
-  <Particle Name="f0(1500)">
+  <Particle>
+    <Name>f0(1500)</Name>
     <Pid>9030221</Pid>
-    <Parameter Type="Mass" Name="mass_f01500">
+    <Parameter>
+      <Type>Mass</Type>
+      <Name>mass_f01500</Name>
       <Value>1.505</Value>
       <Error>0.006</Error>
       <Fix>true</Fix>
     </Parameter>
-    <QuantumNumber Class="Spin" Type="Spin" Value="0" />
-    <QuantumNumber Class="Int" Type="Charge" Value="0" />
-    <QuantumNumber Class="Int" Type="Parity" Value="1" />
-    <QuantumNumber Class="Int" Type="Cparity" Value="1" />
-    <QuantumNumber Class="Int" Type="Gparity" Value="1" />
-    <DecayInfo Type="relativisticBreitWigner">
-      <FormFactor Type="BlattWeisskopf" />
-      <Parameter Type="Width" Name="width_f01500">
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>Spin</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charge</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Parity</Type>
+      <Value>1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Cparity</Type>
+      <Value>1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Gparity</Type>
+      <Value>1</Value>
+    </QuantumNumber>
+    <DecayInfo>
+      <Type>relativisticBreitWigner</Type>
+      <FormFactor>
+        <Type>BlattWeisskopf</Type>
+      </FormFactor>
+      <Parameter>
+        <Type>Width</Type>
+        <Name>width_f01500</Name>
         <Value>0.109</Value>
       </Parameter>
-      <Parameter Type="MesonRadius" Name="Radius_f01500">
+      <Parameter>
+        <Type>MesonRadius</Type>
+        <Name>Radius_f01500</Name>
         <Value>1</Value>
         <Fix>true</Fix>
         <Min>0.0</Min>
@@ -432,24 +1241,54 @@
       </Parameter>
     </DecayInfo>
   </Particle>
-  <Particle Name="f2(1270)">
+  <Particle>
+    <Name>f2(1270)</Name>
     <Pid>225</Pid>
-    <Parameter Type="Mass" Name="mass_f21270">
+    <Parameter>
+      <Type>Mass</Type>
+      <Name>mass_f21270</Name>
       <Value>1.2751</Value>
       <Error>0.0012</Error>
       <Fix>true</Fix>
     </Parameter>
-    <QuantumNumber Class="Spin" Type="Spin" Value="2" />
-    <QuantumNumber Class="Int" Type="Charge" Value="0" />
-    <QuantumNumber Class="Int" Type="Parity" Value="1" />
-    <QuantumNumber Class="Int" Type="Cparity" Value="1" />
-    <QuantumNumber Class="Int" Type="Gparity" Value="1" />
-    <DecayInfo Type="relativisticBreitWigner">
-      <FormFactor Type="BlattWeisskopf" />
-      <Parameter Type="Width" Name="width_f21270">
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>Spin</Type>
+      <Value>2</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charge</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Parity</Type>
+      <Value>1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Cparity</Type>
+      <Value>1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Gparity</Type>
+      <Value>1</Value>
+    </QuantumNumber>
+    <DecayInfo>
+      <Type>relativisticBreitWigner</Type>
+      <FormFactor>
+        <Type>BlattWeisskopf</Type>
+      </FormFactor>
+      <Parameter>
+        <Type>Width</Type>
+        <Name>width_f21270</Name>
         <Value>0.185</Value>
       </Parameter>
-      <Parameter Type="MesonRadius" Name="Radius_f21270">
+      <Parameter>
+        <Type>MesonRadius</Type>
+        <Name>Radius_f21270</Name>
         <Value>1</Value>
         <Fix>true</Fix>
         <Min>0.0</Min>
@@ -457,24 +1296,54 @@
       </Parameter>
     </DecayInfo>
   </Particle>
-  <Particle Name="f2(1950)">
+  <Particle>
+    <Name>f2(1950)</Name>
     <Pid>9050225</Pid>
-    <Parameter Type="Mass" Name="mass_f21950">
+    <Parameter>
+      <Type>Mass</Type>
+      <Name>mass_f21950</Name>
       <Value>1.944</Value>
       <Error>0.012</Error>
       <Fix>true</Fix>
     </Parameter>
-    <QuantumNumber Class="Spin" Type="Spin" Value="2" />
-    <QuantumNumber Class="Int" Type="Charge" Value="0" />
-    <QuantumNumber Class="Int" Type="Parity" Value="1" />
-    <QuantumNumber Class="Int" Type="Cparity" Value="1" />
-    <QuantumNumber Class="Int" Type="Gparity" Value="1" />
-    <DecayInfo Type="relativisticBreitWigner">
-      <FormFactor Type="BlattWeisskopf" />
-      <Parameter Type="Width" Name="width_f21950">
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>Spin</Type>
+      <Value>2</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charge</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Parity</Type>
+      <Value>1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Cparity</Type>
+      <Value>1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Gparity</Type>
+      <Value>1</Value>
+    </QuantumNumber>
+    <DecayInfo>
+      <Type>relativisticBreitWigner</Type>
+      <FormFactor>
+        <Type>BlattWeisskopf</Type>
+      </FormFactor>
+      <Parameter>
+        <Type>Width</Type>
+        <Name>width_f21950</Name>
         <Value>0.472</Value>
       </Parameter>
-      <Parameter Type="MesonRadius" Name="Radius_f21950">
+      <Parameter>
+        <Type>MesonRadius</Type>
+        <Name>Radius_f21950</Name>
         <Value>1</Value>
         <Fix>true</Fix>
         <Min>0.0</Min>
@@ -482,44 +1351,82 @@
       </Parameter>
     </DecayInfo>
   </Particle>
-
-  <Particle Name="a0(980)0">
+  <Particle>
+    <Name>a0(980)0</Name>
     <Pid>9000111</Pid>
-    <Parameter Type="Mass" Name="Mass_a0(980)">
+    <Parameter>
+      <Type>Mass</Type>
+      <Name>Mass_a0(980)</Name>
       <Value>0.994</Value>
       <Error>0.001</Error>
       <Fix>true</Fix>
     </Parameter>
-    <QuantumNumber Class="Spin" Type="Spin" Value="0" />
-    <QuantumNumber Class="Int" Type="Charge" Value="0" />
-    <QuantumNumber Class="Int" Type="Parity" Value="1" />
-    <QuantumNumber Class="Int" Type="Cparity" Value="1" />
-    <QuantumNumber Class="Spin" Type="IsoSpin" Value="1" Projection="0" />
-    <QuantumNumber Class="Int" Type="Gparity" Value="-1" />
-    <DecayInfo Type="flatte">
-      <FormFactor Type="BlattWeisskopf" />
-      <Parameter Type="Coupling" Name="gKK_a0(980)">
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>Spin</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charge</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Parity</Type>
+      <Value>1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Cparity</Type>
+      <Value>1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>IsoSpin</Type>
+      <Value>1</Value>
+      <Projection>0</Projection>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Gparity</Type>
+      <Value>-1</Value>
+    </QuantumNumber>
+    <DecayInfo>
+      <Type>flatte</Type>
+      <FormFactor>
+        <Type>BlattWeisskopf</Type>
+      </FormFactor>
+      <Parameter>
+        <Type>Coupling</Type>
+        <Name>gKK_a0(980)</Name>
         <Value>3.121343843602647</Value>
         <Error>0.001</Error>
         <Fix>false</Fix>
         <ParticleA>K+</ParticleA>
         <ParticleB>K-</ParticleB>
       </Parameter>
-      <Parameter Type="Coupling" Name="gEtaPi_a0(980)">
+      <Parameter>
+        <Type>Coupling</Type>
+        <Name>gEtaPi_a0(980)</Name>
         <Value>2.66</Value>
         <Error>0.001</Error>
         <Fix>true</Fix>
         <ParticleA>eta</ParticleA>
         <ParticleB>pi0</ParticleB>
       </Parameter>
-      <Parameter Type="Coupling" Name="gKK_a0(980)">
+      <Parameter>
+        <Type>Coupling</Type>
+        <Name>gKK_a0(980)</Name>
         <Value>3.121343843602647</Value>
         <Error>0.001</Error>
         <Fix>false</Fix>
         <ParticleA>K_S0</ParticleA>
         <ParticleB>K_S0</ParticleB>
       </Parameter>
-      <Parameter Type="MesonRadius" Name="Radius_a0(980)">
+      <Parameter>
+        <Type>MesonRadius</Type>
+        <Name>Radius_a0(980)</Name>
         <Value>1.5</Value>
         <Fix>true</Fix>
         <Min>1.0</Min>
@@ -527,35 +1434,68 @@
       </Parameter>
     </DecayInfo>
   </Particle>
-  <Particle Name="a0(980)+">
+  <Particle>
+    <Name>a0(980)+</Name>
     <Pid>9000211</Pid>
-    <Parameter Type="Mass" Name="Mass_a0(980)+">
+    <Parameter>
+      <Type>Mass</Type>
+      <Name>Mass_a0(980)+</Name>
       <Value>0.994</Value>
       <Error>0.001</Error>
       <Fix>true</Fix>
     </Parameter>
-    <QuantumNumber Class="Spin" Type="Spin" Value="0" />
-    <QuantumNumber Class="Int" Type="Charge" Value="1" />
-    <QuantumNumber Class="Int" Type="Parity" Value="+1" />
-    <QuantumNumber Class="Spin" Type="IsoSpin" Value="1" Projection="1" />
-    <QuantumNumber Class="Int" Type="Gparity" Value="-1" />
-    <DecayInfo Type="flatte">
-      <FormFactor Type="BlattWeisskopf" />
-      <Parameter Type="Coupling" Name="gKK_a0(980)">
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>Spin</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charge</Type>
+      <Value>1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Parity</Type>
+      <Value>+1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>IsoSpin</Type>
+      <Value>1</Value>
+      <Projection>1</Projection>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Gparity</Type>
+      <Value>-1</Value>
+    </QuantumNumber>
+    <DecayInfo>
+      <Type>flatte</Type>
+      <FormFactor>
+        <Type>BlattWeisskopf</Type>
+      </FormFactor>
+      <Parameter>
+        <Type>Coupling</Type>
+        <Name>gKK_a0(980)</Name>
         <Value>3.121343843602647</Value>
         <Error>0.001</Error>
         <Fix>false</Fix>
         <ParticleA>K_S0</ParticleA>
         <ParticleB>K+</ParticleB>
       </Parameter>
-      <Parameter Type="Coupling" Name="gEtaPi_a0(980)">
+      <Parameter>
+        <Type>Coupling</Type>
+        <Name>gEtaPi_a0(980)</Name>
         <Value>2.66</Value>
         <Error>0.001</Error>
         <Fix>true</Fix>
         <ParticleA>eta</ParticleA>
         <ParticleB>pi0</ParticleB>
       </Parameter>
-      <Parameter Type="MesonRadius" Name="Radius_a0(980)">
+      <Parameter>
+        <Type>MesonRadius</Type>
+        <Name>Radius_a0(980)</Name>
         <Value>1.5</Value>
         <Fix>true</Fix>
         <Min>1.0</Min>
@@ -563,35 +1503,68 @@
       </Parameter>
     </DecayInfo>
   </Particle>
-  <Particle Name="a0(980)-">
+  <Particle>
+    <Name>a0(980)-</Name>
     <Pid>9000211</Pid>
-    <Parameter Type="Mass" Name="Mass_a0(980)-">
+    <Parameter>
+      <Type>Mass</Type>
+      <Name>Mass_a0(980)-</Name>
       <Value>0.994</Value>
       <Error>0.001</Error>
       <Fix>true</Fix>
     </Parameter>
-    <QuantumNumber Class="Spin" Type="Spin" Value="0" />
-    <QuantumNumber Class="Int" Type="Charge" Value="-1" />
-    <QuantumNumber Class="Int" Type="Parity" Value="+1" />
-    <QuantumNumber Class="Spin" Type="IsoSpin" Value="1" Projection="-1" />
-    <QuantumNumber Class="Int" Type="Gparity" Value="-1" />
-    <DecayInfo Type="flatte">
-      <FormFactor Type="BlattWeisskopf" />
-      <Parameter Type="Coupling" Name="gKK_a0(980)">
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>Spin</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charge</Type>
+      <Value>-1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Parity</Type>
+      <Value>+1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>IsoSpin</Type>
+      <Value>1</Value>
+      <Projection>-1</Projection>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Gparity</Type>
+      <Value>-1</Value>
+    </QuantumNumber>
+    <DecayInfo>
+      <Type>flatte</Type>
+      <FormFactor>
+        <Type>BlattWeisskopf</Type>
+      </FormFactor>
+      <Parameter>
+        <Type>Coupling</Type>
+        <Name>gKK_a0(980)</Name>
         <Value>3.121343843602647</Value>
         <Error>0.001</Error>
         <Fix>false</Fix>
         <ParticleA>K_S0</ParticleA>
         <ParticleB>K+</ParticleB>
       </Parameter>
-      <Parameter Type="Coupling" Name="gEtaPi_a0(980)">
+      <Parameter>
+        <Type>Coupling</Type>
+        <Name>gEtaPi_a0(980)</Name>
         <Value>2.66</Value>
         <Error>0.001</Error>
         <Fix>true</Fix>
         <ParticleA>eta</ParticleA>
         <ParticleB>pi0</ParticleB>
       </Parameter>
-      <Parameter Type="MesonRadius" Name="Radius_a0(980)">
+      <Parameter>
+        <Type>MesonRadius</Type>
+        <Name>Radius_a0(980)</Name>
         <Value>1.5</Value>
         <Fix>true</Fix>
         <Min>1.0</Min>
@@ -599,27 +1572,62 @@
       </Parameter>
     </DecayInfo>
   </Particle>
-  <Particle Name="a2(1320)0">
+  <Particle>
+    <Name>a2(1320)0</Name>
     <Pid>115</Pid>
-    <Parameter Type="Mass" Name="Mass_a2(1320)0">
+    <Parameter>
+      <Type>Mass</Type>
+      <Name>Mass_a2(1320)0</Name>
       <Value>1.3184</Value>
       <Error>0.0005</Error>
       <Fix>true</Fix>
     </Parameter>
-    <QuantumNumber Class="Spin" Type="Spin" Value="2" />
-    <QuantumNumber Class="Int" Type="Charge" Value="0" />
-    <QuantumNumber Class="Int" Type="Parity" Value="1" />
-    <QuantumNumber Class="Int" Type="Cparity" Value="1" />
-    <QuantumNumber Class="Spin" Type="IsoSpin" Value="1" Projection="0" />
-    <QuantumNumber Class="Int" Type="Gparity" Value="-1" />
-    <DecayInfo Type="relativisticBreitWigner">
-      <FormFactor Type="1"></FormFactor>
-      <Parameter Type="Width" Name="Width_a2(1320)-">
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>Spin</Type>
+      <Value>2</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charge</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Parity</Type>
+      <Value>1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Cparity</Type>
+      <Value>1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>IsoSpin</Type>
+      <Value>1</Value>
+      <Projection>0</Projection>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Gparity</Type>
+      <Value>-1</Value>
+    </QuantumNumber>
+    <DecayInfo>
+      <Type>relativisticBreitWigner</Type>
+      <FormFactor>
+        <Type>1</Type>
+      </FormFactor>
+      <Parameter>
+        <Type>Width</Type>
+        <Name>Width_a2(1320)-</Name>
         <Value>0.00107</Value>
         <Error>0.00005</Error>
         <Fix>true</Fix>
       </Parameter>
-      <Parameter Type="MesonRadius" Name="Radius_a2(1320)-">
+      <Parameter>
+        <Type>MesonRadius</Type>
+        <Name>Radius_a2(1320)-</Name>
         <Value>1.5</Value>
         <Fix>true</Fix>
         <Min>1.0</Min>
@@ -627,27 +1635,62 @@
       </Parameter>
     </DecayInfo>
   </Particle>
-  <Particle Name="a2(1320)+">
+  <Particle>
+    <Name>a2(1320)+</Name>
     <Pid>215</Pid>
-    <Parameter Type="Mass" Name="Mass_a2(1320)+">
+    <Parameter>
+      <Type>Mass</Type>
+      <Name>Mass_a2(1320)+</Name>
       <Value>1.3184</Value>
       <Error>0.0005</Error>
       <Fix>true</Fix>
     </Parameter>
-    <QuantumNumber Class="Spin" Type="Spin" Value="2" />
-    <QuantumNumber Class="Int" Type="Charge" Value="1" />
-    <QuantumNumber Class="Int" Type="Parity" Value="1" />
-    <QuantumNumber Class="Int" Type="Cparity" Value="1" />
-    <QuantumNumber Class="Spin" Type="IsoSpin" Value="1" Projection="1" />
-    <QuantumNumber Class="Int" Type="Gparity" Value="-1" />
-    <DecayInfo Type="relativisticBreitWigner">
-      <FormFactor Type="1"></FormFactor>
-      <Parameter Type="Width" Name="Width_a2(1320)-">
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>Spin</Type>
+      <Value>2</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charge</Type>
+      <Value>1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Parity</Type>
+      <Value>1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Cparity</Type>
+      <Value>1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>IsoSpin</Type>
+      <Value>1</Value>
+      <Projection>1</Projection>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Gparity</Type>
+      <Value>-1</Value>
+    </QuantumNumber>
+    <DecayInfo>
+      <Type>relativisticBreitWigner</Type>
+      <FormFactor>
+        <Type>1</Type>
+      </FormFactor>
+      <Parameter>
+        <Type>Width</Type>
+        <Name>Width_a2(1320)-</Name>
         <Value>0.00107</Value>
         <Error>0.00005</Error>
         <Fix>true</Fix>
       </Parameter>
-      <Parameter Type="MesonRadius" Name="Radius_a2(1320)-">
+      <Parameter>
+        <Type>MesonRadius</Type>
+        <Name>Radius_a2(1320)-</Name>
         <Value>1.5</Value>
         <Fix>true</Fix>
         <Min>1.0</Min>
@@ -655,27 +1698,62 @@
       </Parameter>
     </DecayInfo>
   </Particle>
-  <Particle Name="a2(1320)-">
+  <Particle>
+    <Name>a2(1320)-</Name>
     <Pid>-215</Pid>
-    <Parameter Type="Mass" Name="Mass_a2(1320)-">
+    <Parameter>
+      <Type>Mass</Type>
+      <Name>Mass_a2(1320)-</Name>
       <Value>1.3184</Value>
       <Error>0.0005</Error>
       <Fix>true</Fix>
     </Parameter>
-    <QuantumNumber Class="Spin" Type="Spin" Value="2" />
-    <QuantumNumber Class="Int" Type="Charge" Value="-1" />
-    <QuantumNumber Class="Int" Type="Parity" Value="1" />
-    <QuantumNumber Class="Int" Type="Cparity" Value="1" />
-    <QuantumNumber Class="Spin" Type="IsoSpin" Value="1" Projection="-1" />
-    <QuantumNumber Class="Int" Type="Gparity" Value="-1" />
-    <DecayInfo Type="relativisticBreitWigner">
-      <FormFactor Type="1"></FormFactor>
-      <Parameter Type="Width" Name="Width_a2(1320)-">
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>Spin</Type>
+      <Value>2</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charge</Type>
+      <Value>-1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Parity</Type>
+      <Value>1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Cparity</Type>
+      <Value>1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>IsoSpin</Type>
+      <Value>1</Value>
+      <Projection>-1</Projection>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Gparity</Type>
+      <Value>-1</Value>
+    </QuantumNumber>
+    <DecayInfo>
+      <Type>relativisticBreitWigner</Type>
+      <FormFactor>
+        <Type>1</Type>
+      </FormFactor>
+      <Parameter>
+        <Type>Width</Type>
+        <Name>Width_a2(1320)-</Name>
         <Value>0.00107</Value>
         <Error>0.00005</Error>
         <Fix>true</Fix>
       </Parameter>
-      <Parameter Type="MesonRadius" Name="Radius_a2(1320)-">
+      <Parameter>
+        <Type>MesonRadius</Type>
+        <Name>Radius_a2(1320)-</Name>
         <Value>1.5</Value>
         <Fix>true</Fix>
         <Min>1.0</Min>
@@ -683,27 +1761,51 @@
       </Parameter>
     </DecayInfo>
   </Particle>
-
-
-  <Particle Name="phi(1020)">
+  <Particle>
+    <Name>phi(1020)</Name>
     <Pid>333</Pid>
-    <Parameter Type="Mass" Name="Mass_phi(1020)">
+    <Parameter>
+      <Type>Mass</Type>
+      <Name>Mass_phi(1020)</Name>
       <Value>1.019461</Value>
       <Error>0.000019</Error>
       <Fix>true</Fix>
     </Parameter>
-    <QuantumNumber Class="Spin" Type="Spin" Value="1" />
-    <QuantumNumber Class="Int" Type="Charge" Value="0" />
-    <QuantumNumber Class="Int" Type="Parity" Value="-1" />
-    <QuantumNumber Class="Int" Type="Gparity" Value="-1" />
-    <DecayInfo Type="relativisticBreitWigner">
-      <FormFactor Type="1" />
-      <Parameter Type="Width" Name="Width_phi(1020)">
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>Spin</Type>
+      <Value>1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charge</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Parity</Type>
+      <Value>-1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Gparity</Type>
+      <Value>-1</Value>
+    </QuantumNumber>
+    <DecayInfo>
+      <Type>relativisticBreitWigner</Type>
+      <FormFactor>
+        <Type>1</Type>
+      </FormFactor>
+      <Parameter>
+        <Type>Width</Type>
+        <Name>Width_phi(1020)</Name>
         <Value>0.004266</Value>
         <Error>0.000031</Error>
         <Fix>true</Fix>
       </Parameter>
-      <Parameter Type="MesonRadius" Name="Radius_phi(1020)">
+      <Parameter>
+        <Type>MesonRadius</Type>
+        <Name>Radius_phi(1020)</Name>
         <Value>1.5</Value>
         <Fix>true</Fix>
         <Min>1.0</Min>
@@ -713,79 +1815,226 @@
   </Particle>
 
   <!-- Strange mesons -->
-  <Particle Name="K-">
+  <Particle>
+    <Name>K-</Name>
     <Pid>-321</Pid>
-    <Parameter Type="Mass" Name="Mass_chargedKaon">
+    <Parameter>
+      <Type>Mass</Type>
+      <Name>Mass_chargedKaon</Name>
       <Value>0.493677</Value>
       <Fix>true</Fix>
     </Parameter>
-    <QuantumNumber Class="Spin" Type="Spin" Value="0" />
-    <QuantumNumber Class="Int" Type="Charge" Value="-1" />
-    <QuantumNumber Class="Int" Type="Parity" Value="-1" />
-    <QuantumNumber Class="Spin" Type="IsoSpin" Value="0.5" Projection="-0.5" />
-    <QuantumNumber Class="Int" Type="BaryonNumber" Value="0" />
-    <QuantumNumber Class="Int" Type="Strangeness" Value="-1" />
-    <QuantumNumber Class="Int" Type="Charm" Value="0" />
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>Spin</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charge</Type>
+      <Value>-1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Parity</Type>
+      <Value>-1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>IsoSpin</Type>
+      <Value>0.5</Value>
+      <Projection>-0.5</Projection>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>BaryonNumber</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Strangeness</Type>
+      <Value>-1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charm</Type>
+      <Value>0</Value>
+    </QuantumNumber>
   </Particle>
-  <Particle Name="K+">
+  <Particle>
+    <Name>K+</Name>
     <Pid>321</Pid>
-    <Parameter Type="Mass" Name="Mass_chargedKaon">
+    <Parameter>
+      <Type>Mass</Type>
+      <Name>Mass_chargedKaon</Name>
       <Value>0.493677</Value>
       <Fix>true</Fix>
     </Parameter>
-    <QuantumNumber Class="Spin" Type="Spin" Value="0" />
-    <QuantumNumber Class="Int" Type="Charge" Value="1" />
-    <QuantumNumber Class="Int" Type="Parity" Value="-1" />
-    <QuantumNumber Class="Spin" Type="IsoSpin" Value="0.5" Projection="0.5" />
-    <QuantumNumber Class="Int" Type="BaryonNumber" Value="0" />
-    <QuantumNumber Class="Int" Type="Strangeness" Value="1" />
-    <QuantumNumber Class="Int" Type="Charm" Value="0" />
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>Spin</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charge</Type>
+      <Value>1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Parity</Type>
+      <Value>-1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>IsoSpin</Type>
+      <Value>0.5</Value>
+      <Projection>0.5</Projection>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>BaryonNumber</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Strangeness</Type>
+      <Value>1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charm</Type>
+      <Value>0</Value>
+    </QuantumNumber>
   </Particle>
-  <Particle Name="K_S0">
+  <Particle>
+    <Name>K_S0</Name>
     <Pid>310</Pid>
-    <Parameter Type="Mass" Name="Mass_neutralKaon">
+    <Parameter>
+      <Type>Mass</Type>
+      <Name>Mass_neutralKaon</Name>
       <Value>0.497614</Value>
       <Fix>true</Fix>
     </Parameter>
-    <QuantumNumber Class="Spin" Type="Spin" Value="0" />
-    <QuantumNumber Class="Int" Type="Charge" Value="0" />
-    <QuantumNumber Class="Int" Type="Parity" Value="-1" />
-    <QuantumNumber Class="Spin" Type="IsoSpin" Value="0.5" Projection="0.0" />
-    <QuantumNumber Class="Int" Type="BaryonNumber" Value="0" />
-    <QuantumNumber Class="Int" Type="Strangeness" Value="0" />
-    <QuantumNumber Class="Int" Type="Charm" Value="0" />
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>Spin</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charge</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Parity</Type>
+      <Value>-1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>IsoSpin</Type>
+      <Value>0.5</Value>
+      <Projection>0.0</Projection>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>BaryonNumber</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Strangeness</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charm</Type>
+      <Value>0</Value>
+    </QuantumNumber>
   </Particle>
-  <Particle Name="K_L0">
+  <Particle>
+    <Name>K_L0</Name>
     <Pid>130</Pid>
-    <Parameter Type="Mass" Name="Mass_neutralKaon">
+    <Parameter>
+      <Type>Mass</Type>
+      <Name>Mass_neutralKaon</Name>
       <Value>0.497614</Value>
       <Fix>true</Fix>
     </Parameter>
-    <QuantumNumber Class="Spin" Type="Spin" Value="0" />
-    <QuantumNumber Class="Int" Type="Charge" Value="0" />
-    <QuantumNumber Class="Int" Type="Parity" Value="-1" />
-    <QuantumNumber Class="Spin" Type="IsoSpin" Value="0.5" Projection="-0.5" />
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>Spin</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charge</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Parity</Type>
+      <Value>-1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>IsoSpin</Type>
+      <Value>0.5</Value>
+      <Projection>-0.5</Projection>
+    </QuantumNumber>
   </Particle>
 
   <!-- Heavy flavour mesons -->
-  <Particle Name="D+">
+  <Particle>
+    <Name>D+</Name>
     <Pid>411</Pid>
-    <Parameter Type="Mass" Name="Mass_chargedD">
+    <Parameter>
+      <Type>Mass</Type>
+      <Name>Mass_chargedD</Name>
       <Value>1.86958</Value>
       <Fix>true</Fix>
     </Parameter>
-    <QuantumNumber Class="Spin" Type="Spin" Value="0" />
-    <QuantumNumber Class="Int" Type="Charge" Value="+1" />
-    <QuantumNumber Class="Int" Type="Parity" Value="-1" />
-    <QuantumNumber Class="Spin" Type="IsoSpin" Value="0.5" Projection="0.5" />
-    <QuantumNumber Class="Int" Type="Charm" Value="1" />
-    <DecayInfo Type="relativisticBreitWigner">
-      <FormFactor Type="BlattWeisskopf" />
-      <Parameter Type="Width" Name="Width_chargedD">
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>Spin</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charge</Type>
+      <Value>+1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Parity</Type>
+      <Value>-1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>IsoSpin</Type>
+      <Value>0.5</Value>
+      <Projection>0.5</Projection>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charm</Type>
+      <Value>1</Value>
+    </QuantumNumber>
+    <DecayInfo>
+      <Type>relativisticBreitWigner</Type>
+      <FormFactor>
+        <Type>BlattWeisskopf</Type>
+      </FormFactor>
+      <Parameter>
+        <Type>Width</Type>
+        <Name>Width_chargedD</Name>
         <Value>6.33E-13</Value>
         <Fix>true</Fix>
       </Parameter>
-      <Parameter Type="MesonRadius" Name="Radius_chargedD">
+      <Parameter>
+        <Type>MesonRadius</Type>
+        <Name>Radius_chargedD</Name>
         <Value>2.5</Value>
         <Fix>true</Fix>
         <Min>2.0</Min>
@@ -793,24 +2042,55 @@
       </Parameter>
     </DecayInfo>
   </Particle>
-  <Particle Name="D-">
+  <Particle>
+    <Name>D-</Name>
     <Pid>-411</Pid>
-    <Parameter Type="Mass" Name="Mass_chargedD">
+    <Parameter>
+      <Type>Mass</Type>
+      <Name>Mass_chargedD</Name>
       <Value>1.86958</Value>
       <Fix>true</Fix>
     </Parameter>
-    <QuantumNumber Class="Spin" Type="Spin" Value="0" />
-    <QuantumNumber Class="Int" Type="Charge" Value="-1" />
-    <QuantumNumber Class="Int" Type="Parity" Value="-1" />
-    <QuantumNumber Class="Spin" Type="IsoSpin" Value="0.5" Projection="-0.5" />
-    <QuantumNumber Class="Int" Type="Charm" Value="-1" />
-    <DecayInfo Type="relativisticBreitWigner">
-      <FormFactor Type="BlattWeisskopf" />
-      <Parameter Type="Width" Name="Width_chargedD">
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>Spin</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charge</Type>
+      <Value>-1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Parity</Type>
+      <Value>-1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>IsoSpin</Type>
+      <Value>0.5</Value>
+      <Projection>-0.5</Projection>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charm</Type>
+      <Value>-1</Value>
+    </QuantumNumber>
+    <DecayInfo>
+      <Type>relativisticBreitWigner</Type>
+      <FormFactor>
+        <Type>BlattWeisskopf</Type>
+      </FormFactor>
+      <Parameter>
+        <Type>Width</Type>
+        <Name>Width_chargedD</Name>
         <Value>6.33E-13</Value>
         <Fix>true</Fix>
       </Parameter>
-      <Parameter Type="MesonRadius" Name="Radius_chargedD">
+      <Parameter>
+        <Type>MesonRadius</Type>
+        <Name>Radius_chargedD</Name>
         <Value>2.5</Value>
         <Fix>true</Fix>
         <Min>2.0</Min>
@@ -818,26 +2098,65 @@
       </Parameter>
     </DecayInfo>
   </Particle>
-  <Particle Name="D0">
+  <Particle>
+    <Name>D0</Name>
     <Pid>421</Pid>
-    <Parameter Type="Mass" Name="Mass_neutralD">
+    <Parameter>
+      <Type>Mass</Type>
+      <Name>Mass_neutralD</Name>
       <Value>1.86483</Value>
       <Fix>true</Fix>
     </Parameter>
-    <QuantumNumber Class="Spin" Type="Spin" Value="0" />
-    <QuantumNumber Class="Int" Type="Charge" Value="0" />
-    <QuantumNumber Class="Int" Type="Parity" Value="-1" />
-    <QuantumNumber Class="Spin" Type="IsoSpin" Value="0.5" Projection="-0.5" />
-    <QuantumNumber Class="Int" Type="Charm" Value="1" />
-    <QuantumNumber Class="Int" Type="Strangeness" Value="0" />
-    <QuantumNumber Class="Int" Type="BaryonNumber" Value="0" />
-    <DecayInfo Type="relativisticBreitWigner">
-      <FormFactor Type="BlattWeisskopf" />
-      <Parameter Type="Width" Name="Width_neutralD">
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>Spin</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charge</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Parity</Type>
+      <Value>-1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>IsoSpin</Type>
+      <Value>0.5</Value>
+      <Projection>-0.5</Projection>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charm</Type>
+      <Value>1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Strangeness</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>BaryonNumber</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <DecayInfo>
+      <Type>relativisticBreitWigner</Type>
+      <FormFactor>
+        <Type>BlattWeisskopf</Type>
+      </FormFactor>
+      <Parameter>
+        <Type>Width</Type>
+        <Name>Width_neutralD</Name>
         <Value>1.605E-12</Value>
         <Fix>true</Fix>
       </Parameter>
-      <Parameter Type="MesonRadius" Name="Radius_neutralD">
+      <Parameter>
+        <Type>MesonRadius</Type>
+        <Name>Radius_neutralD</Name>
         <Value>2.5</Value>
         <Fix>true</Fix>
         <Min>2.0</Min>
@@ -845,26 +2164,65 @@
       </Parameter>
     </DecayInfo>
   </Particle>
-  <Particle Name="D0bar">
+  <Particle>
+    <Name>D0bar</Name>
     <Pid>-421</Pid>
-    <Parameter Type="Mass" Name="Mass_neutralD">
+    <Parameter>
+      <Type>Mass</Type>
+      <Name>Mass_neutralD</Name>
       <Value>1.86483</Value>
       <Fix>true</Fix>
     </Parameter>
-    <QuantumNumber Class="Spin" Type="Spin" Value="0" />
-    <QuantumNumber Class="Int" Type="Charge" Value="0" />
-    <QuantumNumber Class="Int" Type="Parity" Value="-1" />
-    <QuantumNumber Class="Spin" Type="IsoSpin" Value="0.5" Projection="0.5" />
-    <QuantumNumber Class="Int" Type="Charm" Value="-1" />
-    <QuantumNumber Class="Int" Type="Strangeness" Value="0" />
-    <QuantumNumber Class="Int" Type="BaryonNumber" Value="0" />
-    <DecayInfo Type="relativisticBreitWigner">
-      <FormFactor Type="BlattWeisskopf" />
-      <Parameter Type="Width" Name="Width_neutralD">
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>Spin</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charge</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Parity</Type>
+      <Value>-1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>IsoSpin</Type>
+      <Value>0.5</Value>
+      <Projection>0.5</Projection>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charm</Type>
+      <Value>-1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Strangeness</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>BaryonNumber</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <DecayInfo>
+      <Type>relativisticBreitWigner</Type>
+      <FormFactor>
+        <Type>BlattWeisskopf</Type>
+      </FormFactor>
+      <Parameter>
+        <Type>Width</Type>
+        <Name>Width_neutralD</Name>
         <Value>1.605E-12</Value>
         <Fix>true</Fix>
       </Parameter>
-      <Parameter Type="MesonRadius" Name="Radius_neutralD">
+      <Parameter>
+        <Type>MesonRadius</Type>
+        <Name>Radius_neutralD</Name>
         <Value>2.5</Value>
         <Fix>true</Fix>
         <Min>2.0</Min>
@@ -872,25 +2230,60 @@
       </Parameter>
     </DecayInfo>
   </Particle>
-  <Particle Name="D*(2007)0">
+  <Particle>
+    <Name>D*(2007)0</Name>
     <Pid>423</Pid>
-    <Parameter Type="Mass" Name="Mass_D*(2007)0">
+    <Parameter>
+      <Type>Mass</Type>
+      <Name>Mass_D*(2007)0</Name>
       <Value>2.007</Value>
       <Fix>true</Fix>
     </Parameter>
-    <QuantumNumber Class="Spin" Type="Spin" Value="1" />
-    <QuantumNumber Class="Int" Type="Charge" Value="0" />
-    <QuantumNumber Class="Int" Type="Parity" Value="-1" />
-    <QuantumNumber Class="Spin" Type="IsoSpin" Value="0.5" Projection="-0.5" />
-    <QuantumNumber Class="Int" Type="Charm" Value="1" />
-    <QuantumNumber Class="Int" Type="BaryonNumber" Value="0" />
-    <DecayInfo Type="relativisticBreitWigner">
-      <FormFactor Type="BlattWeisskopf" />
-      <Parameter Type="Width" Name="Width_D*(2007)0">
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>Spin</Type>
+      <Value>1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charge</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Parity</Type>
+      <Value>-1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>IsoSpin</Type>
+      <Value>0.5</Value>
+      <Projection>-0.5</Projection>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charm</Type>
+      <Value>1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>BaryonNumber</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <DecayInfo>
+      <Type>relativisticBreitWigner</Type>
+      <FormFactor>
+        <Type>BlattWeisskopf</Type>
+      </FormFactor>
+      <Parameter>
+        <Type>Width</Type>
+        <Name>Width_D*(2007)0</Name>
         <Value>0.001</Value>
         <Fix>true</Fix>
       </Parameter>
-      <Parameter Type="MesonRadius" Name="Radius_D*(2007)0">
+      <Parameter>
+        <Type>MesonRadius</Type>
+        <Name>Radius_D*(2007)0</Name>
         <Value>2.5</Value>
         <Fix>true</Fix>
         <Min>2.0</Min>
@@ -898,25 +2291,60 @@
       </Parameter>
     </DecayInfo>
   </Particle>
-  <Particle Name="D*(2007)0bar">
+  <Particle>
+    <Name>D*(2007)0bar</Name>
     <Pid>-423</Pid>
-    <Parameter Type="Mass" Name="Mass_D*(2007)0bar">
+    <Parameter>
+      <Type>Mass</Type>
+      <Name>Mass_D*(2007)0bar</Name>
       <Value>2.007</Value>
       <Fix>true</Fix>
     </Parameter>
-    <QuantumNumber Class="Spin" Type="Spin" Value="1" />
-    <QuantumNumber Class="Int" Type="Charge" Value="0" />
-    <QuantumNumber Class="Int" Type="Parity" Value="-1" />
-    <QuantumNumber Class="Spin" Type="IsoSpin" Value="0.5" Projection="0.5" />
-    <QuantumNumber Class="Int" Type="Charm" Value="-1" />
-    <QuantumNumber Class="Int" Type="BaryonNumber" Value="0" />
-    <DecayInfo Type="relativisticBreitWigner">
-      <FormFactor Type="BlattWeisskopf" />
-      <Parameter Type="Width" Name="Width_D*(2007)0bar">
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>Spin</Type>
+      <Value>1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charge</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Parity</Type>
+      <Value>-1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>IsoSpin</Type>
+      <Value>0.5</Value>
+      <Projection>0.5</Projection>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charm</Type>
+      <Value>-1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>BaryonNumber</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <DecayInfo>
+      <Type>relativisticBreitWigner</Type>
+      <FormFactor>
+        <Type>BlattWeisskopf</Type>
+      </FormFactor>
+      <Parameter>
+        <Type>Width</Type>
+        <Name>Width_D*(2007)0bar</Name>
         <Value>0.001</Value>
         <Fix>true</Fix>
       </Parameter>
-      <Parameter Type="MesonRadius" Name="Radius_D*(2007)0bar">
+      <Parameter>
+        <Type>MesonRadius</Type>
+        <Name>Radius_D*(2007)0bar</Name>
         <Value>2.5</Value>
         <Fix>true</Fix>
         <Min>2.0</Min>
@@ -924,25 +2352,60 @@
       </Parameter>
     </DecayInfo>
   </Particle>
-  <Particle Name="D*(2010)-">
+  <Particle>
+    <Name>D*(2010)-</Name>
     <Pid>-413</Pid>
-    <Parameter Type="Mass" Name="Mass_D*(2010)-">
+    <Parameter>
+      <Type>Mass</Type>
+      <Name>Mass_D*(2010)-</Name>
       <Value>2.01</Value>
       <Fix>true</Fix>
     </Parameter>
-    <QuantumNumber Class="Spin" Type="Spin" Value="1" />
-    <QuantumNumber Class="Int" Type="Charge" Value="-1" />
-    <QuantumNumber Class="Int" Type="Parity" Value="-1" />
-    <QuantumNumber Class="Spin" Type="IsoSpin" Value="0.5" Projection="-0.5" />
-    <QuantumNumber Class="Int" Type="Charm" Value="-1" />
-    <QuantumNumber Class="Int" Type="BaryonNumber" Value="0" />
-    <DecayInfo Type="relativisticBreitWigner">
-      <FormFactor Type="BlattWeisskopf" />
-      <Parameter Type="Width" Name="Width_D*(2010)-">
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>Spin</Type>
+      <Value>1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charge</Type>
+      <Value>-1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Parity</Type>
+      <Value>-1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>IsoSpin</Type>
+      <Value>0.5</Value>
+      <Projection>-0.5</Projection>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charm</Type>
+      <Value>-1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>BaryonNumber</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <DecayInfo>
+      <Type>relativisticBreitWigner</Type>
+      <FormFactor>
+        <Type>BlattWeisskopf</Type>
+      </FormFactor>
+      <Parameter>
+        <Type>Width</Type>
+        <Name>Width_D*(2010)-</Name>
         <Value>83.4E-6</Value>
         <Fix>true</Fix>
       </Parameter>
-      <Parameter Type="MesonRadius" Name="Radius_D*(2010)-">
+      <Parameter>
+        <Type>MesonRadius</Type>
+        <Name>Radius_D*(2010)-</Name>
         <Value>2.5</Value>
         <Fix>true</Fix>
         <Min>2.0</Min>
@@ -950,25 +2413,60 @@
       </Parameter>
     </DecayInfo>
   </Particle>
-  <Particle Name="D*(2010)+">
+  <Particle>
+    <Name>D*(2010)+</Name>
     <Pid>413</Pid>
-    <Parameter Type="Mass" Name="Mass_D*(2010)+">
+    <Parameter>
+      <Type>Mass</Type>
+      <Name>Mass_D*(2010)+</Name>
       <Value>2.01</Value>
       <Fix>true</Fix>
     </Parameter>
-    <QuantumNumber Class="Spin" Type="Spin" Value="1" />
-    <QuantumNumber Class="Int" Type="Charge" Value="1" />
-    <QuantumNumber Class="Int" Type="Parity" Value="-1" />
-    <QuantumNumber Class="Spin" Type="IsoSpin" Value="0.5" Projection="0.5" />
-    <QuantumNumber Class="Int" Type="Charm" Value="1" />
-    <QuantumNumber Class="Int" Type="BaryonNumber" Value="0" />
-    <DecayInfo Type="relativisticBreitWigner">
-      <FormFactor Type="BlattWeisskopf" />
-      <Parameter Type="Width" Name="Width_D*(2010)+">
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>Spin</Type>
+      <Value>1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charge</Type>
+      <Value>1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Parity</Type>
+      <Value>-1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>IsoSpin</Type>
+      <Value>0.5</Value>
+      <Projection>0.5</Projection>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charm</Type>
+      <Value>1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>BaryonNumber</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <DecayInfo>
+      <Type>relativisticBreitWigner</Type>
+      <FormFactor>
+        <Type>BlattWeisskopf</Type>
+      </FormFactor>
+      <Parameter>
+        <Type>Width</Type>
+        <Name>Width_D*(2010)+</Name>
         <Value>83.4E-6</Value>
         <Fix>true</Fix>
       </Parameter>
-      <Parameter Type="MesonRadius" Name="Radius_D*(2010)+">
+      <Parameter>
+        <Type>MesonRadius</Type>
+        <Name>Radius_D*(2010)+</Name>
         <Value>2.5</Value>
         <Fix>true</Fix>
         <Min>2.0</Min>
@@ -976,25 +2474,60 @@
       </Parameter>
     </DecayInfo>
   </Particle>
-  <Particle Name="D1(2420)0">
+  <Particle>
+    <Name>D1(2420)0</Name>
     <Pid>10423</Pid>
-    <Parameter Type="Mass" Name="Mass_D1(2420)0">
+    <Parameter>
+      <Type>Mass</Type>
+      <Name>Mass_D1(2420)0</Name>
       <Value>2.4214</Value>
       <Fix>true</Fix>
     </Parameter>
-    <QuantumNumber Class="Spin" Type="Spin" Value="1" />
-    <QuantumNumber Class="Int" Type="Charge" Value="0" />
-    <QuantumNumber Class="Int" Type="Parity" Value="1" />
-    <QuantumNumber Class="Spin" Type="IsoSpin" Value="0.5" Projection="-0.5" />
-    <QuantumNumber Class="Int" Type="Charm" Value="1" />
-    <QuantumNumber Class="Int" Type="BaryonNumber" Value="0" />
-    <DecayInfo Type="relativisticBreitWigner">
-      <FormFactor Type="BlattWeisskopf" />
-      <Parameter Type="Width" Name="Width_D1(2420)0">
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>Spin</Type>
+      <Value>1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charge</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Parity</Type>
+      <Value>1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>IsoSpin</Type>
+      <Value>0.5</Value>
+      <Projection>-0.5</Projection>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charm</Type>
+      <Value>1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>BaryonNumber</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <DecayInfo>
+      <Type>relativisticBreitWigner</Type>
+      <FormFactor>
+        <Type>BlattWeisskopf</Type>
+      </FormFactor>
+      <Parameter>
+        <Type>Width</Type>
+        <Name>Width_D1(2420)0</Name>
         <Value>27.4E-3</Value>
         <Fix>true</Fix>
       </Parameter>
-      <Parameter Type="MesonRadius" Name="Radius_D1(2420)0">
+      <Parameter>
+        <Type>MesonRadius</Type>
+        <Name>Radius_D1(2420)0</Name>
         <Value>2.5</Value>
         <Fix>true</Fix>
         <Min>2.0</Min>
@@ -1002,40 +2535,111 @@
       </Parameter>
     </DecayInfo>
   </Particle>
-  <Particle Name="XX">
+  <Particle>
+    <Name>XX</Name>
     <Pid>1111</Pid>
-    <Parameter Type="Mass" Name="Mass_XX">
+    <Parameter>
+      <Type>Mass</Type>
+      <Name>Mass_XX</Name>
       <Value>4.100</Value>
       <Fix>true</Fix>
     </Parameter>
-    <QuantumNumber Class="Spin" Type="Spin" Value="1" />
-    <QuantumNumber Class="Int" Type="Charge" Value="-1" />
-    <QuantumNumber Class="Int" Type="Parity" Value="-1" />
-    <QuantumNumber Class="Spin" Type="IsoSpin" Value="1" Projection="-1" />
-    <QuantumNumber Class="Int" Type="BaryonNumber" Value="0" />
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>Spin</Type>
+      <Value>1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charge</Type>
+      <Value>-1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Parity</Type>
+      <Value>-1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>IsoSpin</Type>
+      <Value>1</Value>
+      <Projection>-1</Projection>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>BaryonNumber</Type>
+      <Value>0</Value>
+    </QuantumNumber>
   </Particle>
-  <Particle Name="J/psi">
+  <Particle>
+    <Name>J/psi</Name>
     <Pid>443</Pid>
-    <Parameter Type="Mass" Name="Mass_jpsi">
+    <Parameter>
+      <Type>Mass</Type>
+      <Name>Mass_jpsi</Name>
       <Value>3.096900</Value>
       <Fix>true</Fix>
     </Parameter>
-    <QuantumNumber Class="Spin" Type="Spin" Value="1" />
-    <QuantumNumber Class="Int" Type="Charge" Value="0" />
-    <QuantumNumber Class="Int" Type="Parity" Value="-1" />
-    <QuantumNumber Class="Int" Type="Cparity" Value="-1" />
-    <QuantumNumber Class="Int" Type="Gparity" Value="-1" />
-    <QuantumNumber Class="Spin" Type="IsoSpin" Value="0" Projection="0" />
-    <QuantumNumber Class="Int" Type="BaryonNumber" Value="0" />
-    <QuantumNumber Class="Int" Type="Charm" Value="0" />
-    <QuantumNumber Class="Int" Type="Strangeness" Value="0" />
-    <DecayInfo Type="relativisticBreitWigner">
-      <FormFactor Type="BlattWeisskopf" />
-      <Parameter Type="Width" Name="Width_jpsi">
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>Spin</Type>
+      <Value>1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charge</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Parity</Type>
+      <Value>-1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Cparity</Type>
+      <Value>-1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Gparity</Type>
+      <Value>-1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>IsoSpin</Type>
+      <Value>0</Value>
+      <Projection>0</Projection>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>BaryonNumber</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charm</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Strangeness</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <DecayInfo>
+      <Type>relativisticBreitWigner</Type>
+      <FormFactor>
+        <Type>BlattWeisskopf</Type>
+      </FormFactor>
+      <Parameter>
+        <Type>Width</Type>
+        <Name>Width_jpsi</Name>
         <Value>9.29E-05</Value>
         <Fix>true</Fix>
       </Parameter>
-      <Parameter Type="MesonRadius" Name="Radius_jpsi">
+      <Parameter>
+        <Type>MesonRadius</Type>
+        <Name>Radius_jpsi</Name>
         <Value>2.5</Value>
         <Fix>true</Fix>
         <Min>2.0</Min>
@@ -1043,27 +2647,64 @@
       </Parameter>
     </DecayInfo>
   </Particle>
-
-  <Particle Name="Y">
+  <Particle>
+    <Name>Y</Name>
     <Pid>11443</Pid>
-    <Parameter Type="Mass" Name="Mass_Y">
+    <Parameter>
+      <Type>Mass</Type>
+      <Name>Mass_Y</Name>
       <Value>4.300</Value>
       <Fix>true</Fix>
     </Parameter>
-    <QuantumNumber Class="Spin" Type="Spin" Value="1" />
-    <QuantumNumber Class="Int" Type="Charge" Value="0" />
-    <QuantumNumber Class="Int" Type="Parity" Value="-1" />
-    <QuantumNumber Class="Int" Type="Cparity" Value="-1" />
-    <QuantumNumber Class="Int" Type="BaryonNumber" Value="0" />
-    <QuantumNumber Class="Int" Type="Charm" Value="0" />
-    <QuantumNumber Class="Int" Type="Strangeness" Value="0" />
-    <DecayInfo Type="relativisticBreitWigner">
-      <FormFactor Type="BlattWeisskopf" />
-      <Parameter Type="Width" Name="Width_Y">
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>Spin</Type>
+      <Value>1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charge</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Parity</Type>
+      <Value>-1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Cparity</Type>
+      <Value>-1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>BaryonNumber</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charm</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Strangeness</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <DecayInfo>
+      <Type>relativisticBreitWigner</Type>
+      <FormFactor>
+        <Type>BlattWeisskopf</Type>
+      </FormFactor>
+      <Parameter>
+        <Type>Width</Type>
+        <Name>Width_Y</Name>
         <Value>9.29E-05</Value>
         <Fix>true</Fix>
       </Parameter>
-      <Parameter Type="MesonRadius" Name="Radius_Y">
+      <Parameter>
+        <Type>MesonRadius</Type>
+        <Name>Radius_Y</Name>
         <Value>2.5</Value>
         <Fix>true</Fix>
         <Min>2.0</Min>
@@ -1071,29 +2712,74 @@
       </Parameter>
     </DecayInfo>
   </Particle>
-
-  <Particle Name="Chic1">
+  <Particle>
+    <Name>Chic1</Name>
     <Pid>1234</Pid>
-    <Parameter Type="Mass" Name="Mass_chic1">
+    <Parameter>
+      <Type>Mass</Type>
+      <Name>Mass_chic1</Name>
       <Value>3.510</Value>
       <Fix>true</Fix>
     </Parameter>
-    <QuantumNumber Class="Spin" Type="Spin" Value="1" />
-    <QuantumNumber Class="Int" Type="Charge" Value="0" />
-    <QuantumNumber Class="Int" Type="Parity" Value="1" />
-    <QuantumNumber Class="Int" Type="Cparity" Value="1" />
-    <QuantumNumber Class="Int" Type="Gparity" Value="1" />
-    <QuantumNumber Class="Spin" Type="IsoSpin" Value="0" />
-    <QuantumNumber Class="Int" Type="BaryonNumber" Value="0" />
-    <QuantumNumber Class="Int" Type="Charm" Value="0" />
-    <QuantumNumber Class="Int" Type="Strangeness" Value="0" />
-    <DecayInfo Type="relativisticBreitWigner">
-      <FormFactor Type="BlattWeisskopf" />
-      <Parameter Type="Width" Name="Width_chic1">
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>Spin</Type>
+      <Value>1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charge</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Parity</Type>
+      <Value>1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Cparity</Type>
+      <Value>1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Gparity</Type>
+      <Value>1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>IsoSpin</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>BaryonNumber</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charm</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Strangeness</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <DecayInfo>
+      <Type>relativisticBreitWigner</Type>
+      <FormFactor>
+        <Type>BlattWeisskopf</Type>
+      </FormFactor>
+      <Parameter>
+        <Type>Width</Type>
+        <Name>Width_chic1</Name>
         <Value>0.00084</Value>
         <Fix>true</Fix>
       </Parameter>
-      <Parameter Type="MesonRadius" Name="Radius_chic1">
+      <Parameter>
+        <Type>MesonRadius</Type>
+        <Name>Radius_chic1</Name>
         <Value>2.5</Value>
         <Fix>true</Fix>
         <Min>2.0</Min>
@@ -1101,306 +2787,908 @@
       </Parameter>
     </DecayInfo>
   </Particle>
-
-  <Particle Name="PatricParticle">
+  <Particle>
+    <Name>PatricParticle</Name>
     <Pid>1234</Pid>
-    <Parameter Type="Mass" Name="Mass_PatricParticle">
+    <Parameter>
+      <Type>Mass</Type>
+      <Name>Mass_PatricParticle</Name>
       <Value>4.050</Value>
       <Fix>true</Fix>
     </Parameter>
-    <QuantumNumber Class="Spin" Type="Spin" Value="1" />
-    <QuantumNumber Class="Int" Type="Charge" Value="1" />
-    <QuantumNumber Class="Int" Type="Parity" Value="1" />
-    <QuantumNumber Class="Int" Type="Cparity" Value="-1" />
-    <QuantumNumber Class="Int" Type="Gparity" Value="-1" />
-    <QuantumNumber Class="Spin" Type="IsoSpin" Value="1" Projection="1" />
-    <QuantumNumber Class="Int" Type="BaryonNumber" Value="0" />
-    <QuantumNumber Class="Int" Type="Charm" Value="0" />
-    <QuantumNumber Class="Int" Type="Strangeness" Value="0" />
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>Spin</Type>
+      <Value>1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charge</Type>
+      <Value>1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Parity</Type>
+      <Value>1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Cparity</Type>
+      <Value>-1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Gparity</Type>
+      <Value>-1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>IsoSpin</Type>
+      <Value>1</Value>
+      <Projection>1</Projection>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>BaryonNumber</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charm</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Strangeness</Type>
+      <Value>0</Value>
+    </QuantumNumber>
   </Particle>
 
 
   <!-- ==================== Baryons ==================== -->
-  <Particle Name="p">
+  <Particle>
+    <Name>p</Name>
     <Pid>2212</Pid>
-    <Parameter Type="Mass" Name="Mass_proton">
+    <Parameter>
+      <Type>Mass</Type>
+      <Name>Mass_proton</Name>
       <Value>0.938272081</Value>
       <Fix>true</Fix>
     </Parameter>
-    <QuantumNumber Class="Spin" Type="Spin" Value="0.5" />
-    <QuantumNumber Class="Int" Type="Charge" Value="1" />
-    <QuantumNumber Class="Int" Type="Parity" Value="1" />
-    <QuantumNumber Class="Spin" Type="IsoSpin" Value="0.5" Projection="0.5" />
-    <QuantumNumber Class="Int" Type="BaryonNumber" Value="1" />
-    <QuantumNumber Class="Int" Type="Charm" Value="0" />
-    <QuantumNumber Class="Int" Type="Strangeness" Value="0" />
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>Spin</Type>
+      <Value>0.5</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charge</Type>
+      <Value>1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Parity</Type>
+      <Value>1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>IsoSpin</Type>
+      <Value>0.5</Value>
+      <Projection>0.5</Projection>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>BaryonNumber</Type>
+      <Value>1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charm</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Strangeness</Type>
+      <Value>0</Value>
+    </QuantumNumber>
   </Particle>
-
-  <Particle Name="pbar">
+  <Particle>
+    <Name>pbar</Name>
     <Pid>-2212</Pid>
-    <Parameter Type="Mass" Name="Mass_antiproton">
+    <Parameter>
+      <Type>Mass</Type>
+      <Name>Mass_antiproton</Name>
       <Value>0.938272081</Value>
       <Fix>true</Fix>
     </Parameter>
-    <QuantumNumber Class="Spin" Type="Spin" Value="0.5" />
-    <QuantumNumber Class="Int" Type="Charge" Value="-1" />
-    <QuantumNumber Class="Int" Type="Parity" Value="-1" />
-    <QuantumNumber Class="Spin" Type="IsoSpin" Value="0.5" Projection="-0.5" />
-    <QuantumNumber Class="Int" Type="BaryonNumber" Value="-1" />
-    <QuantumNumber Class="Int" Type="Charm" Value="0" />
-    <QuantumNumber Class="Int" Type="Strangeness" Value="0" />
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>Spin</Type>
+      <Value>0.5</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charge</Type>
+      <Value>-1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Parity</Type>
+      <Value>-1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>IsoSpin</Type>
+      <Value>0.5</Value>
+      <Projection>-0.5</Projection>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>BaryonNumber</Type>
+      <Value>-1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charm</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Strangeness</Type>
+      <Value>0</Value>
+    </QuantumNumber>
   </Particle>
-
-  <Particle Name="n">
+  <Particle>
+    <Name>n</Name>
     <Pid>2112</Pid>
-    <Parameter Type="Mass" Name="Mass_neutron">
+    <Parameter>
+      <Type>Mass</Type>
+      <Name>Mass_neutron</Name>
       <Value>0.939565413</Value>
       <Fix>true</Fix>
     </Parameter>
-    <QuantumNumber Class="Spin" Type="Spin" Value="0.5" />
-    <QuantumNumber Class="Int" Type="Charge" Value="0" />
-    <QuantumNumber Class="Int" Type="Parity" Value="1" />
-    <QuantumNumber Class="Spin" Type="IsoSpin" Value="0.5" Projection="-0.5" />
-    <QuantumNumber Class="Int" Type="BaryonNumber" Value="1" />
-    <QuantumNumber Class="Int" Type="Charm" Value="0" />
-    <QuantumNumber Class="Int" Type="Strangeness" Value="0" />
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>Spin</Type>
+      <Value>0.5</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charge</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Parity</Type>
+      <Value>1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>IsoSpin</Type>
+      <Value>0.5</Value>
+      <Projection>-0.5</Projection>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>BaryonNumber</Type>
+      <Value>1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charm</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Strangeness</Type>
+      <Value>0</Value>
+    </QuantumNumber>
   </Particle>
-
-  <Particle Name="nbar">
+  <Particle>
+    <Name>nbar</Name>
     <Pid>2112</Pid>
-    <Parameter Type="Mass" Name="Mass_antineutron">
+    <Parameter>
+      <Type>Mass</Type>
+      <Name>Mass_antineutron</Name>
       <Value>0.939565413</Value>
       <Fix>true</Fix>
     </Parameter>
-    <QuantumNumber Class="Spin" Type="Spin" Value="0.5" />
-    <QuantumNumber Class="Int" Type="Charge" Value="0" />
-    <QuantumNumber Class="Int" Type="Parity" Value="-1" />
-    <QuantumNumber Class="Spin" Type="IsoSpin" Value="0.5" Projection="0.5" />
-    <QuantumNumber Class="Int" Type="BaryonNumber" Value="-1" />
-    <QuantumNumber Class="Int" Type="Charm" Value="0" />
-    <QuantumNumber Class="Int" Type="Strangeness" Value="0" />
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>Spin</Type>
+      <Value>0.5</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charge</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Parity</Type>
+      <Value>-1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>IsoSpin</Type>
+      <Value>0.5</Value>
+      <Projection>0.5</Projection>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>BaryonNumber</Type>
+      <Value>-1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charm</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Strangeness</Type>
+      <Value>0</Value>
+    </QuantumNumber>
   </Particle>
-
-  <Particle Name="N(1650)+">
+  <Particle>
+    <Name>N(1650)+</Name>
     <Pid>3112212</Pid>
-    <Parameter Type="Mass" Name="Mass_N(1650)+">
+    <Parameter>
+      <Type>Mass</Type>
+      <Name>Mass_N(1650)+</Name>
       <Value>1.650</Value>
       <Fix>true</Fix>
     </Parameter>
-    <QuantumNumber Class="Spin" Type="Spin" Value="0.5" />
-    <QuantumNumber Class="Int" Type="Charge" Value="1" />
-    <QuantumNumber Class="Int" Type="Parity" Value="-1" />
-    <QuantumNumber Class="Spin" Type="IsoSpin" Value="0.5" Projection="0.5" />
-    <QuantumNumber Class="Int" Type="BaryonNumber" Value="1" />
-    <QuantumNumber Class="Int" Type="Charm" Value="0" />
-    <QuantumNumber Class="Int" Type="Strangeness" Value="0" />
-    <QuantumNumber Class="Int" Type="ElectronLN" Value="0" />
-    <QuantumNumber Class="Int" Type="MuonLN" Value="0" />
-    <QuantumNumber Class="Int" Type="TauLN" Value="0" />
-    <DecayInfo Type="relativisticBreitWigner">
-      <FormFactor Type="BlattWeisskopf" />
-      <Parameter Type="Width" Name="Width_N(1650)+">
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>Spin</Type>
+      <Value>0.5</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charge</Type>
+      <Value>1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Parity</Type>
+      <Value>-1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>IsoSpin</Type>
+      <Value>0.5</Value>
+      <Projection>0.5</Projection>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>BaryonNumber</Type>
+      <Value>1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charm</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Strangeness</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>ElectronLN</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>MuonLN</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>TauLN</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <DecayInfo>
+      <Type>relativisticBreitWigner</Type>
+      <FormFactor>
+        <Type>BlattWeisskopf</Type>
+      </FormFactor>
+      <Parameter>
+        <Type>Width</Type>
+        <Name>Width_N(1650)+</Name>
         <Value>0.125</Value>
       </Parameter>
-      <Parameter Type="MesonRadius" Name="Radius_N(1650)+">
+      <Parameter>
+        <Type>MesonRadius</Type>
+        <Name>Radius_N(1650)+</Name>
         <Value>2.5</Value>
         <Min>2.0</Min>
         <Max>3.0</Max>
       </Parameter>
     </DecayInfo>
   </Particle>
-  <Particle Name="N(1650)-">
+  <Particle>
+    <Name>N(1650)-</Name>
     <Pid>-3112212</Pid>
-    <Parameter Type="Mass" Name="Mass_N(1650)-">
+    <Parameter>
+      <Type>Mass</Type>
+      <Name>Mass_N(1650)-</Name>
       <Value>1.650</Value>
       <Fix>true</Fix>
     </Parameter>
-    <QuantumNumber Class="Spin" Type="Spin" Value="0.5" />
-    <QuantumNumber Class="Int" Type="Charge" Value="-1" />
-    <QuantumNumber Class="Int" Type="Parity" Value="1" />
-    <QuantumNumber Class="Spin" Type="IsoSpin" Value="0.5" Projection="-0.5" />
-    <QuantumNumber Class="Int" Type="BaryonNumber" Value="-1" />
-    <QuantumNumber Class="Int" Type="Charm" Value="0" />
-    <QuantumNumber Class="Int" Type="Strangeness" Value="0" />
-    <DecayInfo Type="relativisticBreitWigner">
-      <FormFactor Type="BlattWeisskopf" />
-      <Parameter Type="Width" Name="Width_N(1650)-">
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>Spin</Type>
+      <Value>0.5</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charge</Type>
+      <Value>-1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Parity</Type>
+      <Value>1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>IsoSpin</Type>
+      <Value>0.5</Value>
+      <Projection>-0.5</Projection>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>BaryonNumber</Type>
+      <Value>-1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charm</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Strangeness</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <DecayInfo>
+      <Type>relativisticBreitWigner</Type>
+      <FormFactor>
+        <Type>BlattWeisskopf</Type>
+      </FormFactor>
+      <Parameter>
+        <Type>Width</Type>
+        <Name>Width_N(1650)-</Name>
         <Value>0.125</Value>
       </Parameter>
-      <Parameter Type="MesonRadius" Name="Radius_N(1650)-">
+      <Parameter>
+        <Type>MesonRadius</Type>
+        <Name>Radius_N(1650)-</Name>
         <Value>2.5</Value>
         <Min>2.0</Min>
         <Max>3.0</Max>
       </Parameter>
     </DecayInfo>
   </Particle>
-
-  <Particle Name="Delta(1232)++">
+  <Particle>
+    <Name>Delta(1232)++</Name>
     <Pid>2224</Pid>
-    <Parameter Type="Mass" Name="Mass_Delta(1232)++">
+    <Parameter>
+      <Type>Mass</Type>
+      <Name>Mass_Delta(1232)++</Name>
       <Value>1.232</Value>
       <Fix>true</Fix>
     </Parameter>
-    <QuantumNumber Class="Spin" Type="Spin" Value="1.5" />
-    <QuantumNumber Class="Int" Type="Charge" Value="2" />
-    <QuantumNumber Class="Int" Type="Parity" Value="1" />
-    <QuantumNumber Class="Spin" Type="IsoSpin" Value="1.5" Projection="1.5" />
-    <QuantumNumber Class="Int" Type="BaryonNumber" Value="1" />
-    <QuantumNumber Class="Int" Type="Charm" Value="0" />
-    <QuantumNumber Class="Int" Type="Strangeness" Value="0" />
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>Spin</Type>
+      <Value>1.5</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charge</Type>
+      <Value>2</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Parity</Type>
+      <Value>1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>IsoSpin</Type>
+      <Value>1.5</Value>
+      <Projection>1.5</Projection>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>BaryonNumber</Type>
+      <Value>1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charm</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Strangeness</Type>
+      <Value>0</Value>
+    </QuantumNumber>
   </Particle>
-  <Particle Name="Delta(1232)+">
+  <Particle>
+    <Name>Delta(1232)+</Name>
     <Pid>2214</Pid>
-    <Parameter Type="Mass" Name="Mass_Delta(1232)+">
+    <Parameter>
+      <Type>Mass</Type>
+      <Name>Mass_Delta(1232)+</Name>
       <Value>1.232</Value>
       <Fix>true</Fix>
     </Parameter>
-    <QuantumNumber Class="Spin" Type="Spin" Value="1.5" />
-    <QuantumNumber Class="Int" Type="Charge" Value="1" />
-    <QuantumNumber Class="Int" Type="Parity" Value="1" />
-    <QuantumNumber Class="Spin" Type="IsoSpin" Value="1.5" Projection="0.5" />
-    <QuantumNumber Class="Int" Type="BaryonNumber" Value="1" />
-    <QuantumNumber Class="Int" Type="Charm" Value="0" />
-    <QuantumNumber Class="Int" Type="Strangeness" Value="0" />
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>Spin</Type>
+      <Value>1.5</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charge</Type>
+      <Value>1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Parity</Type>
+      <Value>1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>IsoSpin</Type>
+      <Value>1.5</Value>
+      <Projection>0.5</Projection>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>BaryonNumber</Type>
+      <Value>1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charm</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Strangeness</Type>
+      <Value>0</Value>
+    </QuantumNumber>
   </Particle>
-  <Particle Name="Delta(1232)0">
+  <Particle>
+    <Name>Delta(1232)0</Name>
     <Pid>2114</Pid>
-    <Parameter Type="Mass" Name="Mass_Delta(1232)0">
+    <Parameter>
+      <Type>Mass</Type>
+      <Name>Mass_Delta(1232)0</Name>
       <Value>1.232</Value>
       <Fix>true</Fix>
     </Parameter>
-    <QuantumNumber Class="Spin" Type="Spin" Value="1.5" />
-    <QuantumNumber Class="Int" Type="Charge" Value="0" />
-    <QuantumNumber Class="Int" Type="Parity" Value="1" />
-    <QuantumNumber Class="Spin" Type="IsoSpin" Value="1.5" Projection="-0.5" />
-    <QuantumNumber Class="Int" Type="BaryonNumber" Value="1" />
-    <QuantumNumber Class="Int" Type="Charm" Value="0" />
-    <QuantumNumber Class="Int" Type="Strangeness" Value="0" />
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>Spin</Type>
+      <Value>1.5</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charge</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Parity</Type>
+      <Value>1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>IsoSpin</Type>
+      <Value>1.5</Value>
+      <Projection>-0.5</Projection>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>BaryonNumber</Type>
+      <Value>1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charm</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Strangeness</Type>
+      <Value>0</Value>
+    </QuantumNumber>
   </Particle>
-  <Particle Name="Delta(1232)-">
+  <Particle>
+    <Name>Delta(1232)-</Name>
     <Pid>1114</Pid>
-    <Parameter Type="Mass" Name="Mass_Delta(1232)-">
+    <Parameter>
+      <Type>Mass</Type>
+      <Name>Mass_Delta(1232)-</Name>
       <Value>1.232</Value>
       <Fix>true</Fix>
     </Parameter>
-    <QuantumNumber Class="Spin" Type="Spin" Value="1.5" />
-    <QuantumNumber Class="Int" Type="Charge" Value="-1" />
-    <QuantumNumber Class="Int" Type="Parity" Value="1" />
-    <QuantumNumber Class="Spin" Type="IsoSpin" Value="1.5" Projection="-1.5" />
-    <QuantumNumber Class="Int" Type="BaryonNumber" Value="1" />
-    <QuantumNumber Class="Int" Type="Charm" Value="0" />
-    <QuantumNumber Class="Int" Type="Strangeness" Value="0" />
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>Spin</Type>
+      <Value>1.5</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charge</Type>
+      <Value>-1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Parity</Type>
+      <Value>1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>IsoSpin</Type>
+      <Value>1.5</Value>
+      <Projection>-1.5</Projection>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>BaryonNumber</Type>
+      <Value>1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charm</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Strangeness</Type>
+      <Value>0</Value>
+    </QuantumNumber>
   </Particle>
-
 
   <!-- ===== Strange Baryons ===== -->
-  <Particle Name="lambda">
+  <Particle>
+    <Name>lambda</Name>
     <Pid>3122</Pid>
-    <Parameter Type="Mass" Name="Mass_lambda">
+    <Parameter>
+      <Type>Mass</Type>
+      <Name>Mass_lambda</Name>
       <Value>1.115683</Value>
       <Fix>true</Fix>
     </Parameter>
-    <QuantumNumber Class="Spin" Type="Spin" Value="0.5" />
-    <QuantumNumber Class="Int" Type="Charge" Value="0" />
-    <QuantumNumber Class="Int" Type="Parity" Value="1" />
-    <QuantumNumber Class="Spin" Type="IsoSpin" Value="0.0" />
-    <QuantumNumber Class="Int" Type="BaryonNumber" Value="1" />
-    <QuantumNumber Class="Int" Type="Charm" Value="0" />
-    <QuantumNumber Class="Int" Type="Strangeness" Value="-1" />
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>Spin</Type>
+      <Value>0.5</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charge</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Parity</Type>
+      <Value>1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>IsoSpin</Type>
+      <Value>0.0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>BaryonNumber</Type>
+      <Value>1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charm</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Strangeness</Type>
+      <Value>-1</Value>
+    </QuantumNumber>
   </Particle>
-
-  <Particle Name="lambdabar">
+  <Particle>
+    <Name>lambdabar</Name>
     <Pid>-3122</Pid>
-    <Parameter Type="Mass" Name="Mass_antilambda">
+    <Parameter>
+      <Type>Mass</Type>
+      <Name>Mass_antilambda</Name>
       <Value>1.115683</Value>
       <Fix>true</Fix>
     </Parameter>
-    <QuantumNumber Class="Spin" Type="Spin" Value="0.5" />
-    <QuantumNumber Class="Int" Type="Charge" Value="0" />
-    <QuantumNumber Class="Int" Type="Parity" Value="-1" />
-    <QuantumNumber Class="Spin" Type="IsoSpin" Value="0.0" />
-    <QuantumNumber Class="Int" Type="BaryonNumber" Value="-1" />
-    <QuantumNumber Class="Int" Type="Charm" Value="0" />
-    <QuantumNumber Class="Int" Type="Strangeness" Value="1" />
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>Spin</Type>
+      <Value>0.5</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charge</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Parity</Type>
+      <Value>-1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>IsoSpin</Type>
+      <Value>0.0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>BaryonNumber</Type>
+      <Value>-1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charm</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Strangeness</Type>
+      <Value>1</Value>
+    </QuantumNumber>
   </Particle>
-
-  <Particle Name="sigma0">
+  <Particle>
+    <Name>sigma0</Name>
     <Pid>3212</Pid>
-    <Parameter Type="Mass" Name="Mass_sigma0">
+    <Parameter>
+      <Type>Mass</Type>
+      <Name>Mass_sigma0</Name>
       <Value>1.192642</Value>
       <Fix>true</Fix>
     </Parameter>
-    <QuantumNumber Class="Spin" Type="Spin" Value="0.5" />
-    <QuantumNumber Class="Int" Type="Charge" Value="0" />
-    <QuantumNumber Class="Int" Type="Parity" Value="1" />
-    <QuantumNumber Class="Spin" Type="IsoSpin" Value="1.0" Projection="0.0" />
-    <QuantumNumber Class="Int" Type="BaryonNumber" Value="1" />
-    <QuantumNumber Class="Int" Type="Charm" Value="0" />
-    <QuantumNumber Class="Int" Type="Strangeness" Value="-1" />
-    <DecayInfo Type="relativisticBreitWigner">
-      <FormFactor Type="BlattWeisskopf" />
-      <Parameter Type="Width" Name="Width_chic1">
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>Spin</Type>
+      <Value>0.5</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charge</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Parity</Type>
+      <Value>1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>IsoSpin</Type>
+      <Value>1.0</Value>
+      <Projection>0.0</Projection>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>BaryonNumber</Type>
+      <Value>1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charm</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Strangeness</Type>
+      <Value>-1</Value>
+    </QuantumNumber>
+    <DecayInfo>
+      <Type>relativisticBreitWigner</Type>
+      <FormFactor>
+        <Type>BlattWeisskopf</Type>
+      </FormFactor>
+      <Parameter>
+        <Type>Width</Type>
+        <Name>Width_chic1</Name>
         <Value>0.0000089</Value>
         <Fix>true</Fix>
       </Parameter>
     </DecayInfo>
   </Particle>
-  <Particle Name="sigma+">
+  <Particle>
+    <Name>sigma+</Name>
     <Pid>3222</Pid>
-    <Parameter Type="Mass" Name="Mass_sigma+">
+    <Parameter>
+      <Type>Mass</Type>
+      <Name>Mass_sigma+</Name>
       <Value>1.18937</Value>
       <Fix>true</Fix>
     </Parameter>
-    <QuantumNumber Class="Spin" Type="Spin" Value="0.5" />
-    <QuantumNumber Class="Int" Type="Charge" Value="1" />
-    <QuantumNumber Class="Int" Type="Parity" Value="1" />
-    <QuantumNumber Class="Spin" Type="IsoSpin" Value="1.0" Projection="1.0" />
-    <QuantumNumber Class="Int" Type="BaryonNumber" Value="1" />
-    <QuantumNumber Class="Int" Type="Charm" Value="0" />
-    <QuantumNumber Class="Int" Type="Strangeness" Value="-1" />
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>Spin</Type>
+      <Value>0.5</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charge</Type>
+      <Value>1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Parity</Type>
+      <Value>1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>IsoSpin</Type>
+      <Value>1.0</Value>
+      <Projection>1.0</Projection>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>BaryonNumber</Type>
+      <Value>1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charm</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Strangeness</Type>
+      <Value>-1</Value>
+    </QuantumNumber>
   </Particle>
-  <Particle Name="sigma-">
+  <Particle>
+    <Name>sigma-</Name>
     <Pid>3112</Pid>
-    <Parameter Type="Mass" Name="Mass_sigma-">
+    <Parameter>
+      <Type>Mass</Type>
+      <Name>Mass_sigma-</Name>
       <Value>1.197449</Value>
       <Fix>true</Fix>
     </Parameter>
-    <QuantumNumber Class="Spin" Type="Spin" Value="0.5" />
-    <QuantumNumber Class="Int" Type="Charge" Value="-1" />
-    <QuantumNumber Class="Int" Type="Parity" Value="1" />
-    <QuantumNumber Class="Spin" Type="IsoSpin" Value="1.0" Projection="-1.0" />
-    <QuantumNumber Class="Int" Type="BaryonNumber" Value="1" />
-    <QuantumNumber Class="Int" Type="Charm" Value="0" />
-    <QuantumNumber Class="Int" Type="Strangeness" Value="-1" />
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>Spin</Type>
+      <Value>0.5</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charge</Type>
+      <Value>-1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Parity</Type>
+      <Value>1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>IsoSpin</Type>
+      <Value>1.0</Value>
+      <Projection>-1.0</Projection>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>BaryonNumber</Type>
+      <Value>1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charm</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Strangeness</Type>
+      <Value>-1</Value>
+    </QuantumNumber>
   </Particle>
-
-  <Particle Name="Xi0">
+  <Particle>
+    <Name>Xi0</Name>
     <Pid>3322</Pid>
-    <Parameter Type="Mass" Name="Mass_xi0">
+    <Parameter>
+      <Type>Mass</Type>
+      <Name>Mass_xi0</Name>
       <Value>1.31486</Value>
       <Fix>true</Fix>
     </Parameter>
-    <QuantumNumber Class="Spin" Type="Spin" Value="0.5" />
-    <QuantumNumber Class="Int" Type="Charge" Value="0" />
-    <QuantumNumber Class="Int" Type="Parity" Value="1" />
-    <QuantumNumber Class="Spin" Type="IsoSpin" Value="0.5" Projection="0.5" />
-    <QuantumNumber Class="Int" Type="BaryonNumber" Value="1" />
-    <QuantumNumber Class="Int" Type="Charm" Value="0" />
-    <QuantumNumber Class="Int" Type="Strangeness" Value="-2" />
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>Spin</Type>
+      <Value>0.5</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charge</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Parity</Type>
+      <Value>1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>IsoSpin</Type>
+      <Value>0.5</Value>
+      <Projection>0.5</Projection>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>BaryonNumber</Type>
+      <Value>1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charm</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Strangeness</Type>
+      <Value>-2</Value>
+    </QuantumNumber>
   </Particle>
-  <Particle Name="Xi-">
+  <Particle>
+    <Name>Xi-</Name>
     <Pid>3312</Pid>
-    <Parameter Type="Mass" Name="Mass_xi-">
+    <Parameter>
+      <Type>Mass</Type>
+      <Name>Mass_xi-</Name>
       <Value>1.32171</Value>
       <Fix>true</Fix>
     </Parameter>
-    <QuantumNumber Class="Spin" Type="Spin" Value="0.5" />
-    <QuantumNumber Class="Int" Type="Charge" Value="-1" />
-    <QuantumNumber Class="Int" Type="Parity" Value="1" />
-    <QuantumNumber Class="Spin" Type="IsoSpin" Value="1.0" Projection="-0.5" />
-    <QuantumNumber Class="Int" Type="BaryonNumber" Value="1" />
-    <QuantumNumber Class="Int" Type="Charm" Value="0" />
-    <QuantumNumber Class="Int" Type="Strangeness" Value="-2" />
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>Spin</Type>
+      <Value>0.5</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charge</Type>
+      <Value>-1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Parity</Type>
+      <Value>1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Spin</Class>
+      <Type>IsoSpin</Type>
+      <Value>1.0</Value>
+      <Projection>-0.5</Projection>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>BaryonNumber</Type>
+      <Value>1</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Charm</Type>
+      <Value>0</Value>
+    </QuantumNumber>
+    <QuantumNumber>
+      <Class>Int</Class>
+      <Type>Strangeness</Type>
+      <Value>-2</Value>
+    </QuantumNumber>
   </Particle>
-
 </ParticleList>

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,7 @@ flake8-builtins
 flake8-docstrings
 flake8-import-order
 flake8-rst-docstrings
-flake8>=3.7.9
+flake8>=3.7 # for per-file-ignores
 mypy>=0.770
 pep8-naming
 pre-commit>=2.2.0

--- a/tests/canonical-formalism/test_LSCoupling.py
+++ b/tests/canonical-formalism/test_LSCoupling.py
@@ -8,11 +8,11 @@ from expertsystem.ui.system_control import (
 from expertsystem.ui.default_settings import (
     create_default_interaction_settings,
 )
+from expertsystem.state import particle
 from expertsystem.state.particle import (
     InteractionQuantumNumberNames,
     SpinQNConverter,
     Spin,
-    XMLLabelConstants,
 )
 from expertsystem.state.conservationrules import ParityConservationHelicity
 
@@ -131,7 +131,7 @@ def test_canonical_clebsch_gordan_ls_coupling(
 
     l_label = InteractionQuantumNumberNames.L
     s_label = InteractionQuantumNumberNames.S
-    qn_label = XMLLabelConstants.QuantumNumber
+    qn_label = particle.LABELS.QuantumNumber
 
     spin_converter = SpinQNConverter()
     node_props = {

--- a/tests/channels/test_D0ToKsKpKm.py
+++ b/tests/channels/test_D0ToKsKpKm.py
@@ -30,7 +30,7 @@ def test_script():
 
     # print intermediate state particle names
     for g in solutions:
-        print(g.edge_props[1]["@Name"])
+        print(g.edge_props[1]["Name"])
 
     xml_generator = HelicityAmplitudeGeneratorXML()
     xml_generator.generate(solutions)

--- a/tests/channels/test_JPsiToGammaPi0Pi0Decay.py
+++ b/tests/channels/test_JPsiToGammaPi0Pi0Decay.py
@@ -61,7 +61,7 @@ def test_script():
     intermediate_states = set()
     for g in solutions:
         int_edge_id = get_intermediate_state_edges(g)[0]
-        intermediate_states.add(g.edge_props[int_edge_id]["@Name"])
+        intermediate_states.add(g.edge_props[int_edge_id]["Name"])
     print(intermediate_states)
 
     xml_generator = HelicityAmplitudeGeneratorXML()

--- a/tests/particle/test_read_write.py
+++ b/tests/particle/test_read_write.py
@@ -1,0 +1,27 @@
+from expertsystem.state import particle
+from expertsystem.state.particle import particle_list
+from expertsystem.ui.system_control import load_default_particle_list
+
+
+def test_import_xml() -> None:
+    load_default_particle_list()
+    assert len(particle_list) == 70
+    assert "sigma+" in particle_list.keys()
+    assert "mu+" in particle_list.keys()
+
+    some_particle = particle_list["gamma"]
+    quantum_numbers = some_particle[particle.LABELS.QuantumNumber.name]
+    quantum_number = quantum_numbers[0]
+    assert (
+        quantum_number[particle.LABELS.Class.name]
+        == particle.StateQuantumNumberNames.Spin.name
+    )
+    assert int(quantum_number[particle.LABELS.Value.name]) == 1
+
+
+def test_xml_io() -> None:
+    load_default_particle_list()
+    particle.write_particle_list_to_xml("test_particle_list.xml")
+    particle_list.clear()
+    particle.load_particle_list_from_xml("test_particle_list.xml")
+    assert len(particle_list) == 70

--- a/tests/ui/test_systemcontrol.py
+++ b/tests/ui/test_systemcontrol.py
@@ -16,11 +16,10 @@ from expertsystem.topology.graph import (
     get_final_state_edges,
     get_initial_state_edges,
 )
+from expertsystem.state import particle
 from expertsystem.state.particle import (
     create_spin_domain,
     InteractionQuantumNumberNames,
-    get_xml_label,
-    XMLLabelConstants,
 )
 
 
@@ -110,16 +109,16 @@ def make_ls_test_graph(angular_momentum_magnitude, coupled_spin_magnitude):
     graph.node_props[0] = {
         "QuantumNumber": [
             {
-                "@Value": str(coupled_spin_magnitude),
-                "@Type": "S",
-                "@Projection": "0.0",
-                "@Class": "Spin",
+                "Value": str(coupled_spin_magnitude),
+                "Type": "S",
+                "Projection": "0.0",
+                "Class": "Spin",
             },
             {
-                "@Value": str(angular_momentum_magnitude),
-                "@Type": "L",
-                "@Projection": "0.0",
-                "@Class": "Spin",
+                "Value": str(angular_momentum_magnitude),
+                "Type": "L",
+                "Projection": "0.0",
+                "Class": "Spin",
             },
         ]
     }
@@ -137,16 +136,16 @@ def make_ls_test_graph_scrambled(
     graph.node_props[0] = {
         "QuantumNumber": [
             {
-                "@Class": "Spin",
-                "@Value": str(angular_momentum_magnitude),
-                "@Type": "L",
-                "@Projection": "0.0",
+                "Class": "Spin",
+                "Value": str(angular_momentum_magnitude),
+                "Type": "L",
+                "Projection": "0.0",
             },
             {
-                "@Projection": "0.0",
-                "@Class": "Spin",
-                "@Value": str(coupled_spin_magnitude),
-                "@Type": "S",
+                "Projection": "0.0",
+                "Class": "Spin",
+                "Value": str(coupled_spin_magnitude),
+                "Type": "S",
             },
         ]
     }
@@ -228,8 +227,8 @@ class TestSolutionFilter(object):
         self, input_values, filter_parameters, result
     ):
         graphs = []
-        name_label = get_xml_label(XMLLabelConstants.Name)
-        value_label = get_xml_label(XMLLabelConstants.Value)
+        name_label = particle.LABELS.Name.name
+        value_label = particle.LABELS.Value.name
         for x in input_values:
             tempgraph = make_ls_test_graph(x[1][0], x[1][1])
             tempgraph.add_edges([0])

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,7 @@ commands =
     flake8
 
 [flake8]
+application-import-names = expertsystem
 filename =
     ./expertsystem/*.py
     ./tests/*.py
@@ -25,12 +26,20 @@ exclude =
 ignore = # more info: https://www.flake8rules.com/
     D102 # method docstring
     D103 # function docstring
+    D105 # docstring in magic method
     D107 # init docstring
+    D400 # method docstring
     E203 # https://github.com/psf/black#slices
     E501 # https://github.com/psf/black#line-length
     RST301 # unexpected indentation (related to google style docstring)
     W503 # https://github.com/psf/black#line-breaks--binary-operators
-application-import-names = expertsystem
+per-file-ignores =
+    tests/*:
+        D100,
+        D101,
+        D205,
+        D208,
+        D210,
 rst-roles =
     class,
     func,
@@ -66,3 +75,4 @@ ignore =
     D107, # init docstring
     D203, # one line before class docstring
     D212, # conflicts with D213
+match = (?!test).*\.py


### PR DESCRIPTION
This PR removes XML attributes in both `particle_list.xml` and in the internal handling.

This is a step towards working with YAML, a follow-up PR will introduce that (see temporary diff [here](https://github.com/redeboer/expertsystem/compare/remove-xml-attributes...redeboer:add-yaml-support)).

Closes #25, closes #26, and closes #31 