### PR TITLE
build: bump version to 0.1.1-alpha

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ def long_description():
 
 setuptools.setup(
     name="expertsystem",
-    version="0.1-alpha",
+    version="0.1.1-alpha",
     author="The ComPWA team",
     maintainer_email="compwa-admin@ep1.rub.de",
     url="https://github.com/ComPWA/expertsystem",


### PR DESCRIPTION
Made a mistake with the version in #59... I thought to have [0.1.1](https://github.com/ComPWA/expertsystem/milestone/7) implement YAML for the helicity formalism (so it can be used in tensorwaves), while [0.1.2](https://github.com/ComPWA/expertsystem/milestone/8) implements the canonical formalism.