### PR TITLE
ci: improve tox usage with more specific jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ jobs:
         - npm install -g cspell
       script:
         - pip3 install -r requirements-dev.txt
-        - tox -e style
+        - tox -e sty
         - cspell $(git diff d4f1928 --name-only)
 
     - name: "Python 3.6 on Ubuntu 18.04"

--- a/doc/contribute.rst
+++ b/doc/contribute.rst
@@ -1,4 +1,4 @@
-.. cSpell:ignore envlist, htmlcov, pylintrc
+.. cSpell:ignore docnb, htmlcov, pylintrc, testenv
 
 How to contribute?
 ==================
@@ -52,14 +52,13 @@ command
   tox
 
 This command will run :code:`pytest`, check for :ref:`test coverage
-<contribute:Test coverage>`, verify the hyperlinks in documentation (requires
-internet connection), and run the Jupyter notebooks. All this can take a few
-minutes, but it's definitely worth it to *run tox before submitting a pull
-request!*
+<contribute:Test coverage>`, verify build the documentation, and verify
+references to and in the API. It's especially recommended to *run tox before
+submitting a pull request!*
 
-The different :code:`tox` tests are defined in the `tox.ini
-<https://github.com/ComPWA/expertsystem/blob/master/tox.ini>`__ file under
-:code:`envlist`.
+More specialized :code:`tox` tests are defined in the `tox.ini
+<https://github.com/ComPWA/expertsystem/blob/master/tox.ini>`__ file, under
+each :code:`testenv`.
 
 
 Spelling
@@ -132,26 +131,25 @@ the command:
 
   tox -e doc
 
+If you want to render the output of the `Jupyter notebook examples
+<https://github.com/ComPWA/expertsystem/tree/master/examples>`_, this can be
+done with:
+
+.. code-block:: shell
+
+  tox -e docnb
+
 Alternatively, you can run :code:`sphinx-build` yourself. The requirements for
 that are in the `doc/requirements.txt
 <https://github.com/ComPWA/expertsystem/blob/master/doc/requirements.txt>`_
-file:
+file (use :code:`NBSPHINX_EXECUTE= make html` if you want to run render the
+notebook output):
 
 .. code-block:: shell
 
   cd doc
   pip install -r requirements.txt
-  make html
-
-If you want to render the output of the `Jupyter notebook examples
-<https://github.com/ComPWA/expertsystem/tree/master/examples>`_, set the
-:code:`NBSPHINX_EXECUTE` environment variable first:
-
-.. code-block:: shell
-
-  NBSPHINX_EXECUTE= make html
-
-Note that the notebooks are also run if you run :code:`tox`.
+  make html  # or NBSPHINX_EXECUTE= make html
 
 A nice feature of `Read the Docs <https://readthedocs.org/>`_, where we host
 our documentation, is that documentation is built for each pull request as

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ skipsdist = True
 envlist =
     py,
     doc,
-    style,
+    sty,
 
 [testenv]
 whitelist_externals =
@@ -46,7 +46,7 @@ whitelist_externals =
 commands =
     make linkcheck
 
-[testenv:style]
+[testenv:sty]
 setenv =
     SKIP = check-xml
 whitelist_externals =

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ skip_missing_interpreters=true
 skipsdist = True
 envlist =
     py,
-    linkcheck,
+    doc,
     style,
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -30,9 +30,16 @@ whitelist_externals =
 commands =
     make html
 
-[testenv:linkcheck]
+[testenv:docnb]
 setenv =
     NBSPHINX_EXECUTE = "yes"
+changedir = doc
+whitelist_externals =
+    make
+commands =
+    make html
+
+[testenv:linkcheck]
 changedir = doc
 whitelist_externals =
     make

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ envlist =
 whitelist_externals =
     pytest
 commands =
-    pytest \
+    pytest {posargs} \
         --cov-fail-under=70 \
         --cov-report=html \
         --cov-report=xml \
@@ -45,14 +45,14 @@ setenv =
 whitelist_externals =
     pre-commit
 commands =
-    pre-commit run -a
+    pre-commit run {posargs} -a
 
 ; Job that runs the fast tests only
 [testenv:test]
 whitelist_externals =
     pytest
 commands =
-    pytest -m "not slow"
+    pytest -m "not slow" {posargs}
 
 [coverage:run]
 omit = */expertsystem/solvers/constraint/*

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ envlist =
 whitelist_externals =
     pytest
 commands =
-    pytest {posargs} \
+    pytest tests {posargs} \
         --cov-fail-under=70 \
         --cov-report=html \
         --cov-report=xml \
@@ -52,7 +52,7 @@ commands =
 whitelist_externals =
     pytest
 commands =
-    pytest -m "not slow" {posargs}
+    pytest tests -m "not slow" {posargs}
 
 [coverage:run]
 omit = */expertsystem/solvers/constraint/*


### PR DESCRIPTION
* Speed up main `tox` job by avoiding check on external links (`linkcheck`) and not executing Jupyter notebooks
* Define `docnb` job for executing notebooks (and building them into the docs)
* Simplify command `tox -e sty` (previously `tox -e style`)

_Follow-up to #96_
_Part of the PR series mentioned in https://github.com/ComPWA/expertsystem/issues/22#issuecomment-654052278_