### PR TITLE
refactor: capitalize globals

### DIFF
--- a/expertsystem/state/particle.py
+++ b/expertsystem/state/particle.py
@@ -283,19 +283,20 @@ def is_boson(qn_dict):
     return abs(qn_dict[spin_label].magnitude() % 1) < 0.01
 
 
-particle_list = dict()
+DATABASE = dict()
 
 
 def load_particle_list_from_xml(file_path: str) -> None:
-    """Add entries to the ``particle_list`` from definitions in an XML file.
+    """Add entries to the particle database from definitions in an XML file.
 
-    By default, the expert system loads the ``particle_list``
-    from the XML file ``particle_list.xml`` located in the ComPWA module.
-    Use `.load_particle_list_from_xml` to append to the ``particle_list``.
+    By default, the expert system loads the particle database from the XML file
+    :file:`particle_list.xml` located in the ComPWA module. Use
+    `.load_particle_list_from_xml` to append to the particle database.
 
     .. note::
         If a particle name in the loaded XML file already exists in the
-        ``particle_list``, the one in the ``particle_list`` will be overwritten.
+        particle database, the one in the particle database will be
+        overwritten.
     """
 
     def to_dict(input_ordered_dict: OrderedDict) -> dict:
@@ -308,12 +309,12 @@ def load_particle_list_from_xml(file_path: str) -> None:
         full_dict = full_dict.get("root", full_dict)
     for particle_definition in full_dict["ParticleList"]["Particle"]:
         particle_name = particle_definition[name_label]
-        particle_list[particle_name] = to_dict(particle_definition)
+        DATABASE[particle_name] = to_dict(particle_definition)
 
 
 def write_particle_list_to_xml(file_path: str) -> None:
-    """Write ``particle_list`` instance to XML file."""
-    entries = list(particle_list.values())
+    """Write particle database instance to XML file."""
+    entries = list(DATABASE.values())
     particle_dict = {"ParticleList": {"Particle": entries}}
     xmlstring = xmltodict.unparse(
         {"root": particle_dict}, pretty=True, indent="  "
@@ -323,11 +324,11 @@ def write_particle_list_to_xml(file_path: str) -> None:
 
 
 def load_particle_list_from_yaml(file_path: str) -> None:
-    """Use `.load_particle_list_from_yaml` to append to the ``particle_list``.
+    """Use `.load_particle_list_from_yaml` to append to the particle database.
 
     .. note::
         If a particle name in the YAML file already exists in the
-        ``particle_list`` instance, the one in ``particle_list`` will be
+        particle database instance, the one in particle database will be
         overwritten.
     """
     name_label = Labels.Name.name
@@ -335,48 +336,48 @@ def load_particle_list_from_yaml(file_path: str) -> None:
         full_dict = yaml.load(input_file, Loader=yaml.FullLoader)
         for particle_definition in full_dict["ParticleList"]:
             particle_name = particle_definition[name_label]
-            particle_list[particle_name] = particle_definition
+            DATABASE[particle_name] = particle_definition
 
 
 def write_particle_list_to_yaml(file_path: str) -> None:
-    """Write ``particle_list`` instance to a YAML file."""
-    entries = list(particle_list.values())
+    """Write particle database instance to a YAML file."""
+    entries = list(DATABASE.values())
     particle_dict = {"ParticleList": entries}
     with open(file_path, "w") as output_file:
         yaml.dump(particle_dict, output_file)
 
 
 def add_to_particle_list(particle):
-    """Add a particle dictionary object to the ``particle_list`` dictionary.
+    """Add a particle dictionary object to the particle database dictionary.
 
     The key will be extracted from the ``particle`` name (XML tag ``@Name``).
-    If the key already exists, the entry in ``particle_list`` will be
+    If the key already exists, the entry in particle database will be
     overwritten by this one.
     """
     if not isinstance(particle, dict):
-        logging.warning("Can only add dictionary entries to particle_list")
+        logging.warning("Can only add dictionary entries to particle database")
         return
     particle_name = particle[Labels.Name.name]
-    particle_list[particle_name] = particle
+    DATABASE[particle_name] = particle
 
 
 def get_particle_with_name(particle_name):
     """Get particle from the particle database by name.
 
     .. deprecated:: 0.2.0
