### PR TITLE
ci: remove GitHub PR templates

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/adr_pull_request.md
+++ b/.github/PULL_REQUEST_TEMPLATE/adr_pull_request.md
@@ -1,1 +1,0 @@
-Initiated from issue #<issue number>

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,6 +1,0 @@
-Closes #<issue number>
-
-Summary of changes:
-
-- [ ]
-- [ ]


### PR DESCRIPTION
Turns out that the PR templates introduced in #52 aren't too great (the issue templates are still useful). This problem is particularly problematic when working with the [vscode GitHub PR extension](https://code.visualstudio.com/docs/editor/github): without a PR template (as is the case in tensorwaves), vscode nicely extracts most info for the PR from the incoming commits, but this info is overruled by the PR template.