### PR TITLE
ci: add cspell support

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,3 +14,8 @@ indent_size = 2
 
 [*.{rst,inc}]
 indent_size = 2
+
+# when adding words through vscode, this is the resulting output format
+[cspell.json]
+indent_size = 4
+insert_final_newline = false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,9 @@
 repos:
+  - repo: meta
+    hooks:
+      - id: check-hooks-apply
+      - id: check-useless-excludes
+
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.1.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,6 +13,7 @@ repos:
       - id: check-yaml
       - id: debug-statements
       - id: end-of-file-fixer
+        exclude: cspell.json
       - id: mixed-line-ending
       - id: name-tests-test
         args: ["--django"]

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+cspell.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,6 @@ jobs:
   include:
     - name: "Build and test documentation"
       python: 3.7
-      before_install:
-        - npm install -g cspell
       before_script:
         - sudo apt-get -y install pandoc
         - pip3 install -r doc/requirements.txt
@@ -35,9 +33,12 @@ jobs:
 
     - name: "Style checks"
       python: 3.6
+      before_script:
+        - npm install -g cspell
       script:
         - pip3 install -r requirements-dev.txt
         - tox -e style
+        - cspell $(git diff master --name-only)
 
     - name: "Python 3.6 on Ubuntu 18.04"
       python: 3.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,8 @@ jobs:
   include:
     - name: "Build and test documentation"
       python: 3.7
+      before_install:
+        - npm install -g cspell
       before_script:
         - sudo apt-get -y install pandoc
         - pip3 install -r doc/requirements.txt

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,7 +8,8 @@
   "[yaml]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
-  "cSpell.language": "en-US",
+  "cSpell.customFolderDictionaries": ["cspell.json"],
+  "cSpell.enabled": true,
   "coverage-gutters.coverageFileNames": ["coverage.xml"],
   "coverage-gutters.coverageReportFileName": "**/htmlcov/index.html",
   "editor.rulers": [80],

--- a/cspell.json
+++ b/cspell.json
@@ -13,5 +13,33 @@
     "ignorePaths": [
         "cspell.json"
     ],
-    "language": "en-US"
+    "language": "en-US",
+    "words": [
+        "docstrings",
+        "expertsystem",
+        "jupyter",
+        "mypy",
+        "numpy",
+        "permalinks",
+        "pydocstyle",
+        "pylint",
+        "pytest",
+        "repos",
+        "rstcheck",
+        "xmltodict"
+    ],
+    "ignoreWords": [
+        "commit's",
+        "envlist",
+        "esbenp",
+        "htmlcov",
+        "ipynb",
+        "nbsphinx",
+        "nbstripout",
+        "oneline",
+        "pylintrc",
+        "pyproject",
+        "rcfile",
+        "rtfd"
+    ]
 }

--- a/cspell.json
+++ b/cspell.json
@@ -1,0 +1,17 @@
+{
+    "version": "0.1",
+    "enableFiletypes": [
+        "git-rebase",
+        "ini",
+        "pip-requirements"
+    ],
+    "flagWords": [
+        "colour",
+        "hte",
+        "optimise"
+    ],
+    "ignorePaths": [
+        "cspell.json"
+    ],
+    "language": "en-US"
+}

--- a/cspell.json
+++ b/cspell.json
@@ -23,23 +23,29 @@
         "permalinks",
         "pydocstyle",
         "pylint",
+        "pypi",
         "pytest",
         "repos",
         "rstcheck",
+        "xcode",
         "xmltodict"
     ],
     "ignoreWords": [
+        "codecov",
         "commit's",
         "envlist",
         "esbenp",
         "htmlcov",
         "ipynb",
+        "linkcheck",
         "nbsphinx",
         "nbstripout",
         "oneline",
+        "pandoc",
         "pylintrc",
         "pyproject",
         "rcfile",
-        "rtfd"
+        "rtfd",
+        "sdist"
     ]
 }

--- a/doc/contribute.rst
+++ b/doc/contribute.rst
@@ -60,6 +60,33 @@ The different :code:`tox` tests are defined in the `tox.ini
 :code:`envlist`.
 
 
+Spelling
+--------
+
+Throughout this repository, we follow American English (`en-us
+<https://www.andiamo.co.uk/resources/iso-language-codes/>`_) spelling
+conventions. As a tool, we use `cSpell
+<https://github.com/streetsidesoftware/cspell/blob/master/packages/cspell/README.md>`_
+because it allows to check variable names in camel case and snake case.
+Accepted words are tracked through the :file:`cspell.json` file (they formulate
+our conventions), where the the :code:`words` lists words that you want to see
+as suggested corrections, while :code:`ignoreWords` are just the words that
+won't be flagged. This way, a spelling checker helps you in avoid mistakes in
+the code as well!
+
+It is easiest to use cSpell in :ref:`contribute:Visual Studio Code`, through
+the `Code Spell Checker
+<https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker>`_
+extension: it provides linting, suggests corrections from the :code:`words`
+section, and enables you to quickly add or ignore words through the
+:file:`cspell.json` file.
+
+Alternatively, you can `run cSpell
+<https://www.npmjs.com/package/cspell#installation>`__ on the entire code base
+(with :code:`cspell *`), but for that your system requires `npm
+<https://www.npmjs.com/>`_.
+
+
 Test coverage
 -------------
 

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ INSTALL_REQUIRES = [
 ]
 
 
-def long_description():
+def long_description() -> str:
     """Parse long description from readme."""
     with open("README.md", "r") as readme_file:
         return readme_file.read()


### PR DESCRIPTION
Note that:
1. `cspell` has not been added as a pre-commit hook, because it requires the system to have `npm`
2. `cspell` is not enforced through Travis