### PR TITLE
ci: speed up tox further

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,7 @@ whitelist_externals =
     pytest
 commands =
     pytest tests {posargs} \
+        -m "not slow" \
         --cov-fail-under=70 \
         --cov-report=html \
         --cov-report=xml \
@@ -52,12 +53,16 @@ whitelist_externals =
 commands =
     pre-commit run {posargs} -a
 
-; Job that runs the fast tests only
+; Job that runs all tests, also the slow ones
 [testenv:test]
 whitelist_externals =
     pytest
 commands =
-    pytest tests -m "not slow" {posargs}
+    pytest tests {posargs} \
+        --cov-fail-under=70 \
+        --cov-report=html \
+        --cov-report=xml \
+        --cov=expertsystem
 
 [coverage:run]
 omit = */expertsystem/solvers/constraint/*


### PR DESCRIPTION
Locally, tests marked `slow` are not run anymore by `tox`. This was annoying because you just want to run `tox` whenever you make a PR and don't want to wait for that several minutes.

If you want to run all tests, use `tox -e test`.

Note that not running the slow tests hardly affects the benchmarks, but greatly increases speed:

| command                | duration | coverage |
|------------------------|----------|----------|
| `pytest`               | 133s     | 74.82%   |
| `pytest -m "not slow"` |  17s     | 74.51%   |