-        ``particle_list`` has become a dictionary, so you can already access
+        particle database has become a dictionary, so you can already access
         its entries with a string index.
     """
-    return particle_list[particle_name]
+    return DATABASE[particle_name]
 
 
 def get_particle_copy_by_name(particle_name):
-    """Get a `~copy.deepcopy` of a particle from the ``particle_list``.
+    """Get a `~copy.deepcopy` of a particle from the particle database.
 
     This is useful when you want to manipulate that copy and add it as a new
     entry to the particle data base.
     """
-    return deepcopy(particle_list[particle_name])
+    return deepcopy(DATABASE[particle_name])
 
 
 def get_particle_property(particle_properties, qn_name, converter=None):
@@ -781,11 +782,11 @@ def initialize_graphs_with_particles(graphs, allowed_particle_list=None):
 def initialize_allowed_particle_list(allowed_particle_list):
     mod_allowed_particle_list = []
     if len(allowed_particle_list) == 0:
-        mod_allowed_particle_list = list(particle_list.values())
+        mod_allowed_particle_list = list(DATABASE.values())
     else:
         for allowed_particle in allowed_particle_list:
             if isinstance(allowed_particle, str):
-                for name, value in particle_list.items():
+                for name, value in DATABASE.items():
                     if allowed_particle in name:
                         mod_allowed_particle_list.append(value)
             else:

--- a/expertsystem/ui/default_settings.py
+++ b/expertsystem/ui/default_settings.py
@@ -2,6 +2,11 @@
 
 import sys
 from copy import deepcopy
