### PR TITLE
feat: add yaml support for particle list

### DIFF
--- a/expertsystem/state/particle.py
+++ b/expertsystem/state/particle.py
@@ -3,15 +3,18 @@ This module defines a particle as a collection of quantum numbers and
 things related to this
 """
 import logging
+from abc import ABC, abstractmethod
+from collections import OrderedDict
 from copy import deepcopy
 from enum import Enum
-from abc import ABC, abstractmethod
-from numpy import arange
 from itertools import permutations
 from json import loads, dumps
-from collections import OrderedDict
+
+from numpy import arange
 
 import xmltodict
+
+import yaml
 
 from ..topology.graph import (
     get_initial_state_edges,
@@ -291,9 +294,7 @@ def load_particle_list_from_xml(file_path: str) -> None:
             particle_list[particle_name] = to_dict(particle_definition)
 
 
-def write_particle_list_to_xml(
-    file_path: str = "new_particle_list.xml",
-) -> None:
+def write_particle_list_to_xml(file_path: str) -> None:
     """Write ``particle_list`` instance to XML file."""
     entries = list(particle_list.values())
     particle_dict = {"ParticleList": {"Particle": entries}}
@@ -301,6 +302,32 @@ def write_particle_list_to_xml(
         output_file.write(
             xmltodict.unparse(particle_dict, full_document=False, pretty=True)
         )
+
+
+def load_particle_list_from_yaml(file_path: str) -> None:
+    """
+    Use `.load_particle_list_from_yaml` to append to the ``particle_list`` from
+    a YAML file.
+
+    .. note::
+        If a particle name in the YAML file already exists in the
+        ``particle_list`` instance, the one in ``particle_list`` will be
+        overwritten.
+    """
+    name_label = LABELS.Name.name
+    with open(file_path, "rb") as input_file:
+        full_dict = yaml.load(input_file, Loader=yaml.FullLoader)
+        for particle_definition in full_dict["ParticleList"]:
+            particle_name = particle_definition[name_label]
+            particle_list[particle_name] = particle_definition
+
+
+def write_particle_list_to_yaml(file_path: str) -> None:
+    """Write ``particle_list`` instance to a YAML file."""
+    entries = list(particle_list.values())
+    particle_dict = {"ParticleList": entries}
+    with open(file_path, "w") as output_file:
+        yaml.dump(particle_dict, output_file)
 
 
 def add_to_particle_list(particle):

--- a/expertsystem/state/particle.py
+++ b/expertsystem/state/particle.py
@@ -40,6 +40,11 @@ LABELS = Enum(
 )
 
 
+def to_dict(input_ordered_dict: OrderedDict) -> dict:
+    """Convert nested `OrderedDict` to a nested `dict`."""
+    return loads(dumps(input_ordered_dict))
+
+
 class Spin:
     """
     Simple struct-like class defining spin as a magnitude plus the projection
@@ -283,7 +288,7 @@ def load_particle_list_from_xml(file_path: str) -> None:
         full_dict = xmltodict.parse(xmlfile)
         for particle_definition in full_dict["ParticleList"]["Particle"]:
             particle_name = particle_definition[name_label]
-            particle_list[particle_name] = particle_definition
+            particle_list[particle_name] = to_dict(particle_definition)
 
 
 def write_particle_list_to_xml(

--- a/expertsystem/state/particle.py
+++ b/expertsystem/state/particle.py
@@ -43,11 +43,6 @@ LABELS = Enum(
 )
 
 
-def to_dict(input_ordered_dict: OrderedDict) -> dict:
-    """Convert nested `OrderedDict` to a nested `dict`."""
-    return loads(dumps(input_ordered_dict))
-
-
 class Spin:
     """
     Simple struct-like class defining spin as a magnitude plus the projection
@@ -278,6 +273,8 @@ particle_list = dict()
 
 def load_particle_list_from_xml(file_path: str) -> None:
     """
+    Add entries to the ``particle_list`` from definitions in an XML file.
+
     By default, the expert system loads the ``particle_list``
     from the XML file ``particle_list.xml`` located in the ComPWA module.
     Use `.load_particle_list_from_xml` to append to the ``particle_list``.
@@ -286,6 +283,11 @@ def load_particle_list_from_xml(file_path: str) -> None:
         If a particle name in the loaded XML file already exists in the
         ``particle_list``, the one in the ``particle_list`` will be overwritten.
     """
+
+    def to_dict(input_ordered_dict: OrderedDict) -> dict:
+        """Convert nested `OrderedDict` to a nested `dict`."""
+        return loads(dumps(input_ordered_dict))
+
     name_label = LABELS.Name.name
     with open(file_path, "rb") as xmlfile:
         full_dict = xmltodict.parse(xmlfile)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 numpy
 progress
+pyyaml>=5
 xmltodict

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,1 +1,3 @@
 *.xml
+*.yaml
+*.yml

--- a/tests/particle/test_read_write.py
+++ b/tests/particle/test_read_write.py
@@ -1,3 +1,5 @@
+from copy import deepcopy
+
 from expertsystem.state import particle
 from expertsystem.state.particle import particle_list
 from expertsystem.ui.system_control import load_default_particle_list
@@ -25,3 +27,16 @@ def test_xml_io() -> None:
     particle_list.clear()
     particle.load_particle_list_from_xml("test_particle_list.xml")
     assert len(particle_list) == 70
+
+
+def test_yaml_io() -> None:
+    load_default_particle_list()
+    particles_xml = deepcopy(particle_list)
+    particle.write_particle_list_to_yaml("test_particle_list.yml")
+
+    particle_list.clear()
+    particle.load_particle_list_from_yaml("test_particle_list.yml")
+
+    assert particle_list == particles_xml
+    particle_list["gamma"]["Pid"] = "23"
+    assert particle_list != particles_xml


### PR DESCRIPTION
The `particle_list` now contains `dict`s instead of `OrderedDict`, so that it can be processed by `pyyaml`. The structure of `particle_list` is still the same though and does not yet reflect the [structure of `particle_list.yml`](https://github.com/ComPWA/expertsystem/blob/74e9bf34825155c7b044375f05e140e196b0e036/particle_list.yml).