+from typing import (
+    Any,
+    Dict,
+    List,
+)
 
 from expertsystem.state.conservation_rules import (
     AdditiveQuantumNumberConservation,
@@ -57,8 +62,8 @@ CONSERVATION_LAW_PRIORITIES = {
 
 
 def create_default_interaction_settings(
-    formalism_type, use_mass_conservation=True
-):
+    formalism_type: str, use_mass_conservation: bool = True
+) -> Dict[InteractionTypes, InteractionNodeSettings]:
     """Create a container that holds the settings for the various interactions.
 
     E.g.: strong, em and weak interaction.
@@ -176,7 +181,9 @@ def create_default_interaction_settings(
     return interaction_type_settings
 
 
-def reorder_list_by_priority(some_list, priority_mapping):
+def reorder_list_by_priority(
+    some_list: List[Any], priority_mapping: Dict[str, Any]
+) -> List[Any]:
     # first add priorities to the entries
     priority_list = [
         (x, priority_mapping[str(x)]) if str(x) in priority_mapping else (x, 1)

--- a/expertsystem/ui/default_settings.py
+++ b/expertsystem/ui/default_settings.py
@@ -27,15 +27,15 @@ from expertsystem.state.propagation import (
 )
 
 
-default_particle_list_search_paths = [
+SYSTEM_SEARCH_PATHS = [
     ".",
     "..",
 ]
-default_particle_list_search_paths += sys.path
+SYSTEM_SEARCH_PATHS += sys.path
 
 # If a conservation law is not listed here, a default priority of 1 is assumed.
 # Higher number means higher priority
-default_conservation_law_priorities = {
+CONSERVATION_LAW_PRIORITIES = {
     "SpinConservation": 8,
     "HelicityConservation": 7,
     "MassConservation": 10,
@@ -164,13 +164,13 @@ def create_default_interaction_settings(
 
     # reorder conservation laws according to priority
     weak_settings.conservation_laws = reorder_list_by_priority(
-        weak_settings.conservation_laws, default_conservation_law_priorities
+        weak_settings.conservation_laws, CONSERVATION_LAW_PRIORITIES
     )
     em_settings.conservation_laws = reorder_list_by_priority(
-        em_settings.conservation_laws, default_conservation_law_priorities
+        em_settings.conservation_laws, CONSERVATION_LAW_PRIORITIES
     )
     strong_settings.conservation_laws = reorder_list_by_priority(
-        strong_settings.conservation_laws, default_conservation_law_priorities
+        strong_settings.conservation_laws, CONSERVATION_LAW_PRIORITIES
     )
 
     return interaction_type_settings

--- a/expertsystem/ui/system_control.py
+++ b/expertsystem/ui/system_control.py
@@ -26,7 +26,6 @@ from expertsystem.state.particle import (
     get_interaction_property,
     get_particle_property,
     initialize_graph,
-    particle_list,
 )
 from expertsystem.state.propagation import (
     FullPropagator,
@@ -822,7 +821,7 @@ def load_default_particle_list(
     method: Callable = particle.load_particle_list_from_xml,
 ) -> None:
     """Load the default particle list that comes with the expertsystem."""
-    if len(particle_list) == 0:
+    if len(particle.DATABASE) == 0:
         for search_path in default_particle_list_search_paths:
             if search_path.startswith("/"):  # absolute path
                 file_path = search_path
@@ -834,10 +833,11 @@ def load_default_particle_list(
             if path.exists(file_path):
                 method(file_path)
                 logging.info(
-                    "loaded %d particles from xml file!", len(particle_list)
+                    "loaded %d particles from xml file!",
+                    len(particle.DATABASE),
                 )
                 break
-    if len(particle_list) == 0:
+    if len(particle.DATABASE) == 0:
         raise FileNotFoundError(
             "\n  Failed to load particle_list.xml from search paths!"
             "\n  Please contact the developers: https://github.com/ComPWA"

--- a/expertsystem/ui/system_control.py
+++ b/expertsystem/ui/system_control.py
@@ -45,8 +45,8 @@ from expertsystem.topology.topology_builder import (
 )
 
 from .default_settings import (
+    SYSTEM_SEARCH_PATHS,
     create_default_interaction_settings,
-    default_particle_list_search_paths,
 )
 
 
@@ -822,7 +822,7 @@ def load_default_particle_list(
 ) -> None:
     """Load the default particle list that comes with the expertsystem."""
     if len(particle.DATABASE) == 0:
-        for search_path in default_particle_list_search_paths:
+        for search_path in SYSTEM_SEARCH_PATHS:
             if search_path.startswith("/"):  # absolute path
                 file_path = search_path
             else:  # relative path

--- a/tests/particle/test_read_write.py
+++ b/tests/particle/test_read_write.py
@@ -1,17 +1,16 @@
 from copy import deepcopy
 
 from expertsystem.state import particle
-from expertsystem.state.particle import particle_list
 from expertsystem.ui.system_control import load_default_particle_list
 
 
 def test_import_xml() -> None:
     load_default_particle_list()
-    assert len(particle_list) == 69
-    assert "sigma+" in particle_list.keys()
-    assert "mu+" in particle_list.keys()
+    assert len(particle.DATABASE) == 69
+    assert "sigma+" in particle.DATABASE.keys()
+    assert "mu+" in particle.DATABASE.keys()
 
-    some_particle = particle_list["gamma"]
+    some_particle = particle.DATABASE["gamma"]
     quantum_numbers = some_particle[particle.Labels.QuantumNumber.name]
     quantum_number = quantum_numbers[0]
     assert (
@@ -24,19 +23,19 @@ def test_import_xml() -> None:
 def test_xml_io() -> None:
     load_default_particle_list()
     particle.write_particle_list_to_xml("test_particle_list.xml")
-    particle_list.clear()
+    particle.DATABASE.clear()
     particle.load_particle_list_from_xml("test_particle_list.xml")
-    assert len(particle_list) == 69
+    assert len(particle.DATABASE) == 69
 
 
 def test_yaml_io() -> None:
     load_default_particle_list()
-    particles_xml = deepcopy(particle_list)
+    particles_xml = deepcopy(particle.DATABASE)
     particle.write_particle_list_to_yaml("test_particle_list.yml")
 
-    particle_list.clear()
+    particle.DATABASE.clear()
     particle.load_particle_list_from_yaml("test_particle_list.yml")
 
-    assert particle_list == particles_xml
-    particle_list["gamma"]["Pid"] = "23"
-    assert particle_list != particles_xml
+    assert particle.DATABASE == particles_xml
+    particle.DATABASE["gamma"]["Pid"] = "23"
+    assert particle.DATABASE != particles_xml

--- a/tox.ini
+++ b/tox.ini
@@ -117,6 +117,8 @@ disallow_untyped_defs = False
 ; Slowly introduce type hints (#43)
 [mypy-expertsystem.*]
 ignore_errors = True
+[mypy-expertsystem.ui.default_settings.*]
+ignore_errors = False
 
 [pydocstyle]
 convention=google

--- a/tox.ini
+++ b/tox.ini
@@ -82,6 +82,7 @@ ignore = # more info: https://www.flake8rules.com/
 rst-roles =
     attr,
     class,
+    file,
     func,
     meth,
     mod,


### PR DESCRIPTION
While removing the `default_particle_list_search_paths` (this can be done since #102), I figured I'd address the smaller style issues below in a smaller PR first.

* Add typing hints to `default_settings` module
* Rename `particle_list` to `DATABASE` (this global should eventually be replaced by some sort of `ParticleCollection` singleton, but that first requires #42)
* Capitalize globals of `default_settings`