### PR TITLE
refactor!: ParticleCollection -> particle.DATABASE

### DIFF
--- a/expertsystem/amplitude/_yaml_adapter.py
+++ b/expertsystem/amplitude/_yaml_adapter.py
@@ -66,7 +66,7 @@ def to_dynamics(recipe: Dict[str, Any]) -> Dict[str, Any]:
     for particle_xml in particle_list_xml:
         name = particle_xml["Name"]
         decay_info_xml = particle_xml.get("DecayInfo", None)
-        if decay_info_xml:
+        if decay_info_xml and "Type" in decay_info_xml:
             decay_type = determine_type(decay_info_xml)
             form_factor = determine_form_factor(
                 decay_info_xml, particle_xml, decay_type

--- a/expertsystem/amplitude/helicity_decay.py
+++ b/expertsystem/amplitude/helicity_decay.py
@@ -18,7 +18,6 @@ from expertsystem.state.particle import (
     InteractionQuantumNumberNames,
     StateQuantumNumberNames,
     get_interaction_property,
-    get_particle_property,
 )
 from expertsystem.topology.graph import (
     get_edges_ingoing_to_node,
@@ -570,43 +569,10 @@ class HelicityAmplitudeGenerator(AbstractAmplitudeGenerator):
         class_label = particle.Labels.Class.name
         name_label = particle.Labels.Name.name
         component_label = particle.Labels.Component.name
-        spin_label = StateQuantumNumberNames.Spin
-        decay_info_label = particle.Labels.DecayInfo.name
-        type_label = particle.Labels.Type.name
-        partial_decays = []
-        for node_id in graph.nodes:
-            # in case a scalar without dynamics decays into daughters with no
-            # net helicity, the partial amplitude can be dropped
-            # (it is just a constant)
-            in_edges = get_edges_ingoing_to_node(graph, node_id)
-            out_edges = get_edges_outgoing_to_node(graph, node_id)
-            # check mother particle is spin 0
-            in_spin = get_particle_property(
-                graph.edge_props[in_edges[0]], spin_label
-            )
-            out_spins = [
-                get_particle_property(graph.edge_props[x], spin_label)
-                for x in out_edges
-            ]
-            if (
-                in_spin is not None
-                and None not in out_spins
-                and in_spin.magnitude() == 0
-            ):
-                if (
-                    abs(out_spins[0].projection() - out_spins[1].projection())
-                    == 0.0
-                ):
-                    # check if dynamics is non-resonant (constant)
-                    if (
-                        graph.edge_props[in_edges[0]][decay_info_label][
-                            type_label
-                        ]
-                        == "NonResonant"
-                    ):
-                        continue
-
-            partial_decays.append(self.generate_partial_decay(graph, node_id))
+        partial_decays = [
+            self.generate_partial_decay(graph, node_id)
+            for node_id in graph.nodes
+        ]
 
         gen = self.name_generator
         amp_name = gen.generate_unique_amplitude_name(graph)

--- a/expertsystem/data.py
+++ b/expertsystem/data.py
@@ -96,7 +96,7 @@ class Particle(NamedTuple):
 
     name: str
     pid: int
-    charge: float
+    charge: int
     spin: float
     mass: MeasuredValue
     strangeness: int = 0

--- a/expertsystem/io/xml/_build.py
+++ b/expertsystem/io/xml/_build.py
@@ -52,7 +52,7 @@ def build_particle(definition: dict) -> Particle:
         pid=int(definition["Pid"]),
         mass=_xml_to_measured_value(definition["Parameter"]),
         width=_xml_to_width(definition),
-        charge=float(qn_defs["Charge"]),
+        charge=int(qn_defs["Charge"]),
         spin=float(qn_defs["Spin"]),
         strangeness=int(qn_defs.get("Strangeness", 0)),
         charmness=int(qn_defs.get("Charm", 0)),
@@ -101,7 +101,7 @@ def _xml_qn_list_to_qn_object(definitions: List[dict],) -> Dict[str, Any]:
 def _xml_to_quantum_number(definition: Dict[str, str]) -> Tuple[str, Any]:
     conversion_map: Dict[str, Callable] = {
         "Spin": _xml_to_float,
-        "Charge": _xml_to_float,
+        "Charge": _xml_to_int,
         "Strangeness": _xml_to_int,
         "Charm": _xml_to_int,
         "BaryonNumber": _xml_to_int,

--- a/expertsystem/io/xml/_dump.py
+++ b/expertsystem/io/xml/_dump.py
@@ -58,8 +58,8 @@ def from_particle(particle: Particle) -> dict:
 def _from_measured_value(instance: MeasuredValue, name: str) -> dict:
     type_name = name.split("_")[0]
     output = {
-        "Name": name,
         "Type": type_name,
+        "Name": name,
         "Value": instance.value,
     }
     if instance.uncertainty is not None:
@@ -100,8 +100,11 @@ def _to_quantum_number_list(particle: Particle) -> List[Dict[str, Any]]:
 def _qn_to_dict(
     instance: Union[Parity, Spin, float, int], type_name: str
 ) -> Dict[str, Any]:
-    output: Dict[str, Any] = {"Type": type_name}
-    output["Class"] = "Int"
+    output: Dict[str, Any] = {
+        "Class": "Int",
+        "Type": type_name,
+    }
+
     if type_name == "Spin":
         output["Class"] = "Spin"
     if isinstance(instance, (float, int)):

--- a/expertsystem/io/yaml/_build.py
+++ b/expertsystem/io/yaml/_build.py
@@ -32,7 +32,7 @@ def build_particle(name: str, definition: dict) -> Particle:
         pid=int(definition["PID"]),
         mass=_yaml_to_measured_value(definition["Mass"]),
         width=_yaml_to_measured_value_optional(definition.get("Width", None)),
-        charge=float(qn_def["Charge"]),
+        charge=int(qn_def["Charge"]),
         spin=float(qn_def["Spin"]),
         strangeness=int(qn_def.get("Strangeness", 0)),
         charmness=int(qn_def.get("Charmness", 0)),

--- a/expertsystem/io/yaml/_dump.py
+++ b/expertsystem/io/yaml/_dump.py
@@ -42,7 +42,7 @@ def from_particle(particle: Particle) -> dict:
 def _to_quantum_number_dict(particle: Particle) -> dict:
     output_dict = {
         "Spin": _attempt_to_int(particle.spin),
-        "Charge": _attempt_to_int(particle.charge),
+        "Charge": int(particle.charge),
     }
     optional_qn: List[
         Tuple[str, Union[Optional[Parity], Spin, int], Union[Callable, int]]

--- a/expertsystem/particle_list.xml
+++ b/expertsystem/particle_list.xml
@@ -76,7 +76,6 @@
         <Type>Mass</Type>
         <Name>Mass_EpEm (4230 MeV)</Name>
         <Value>4.23</Value>
-        <Fix>true</Fix>
       </Parameter>
       <QuantumNumber>
         <Class>Spin</Class>
@@ -511,7 +510,6 @@
         <Name>Mass_pi+</Name>
         <Value>0.13957018</Value>
         <Error>0.00000035</Error>
-        <Fix>true</Fix>
       </Parameter>
       <QuantumNumber>
         <Class>Spin</Class>
@@ -548,7 +546,6 @@
         <Name>Mass_pi-</Name>
         <Value>0.13957018</Value>
         <Error>0.00000035</Error>
-        <Fix>true</Fix>
       </Parameter>
       <QuantumNumber>
         <Class>Spin</Class>
@@ -616,13 +613,11 @@
           <Name>Width_eta</Name>
           <Value>0.00000131</Value>
           <Error>0.00000005</Error>
-          <Fix>true</Fix>
         </Parameter>
         <Parameter>
           <Type>MesonRadius</Type>
           <Name>Radius_eta</Name>
           <Value>2.5</Value>
-          <Fix>true</Fix>
           <Min>2.0</Min>
           <Max>3.0</Max>
         </Parameter>
@@ -682,7 +677,6 @@
           <Type>MesonRadius</Type>
           <Name>Radius_rho</Name>
           <Value>2.5</Value>
-          <Fix>true</Fix>
           <Min>2.0</Min>
           <Max>3.0</Max>
         </Parameter>
@@ -737,7 +731,6 @@
           <Type>MesonRadius</Type>
           <Name>Radius_rho</Name>
           <Value>2.5</Value>
-          <Fix>true</Fix>
           <Min>2.0</Min>
           <Max>3.0</Max>
         </Parameter>
@@ -792,7 +785,6 @@
           <Type>MesonRadius</Type>
           <Name>Radius_rho</Name>
           <Value>2.5</Value>
-          <Fix>true</Fix>
           <Min>2.0</Min>
           <Max>3.0</Max>
         </Parameter>
@@ -846,7 +838,6 @@
           <Type>MesonRadius</Type>
           <Name>Radius_omega782</Name>
           <Value>2.5</Value>
-          <Fix>true</Fix>
           <Min>2.0</Min>
           <Max>3.0</Max>
         </Parameter>
@@ -860,7 +851,6 @@
         <Name>Mass_f0(980)</Name>
         <Value>0.994</Value>
         <Error>0.001</Error>
-        <Fix>true</Fix>
       </Parameter>
       <QuantumNumber>
         <Class>Spin</Class>
@@ -901,7 +891,6 @@
           <Type>MesonRadius</Type>
           <Name>Radius_f0980</Name>
           <Value>1</Value>
-          <Fix>true</Fix>
           <Min>0.0</Min>
           <Max>2.0</Max>
         </Parameter>
@@ -915,7 +904,6 @@
         <Name>Mass_f0(1500)</Name>
         <Value>1.505</Value>
         <Error>0.006</Error>
-        <Fix>true</Fix>
       </Parameter>
       <QuantumNumber>
         <Class>Spin</Class>
@@ -956,7 +944,6 @@
           <Type>MesonRadius</Type>
           <Name>Radius_f01500</Name>
           <Value>1</Value>
-          <Fix>true</Fix>
           <Min>0.0</Min>
           <Max>2.0</Max>
         </Parameter>
@@ -970,7 +957,6 @@
         <Name>Mass_f2(1270)</Name>
         <Value>1.2751</Value>
         <Error>0.0012</Error>
-        <Fix>true</Fix>
       </Parameter>
       <QuantumNumber>
         <Class>Spin</Class>
@@ -1011,7 +997,6 @@
           <Type>MesonRadius</Type>
           <Name>Radius_f21270</Name>
           <Value>1</Value>
-          <Fix>true</Fix>
           <Min>0.0</Min>
           <Max>2.0</Max>
         </Parameter>
@@ -1025,7 +1010,6 @@
         <Name>Mass_f2(1950)</Name>
         <Value>1.944</Value>
         <Error>0.012</Error>
-        <Fix>true</Fix>
       </Parameter>
       <QuantumNumber>
         <Class>Spin</Class>
@@ -1066,7 +1050,6 @@
           <Type>MesonRadius</Type>
           <Name>Radius_f21950</Name>
           <Value>1</Value>
-          <Fix>true</Fix>
           <Min>0.0</Min>
           <Max>2.0</Max>
         </Parameter>
@@ -1080,7 +1063,6 @@
         <Name>Mass_a0(980)0</Name>
         <Value>0.994</Value>
         <Error>0.001</Error>
-        <Fix>true</Fix>
       </Parameter>
       <QuantumNumber>
         <Class>Spin</Class>
@@ -1123,7 +1105,6 @@
           <Name>gKK_a0(980)</Name>
           <Value>3.121343843602647</Value>
           <Error>0.001</Error>
-          <Fix>false</Fix>
           <ParticleA>K+</ParticleA>
           <ParticleB>K-</ParticleB>
         </Parameter>
@@ -1132,7 +1113,6 @@
           <Name>gEtaPi_a0(980)</Name>
           <Value>2.66</Value>
           <Error>0.001</Error>
-          <Fix>true</Fix>
           <ParticleA>eta</ParticleA>
           <ParticleB>pi0</ParticleB>
         </Parameter>
@@ -1141,7 +1121,6 @@
           <Name>gKK_a0(980)</Name>
           <Value>3.121343843602647</Value>
           <Error>0.001</Error>
-          <Fix>false</Fix>
           <ParticleA>K_S0</ParticleA>
           <ParticleB>K_S0</ParticleB>
         </Parameter>
@@ -1149,7 +1128,6 @@
           <Type>MesonRadius</Type>
           <Name>Radius_a0(980)</Name>
           <Value>1.5</Value>
-          <Fix>true</Fix>
           <Min>1.0</Min>
           <Max>2.0</Max>
         </Parameter>
@@ -1163,7 +1141,6 @@
         <Name>Mass_a0(980)+</Name>
         <Value>0.994</Value>
         <Error>0.001</Error>
-        <Fix>true</Fix>
       </Parameter>
       <QuantumNumber>
         <Class>Spin</Class>
@@ -1201,7 +1178,6 @@
           <Name>gKK_a0(980)</Name>
           <Value>3.121343843602647</Value>
           <Error>0.001</Error>
-          <Fix>false</Fix>
           <ParticleA>K_S0</ParticleA>
           <ParticleB>K+</ParticleB>
         </Parameter>
@@ -1210,7 +1186,6 @@
           <Name>gEtaPi_a0(980)</Name>
           <Value>2.66</Value>
           <Error>0.001</Error>
-          <Fix>true</Fix>
           <ParticleA>eta</ParticleA>
           <ParticleB>pi0</ParticleB>
         </Parameter>
@@ -1218,7 +1193,6 @@
           <Type>MesonRadius</Type>
           <Name>Radius_a0(980)</Name>
           <Value>1.5</Value>
-          <Fix>true</Fix>
           <Min>1.0</Min>
           <Max>2.0</Max>
         </Parameter>
@@ -1232,7 +1206,6 @@
         <Name>Mass_a0(980)-</Name>
         <Value>0.994</Value>
         <Error>0.001</Error>
-        <Fix>true</Fix>
       </Parameter>
       <QuantumNumber>
         <Class>Spin</Class>
@@ -1270,7 +1243,6 @@
           <Name>gKK_a0(980)</Name>
           <Value>3.121343843602647</Value>
           <Error>0.001</Error>
-          <Fix>false</Fix>
           <ParticleA>K_S0</ParticleA>
           <ParticleB>K+</ParticleB>
         </Parameter>
@@ -1279,7 +1251,6 @@
           <Name>gEtaPi_a0(980)</Name>
           <Value>2.66</Value>
           <Error>0.001</Error>
-          <Fix>true</Fix>
           <ParticleA>eta</ParticleA>
           <ParticleB>pi0</ParticleB>
         </Parameter>
@@ -1287,7 +1258,6 @@
           <Type>MesonRadius</Type>
           <Name>Radius_a0(980)</Name>
           <Value>1.5</Value>
-          <Fix>true</Fix>
           <Min>1.0</Min>
           <Max>2.0</Max>
         </Parameter>
@@ -1301,7 +1271,6 @@
         <Name>Mass_a2(1320)0</Name>
         <Value>1.3184</Value>
         <Error>0.0005</Error>
-        <Fix>true</Fix>
       </Parameter>
       <QuantumNumber>
         <Class>Spin</Class>
@@ -1344,13 +1313,11 @@
           <Name>Width_a2(1320)0</Name>
           <Value>0.00107</Value>
           <Error>0.00005</Error>
-          <Fix>true</Fix>
         </Parameter>
         <Parameter>
           <Type>MesonRadius</Type>
           <Name>Radius_a2(1320)-</Name>
           <Value>1.5</Value>
-          <Fix>true</Fix>
           <Min>1.0</Min>
           <Max>2.0</Max>
         </Parameter>
@@ -1364,7 +1331,6 @@
         <Name>Mass_a2(1320)+</Name>
         <Value>1.3184</Value>
         <Error>0.0005</Error>
-        <Fix>true</Fix>
       </Parameter>
       <QuantumNumber>
         <Class>Spin</Class>
@@ -1407,13 +1373,11 @@
           <Name>Width_a2(1320)+</Name>
           <Value>0.00107</Value>
           <Error>0.00005</Error>
-          <Fix>true</Fix>
         </Parameter>
         <Parameter>
           <Type>MesonRadius</Type>
           <Name>Radius_a2(1320)-</Name>
           <Value>1.5</Value>
-          <Fix>true</Fix>
           <Min>1.0</Min>
           <Max>2.0</Max>
         </Parameter>
@@ -1427,7 +1391,6 @@
         <Name>Mass_a2(1320)-</Name>
         <Value>1.3184</Value>
         <Error>0.0005</Error>
-        <Fix>true</Fix>
       </Parameter>
       <QuantumNumber>
         <Class>Spin</Class>
@@ -1470,13 +1433,11 @@
           <Name>Width_a2(1320)-</Name>
           <Value>0.00107</Value>
           <Error>0.00005</Error>
-          <Fix>true</Fix>
         </Parameter>
         <Parameter>
           <Type>MesonRadius</Type>
           <Name>Radius_a2(1320)-</Name>
           <Value>1.5</Value>
-          <Fix>true</Fix>
           <Min>1.0</Min>
           <Max>2.0</Max>
         </Parameter>
@@ -1490,7 +1451,6 @@
         <Name>Mass_phi(1020)</Name>
         <Value>1.019461</Value>
         <Error>0.000019</Error>
-        <Fix>true</Fix>
       </Parameter>
       <QuantumNumber>
         <Class>Spin</Class>
@@ -1522,13 +1482,11 @@
           <Name>Width_phi(1020)</Name>
           <Value>0.004266</Value>
           <Error>0.000031</Error>
-          <Fix>true</Fix>
         </Parameter>
         <Parameter>
           <Type>MesonRadius</Type>
           <Name>Radius_phi(1020)</Name>
           <Value>1.5</Value>
-          <Fix>true</Fix>
           <Min>1.0</Min>
           <Max>2.0</Max>
         </Parameter>
@@ -1543,7 +1501,6 @@
         <Type>Mass</Type>
         <Name>Mass_K-</Name>
         <Value>0.493677</Value>
-        <Fix>true</Fix>
       </Parameter>
       <QuantumNumber>
         <Class>Spin</Class>
@@ -1579,7 +1536,6 @@
         <Type>Mass</Type>
         <Name>Mass_K+</Name>
         <Value>0.493677</Value>
-        <Fix>true</Fix>
       </Parameter>
       <QuantumNumber>
         <Class>Spin</Class>
@@ -1615,7 +1571,6 @@
         <Type>Mass</Type>
         <Name>Mass_K_S0</Name>
         <Value>0.497614</Value>
-        <Fix>true</Fix>
       </Parameter>
       <QuantumNumber>
         <Class>Spin</Class>
@@ -1646,7 +1601,6 @@
         <Type>Mass</Type>
         <Name>Mass_K_L0</Name>
         <Value>0.497614</Value>
-        <Fix>true</Fix>
       </Parameter>
       <QuantumNumber>
         <Class>Spin</Class>
@@ -1679,7 +1633,6 @@
         <Type>Mass</Type>
         <Name>Mass_D+</Name>
         <Value>1.86958</Value>
-        <Fix>true</Fix>
       </Parameter>
       <QuantumNumber>
         <Class>Spin</Class>
@@ -1716,13 +1669,11 @@
           <Type>Width</Type>
           <Name>Width_D+</Name>
           <Value>6.33E-13</Value>
-          <Fix>true</Fix>
         </Parameter>
         <Parameter>
           <Type>MesonRadius</Type>
           <Name>Radius_chargedD</Name>
           <Value>2.5</Value>
-          <Fix>true</Fix>
           <Min>2.0</Min>
           <Max>3.0</Max>
         </Parameter>
@@ -1735,7 +1686,6 @@
         <Type>Mass</Type>
         <Name>Mass_D-</Name>
         <Value>1.86958</Value>
-        <Fix>true</Fix>
       </Parameter>
       <QuantumNumber>
         <Class>Spin</Class>
@@ -1772,13 +1722,11 @@
           <Type>Width</Type>
           <Name>Width_D-</Name>
           <Value>6.33E-13</Value>
-          <Fix>true</Fix>
         </Parameter>
         <Parameter>
           <Type>MesonRadius</Type>
           <Name>Radius_chargedD</Name>
           <Value>2.5</Value>
-          <Fix>true</Fix>
           <Min>2.0</Min>
           <Max>3.0</Max>
         </Parameter>
@@ -1791,7 +1739,6 @@
         <Type>Mass</Type>
         <Name>Mass_D0</Name>
         <Value>1.86483</Value>
-        <Fix>true</Fix>
       </Parameter>
       <QuantumNumber>
         <Class>Spin</Class>
@@ -1828,13 +1775,11 @@
           <Type>Width</Type>
           <Name>Width_D0</Name>
           <Value>1.605E-12</Value>
-          <Fix>true</Fix>
         </Parameter>
         <Parameter>
           <Type>MesonRadius</Type>
           <Name>Radius_neutralD</Name>
           <Value>2.5</Value>
-          <Fix>true</Fix>
           <Min>2.0</Min>
           <Max>3.0</Max>
         </Parameter>
@@ -1847,7 +1792,6 @@
         <Type>Mass</Type>
         <Name>Mass_D0bar</Name>
         <Value>1.86483</Value>
-        <Fix>true</Fix>
       </Parameter>
       <QuantumNumber>
         <Class>Spin</Class>
@@ -1884,13 +1828,11 @@
           <Type>Width</Type>
           <Name>Width_D0bar</Name>
           <Value>1.605E-12</Value>
-          <Fix>true</Fix>
         </Parameter>
         <Parameter>
           <Type>MesonRadius</Type>
           <Name>Radius_neutralD</Name>
           <Value>2.5</Value>
-          <Fix>true</Fix>
           <Min>2.0</Min>
           <Max>3.0</Max>
         </Parameter>
@@ -1903,7 +1845,6 @@
         <Type>Mass</Type>
         <Name>Mass_D*(2007)0</Name>
         <Value>2.007</Value>
-        <Fix>true</Fix>
       </Parameter>
       <QuantumNumber>
         <Class>Spin</Class>
@@ -1940,13 +1881,11 @@
           <Type>Width</Type>
           <Name>Width_D*(2007)0</Name>
           <Value>0.001</Value>
-          <Fix>true</Fix>
         </Parameter>
         <Parameter>
           <Type>MesonRadius</Type>
           <Name>Radius_D*(2007)0</Name>
           <Value>2.5</Value>
-          <Fix>true</Fix>
           <Min>2.0</Min>
           <Max>3.0</Max>
         </Parameter>
@@ -1959,7 +1898,6 @@
         <Type>Mass</Type>
         <Name>Mass_D*(2007)0bar</Name>
         <Value>2.007</Value>
-        <Fix>true</Fix>
       </Parameter>
       <QuantumNumber>
         <Class>Spin</Class>
@@ -1996,13 +1934,11 @@
           <Type>Width</Type>
           <Name>Width_D*(2007)0bar</Name>
           <Value>0.001</Value>
-          <Fix>true</Fix>
         </Parameter>
         <Parameter>
           <Type>MesonRadius</Type>
           <Name>Radius_D*(2007)0bar</Name>
           <Value>2.5</Value>
-          <Fix>true</Fix>
           <Min>2.0</Min>
           <Max>3.0</Max>
         </Parameter>
@@ -2015,7 +1951,6 @@
         <Type>Mass</Type>
         <Name>Mass_D*(2010)-</Name>
         <Value>2.01</Value>
-        <Fix>true</Fix>
       </Parameter>
       <QuantumNumber>
         <Class>Spin</Class>
@@ -2052,13 +1987,11 @@
           <Type>Width</Type>
           <Name>Width_D*(2010)-</Name>
           <Value>83.4E-6</Value>
-          <Fix>true</Fix>
         </Parameter>
         <Parameter>
           <Type>MesonRadius</Type>
           <Name>Radius_D*(2010)-</Name>
           <Value>2.5</Value>
-          <Fix>true</Fix>
           <Min>2.0</Min>
           <Max>3.0</Max>
         </Parameter>
@@ -2071,7 +2004,6 @@
         <Type>Mass</Type>
         <Name>Mass_D*(2010)+</Name>
         <Value>2.01</Value>
-        <Fix>true</Fix>
       </Parameter>
       <QuantumNumber>
         <Class>Spin</Class>
@@ -2108,13 +2040,11 @@
           <Type>Width</Type>
           <Name>Width_D*(2010)+</Name>
           <Value>83.4E-6</Value>
-          <Fix>true</Fix>
         </Parameter>
         <Parameter>
           <Type>MesonRadius</Type>
           <Name>Radius_D*(2010)+</Name>
           <Value>2.5</Value>
-          <Fix>true</Fix>
           <Min>2.0</Min>
           <Max>3.0</Max>
         </Parameter>
@@ -2127,7 +2057,6 @@
         <Type>Mass</Type>
         <Name>Mass_D1(2420)0</Name>
         <Value>2.4214</Value>
-        <Fix>true</Fix>
       </Parameter>
       <QuantumNumber>
         <Class>Spin</Class>
@@ -2164,13 +2093,11 @@
           <Type>Width</Type>
           <Name>Width_D1(2420)0</Name>
           <Value>27.4E-3</Value>
-          <Fix>true</Fix>
         </Parameter>
         <Parameter>
           <Type>MesonRadius</Type>
           <Name>Radius_D1(2420)0</Name>
           <Value>2.5</Value>
-          <Fix>true</Fix>
           <Min>2.0</Min>
           <Max>3.0</Max>
         </Parameter>
@@ -2183,7 +2110,6 @@
         <Type>Mass</Type>
         <Name>Mass_XX</Name>
         <Value>4.1</Value>
-        <Fix>true</Fix>
       </Parameter>
       <QuantumNumber>
         <Class>Spin</Class>
@@ -2214,7 +2140,6 @@
         <Type>Mass</Type>
         <Name>Mass_J/psi</Name>
         <Value>3.0969</Value>
-        <Fix>true</Fix>
       </Parameter>
       <QuantumNumber>
         <Class>Spin</Class>
@@ -2250,13 +2175,11 @@
           <Type>Width</Type>
           <Name>Width_J/psi</Name>
           <Value>9.29E-05</Value>
-          <Fix>true</Fix>
         </Parameter>
         <Parameter>
           <Type>MesonRadius</Type>
           <Name>Radius_jpsi</Name>
           <Value>2.5</Value>
-          <Fix>true</Fix>
           <Min>2.0</Min>
           <Max>3.0</Max>
         </Parameter>
@@ -2269,7 +2192,6 @@
         <Type>Mass</Type>
         <Name>Mass_Y</Name>
         <Value>4.300</Value>
-        <Fix>true</Fix>
       </Parameter>
       <QuantumNumber>
         <Class>Spin</Class>
@@ -2300,13 +2222,11 @@
           <Type>Width</Type>
           <Name>Width_Y</Name>
           <Value>9.29E-05</Value>
-          <Fix>true</Fix>
         </Parameter>
         <Parameter>
           <Type>MesonRadius</Type>
           <Name>Radius_Y</Name>
           <Value>2.5</Value>
-          <Fix>true</Fix>
           <Min>2.0</Min>
           <Max>3.0</Max>
         </Parameter>
@@ -2319,7 +2239,6 @@
         <Type>Mass</Type>
         <Name>Mass_Chic1</Name>
         <Value>3.51</Value>
-        <Fix>true</Fix>
       </Parameter>
       <QuantumNumber>
         <Class>Spin</Class>
@@ -2355,13 +2274,11 @@
           <Type>Width</Type>
           <Name>Width_Chic1</Name>
           <Value>0.00084</Value>
-          <Fix>true</Fix>
         </Parameter>
         <Parameter>
           <Type>MesonRadius</Type>
           <Name>Radius_chic1</Name>
           <Value>2.5</Value>
-          <Fix>true</Fix>
           <Min>2.0</Min>
           <Max>3.0</Max>
         </Parameter>
@@ -2377,7 +2294,6 @@
         <Type>Mass</Type>
         <Name>Mass_p</Name>
         <Value>0.938272081</Value>
-        <Fix>true</Fix>
       </Parameter>
       <QuantumNumber>
         <Class>Spin</Class>
@@ -2413,7 +2329,6 @@
         <Type>Mass</Type>
         <Name>Mass_pbar</Name>
         <Value>0.938272081</Value>
-        <Fix>true</Fix>
       </Parameter>
       <QuantumNumber>
         <Class>Spin</Class>
@@ -2449,7 +2364,6 @@
         <Type>Mass</Type>
         <Name>Mass_n</Name>
         <Value>0.939565413</Value>
-        <Fix>true</Fix>
       </Parameter>
       <QuantumNumber>
         <Class>Spin</Class>
@@ -2485,7 +2399,6 @@
         <Type>Mass</Type>
         <Name>Mass_nbar</Name>
         <Value>0.939565413</Value>
-        <Fix>true</Fix>
       </Parameter>
       <QuantumNumber>
         <Class>Spin</Class>
@@ -2521,7 +2434,6 @@
         <Type>Mass</Type>
         <Name>Mass_N(1650)+</Name>
         <Value>1.65</Value>
-        <Fix>true</Fix>
       </Parameter>
       <QuantumNumber>
         <Class>Spin</Class>
@@ -2575,7 +2487,6 @@
         <Type>Mass</Type>
         <Name>Mass_N(1650)-</Name>
         <Value>1.65</Value>
-        <Fix>true</Fix>
       </Parameter>
       <QuantumNumber>
         <Class>Spin</Class>
@@ -2629,7 +2540,6 @@
         <Type>Mass</Type>
         <Name>Mass_Delta(1232)++</Name>
         <Value>1.232</Value>
-        <Fix>true</Fix>
       </Parameter>
       <QuantumNumber>
         <Class>Spin</Class>
@@ -2665,7 +2575,6 @@
         <Type>Mass</Type>
         <Name>Mass_Delta(1232)+</Name>
         <Value>1.232</Value>
-        <Fix>true</Fix>
       </Parameter>
       <QuantumNumber>
         <Class>Spin</Class>
@@ -2701,7 +2610,6 @@
         <Type>Mass</Type>
         <Name>Mass_Delta(1232)0</Name>
         <Value>1.232</Value>
-        <Fix>true</Fix>
       </Parameter>
       <QuantumNumber>
         <Class>Spin</Class>
@@ -2737,7 +2645,6 @@
         <Type>Mass</Type>
         <Name>Mass_Delta(1232)-</Name>
         <Value>1.232</Value>
-        <Fix>true</Fix>
       </Parameter>
       <QuantumNumber>
         <Class>Spin</Class>
@@ -2775,7 +2682,6 @@
         <Type>Mass</Type>
         <Name>Mass_lambda</Name>
         <Value>1.115683</Value>
-        <Fix>true</Fix>
       </Parameter>
       <QuantumNumber>
         <Class>Spin</Class>
@@ -2810,7 +2716,6 @@
         <Type>Mass</Type>
         <Name>Mass_lambdabar</Name>
         <Value>1.115683</Value>
-        <Fix>true</Fix>
       </Parameter>
       <QuantumNumber>
         <Class>Spin</Class>
@@ -2845,7 +2750,6 @@
         <Type>Mass</Type>
         <Name>Mass_sigma0</Name>
         <Value>1.192642</Value>
-        <Fix>true</Fix>
       </Parameter>
       <QuantumNumber>
         <Class>Spin</Class>
@@ -2887,7 +2791,6 @@
           <Type>Width</Type>
           <Name>Width_sigma0</Name>
           <Value>0.0000089</Value>
-          <Fix>true</Fix>
         </Parameter>
       </DecayInfo>
     </Particle>
@@ -2898,7 +2801,6 @@
         <Type>Mass</Type>
         <Name>Mass_sigma+</Name>
         <Value>1.18937</Value>
-        <Fix>true</Fix>
       </Parameter>
       <QuantumNumber>
         <Class>Spin</Class>
@@ -2939,7 +2841,6 @@
         <Type>Mass</Type>
         <Name>Mass_sigma-</Name>
         <Value>1.197449</Value>
-        <Fix>true</Fix>
       </Parameter>
       <QuantumNumber>
         <Class>Spin</Class>
@@ -2980,7 +2881,6 @@
         <Type>Mass</Type>
         <Name>Mass_Xi0</Name>
         <Value>1.31486</Value>
-        <Fix>true</Fix>
       </Parameter>
       <QuantumNumber>
         <Class>Spin</Class>
@@ -3021,7 +2921,6 @@
         <Type>Mass</Type>
         <Name>Mass_Xi-</Name>
         <Value>1.32171</Value>
-        <Fix>true</Fix>
       </Parameter>
       <QuantumNumber>
         <Class>Spin</Class>

--- a/expertsystem/particle_list.xml
+++ b/expertsystem/particle_list.xml
@@ -30,27 +30,6 @@
         <Type>CParity</Type>
         <Value>-1</Value>
       </QuantumNumber>
-      <QuantumNumber>
-        <Class>Spin</Class>
-        <Type>IsoSpin</Type>
-        <Value>0</Value>
-        <Projection>0</Projection>
-      </QuantumNumber>
-      <QuantumNumber>
-        <Class>Int</Class>
-        <Type>BaryonNumber</Type>
-        <Value>0</Value>
-      </QuantumNumber>
-      <QuantumNumber>
-        <Class>Int</Class>
-        <Type>Charm</Type>
-        <Value>0</Value>
-      </QuantumNumber>
-      <QuantumNumber>
-        <Class>Int</Class>
-        <Type>Strangeness</Type>
-        <Value>0</Value>
-      </QuantumNumber>
     </Particle>
     <Particle>
       <Name>W-</Name>
@@ -95,8 +74,8 @@
       <Pid>2299</Pid>
       <Parameter>
         <Type>Mass</Type>
-        <Name>Mass_epem</Name>
-        <Value>4.230</Value>
+        <Name>Mass_EpEm (4230 MeV)</Name>
+        <Value>4.23</Value>
         <Fix>true</Fix>
       </Parameter>
       <QuantumNumber>
@@ -124,27 +103,6 @@
         <Type>GParity</Type>
         <Value>-1</Value>
       </QuantumNumber>
-      <QuantumNumber>
-        <Class>Spin</Class>
-        <Type>IsoSpin</Type>
-        <Value>0</Value>
-        <Projection>0</Projection>
-      </QuantumNumber>
-      <QuantumNumber>
-        <Class>Int</Class>
-        <Type>Charm</Type>
-        <Value>0</Value>
-      </QuantumNumber>
-      <QuantumNumber>
-        <Class>Int</Class>
-        <Type>Strangeness</Type>
-        <Value>0</Value>
-      </QuantumNumber>
-      <QuantumNumber>
-        <Class>Int</Class>
-        <Type>BaryonNumber</Type>
-        <Value>0</Value>
-      </QuantumNumber>
     </Particle>
 
 
@@ -154,7 +112,7 @@
       <Pid>11</Pid>
       <Parameter>
         <Type>Mass</Type>
-        <Name>Mass_electron</Name>
+        <Name>Mass_e+</Name>
         <Value>0.0005109989461</Value>
       </Parameter>
       <QuantumNumber>
@@ -176,21 +134,6 @@
         <Class>Int</Class>
         <Type>ElectronLN</Type>
         <Value>-1</Value>
-      </QuantumNumber>
-      <QuantumNumber>
-        <Class>Int</Class>
-        <Type>MuonLN</Type>
-        <Value>0</Value>
-      </QuantumNumber>
-      <QuantumNumber>
-        <Class>Int</Class>
-        <Type>TauLN</Type>
-        <Value>0</Value>
-      </QuantumNumber>
-      <QuantumNumber>
-        <Class>Int</Class>
-        <Type>BaryonNumber</Type>
-        <Value>0</Value>
       </QuantumNumber>
     </Particle>
     <Particle>
@@ -198,7 +141,7 @@
       <Pid>-11</Pid>
       <Parameter>
         <Type>Mass</Type>
-        <Name>Mass_electron</Name>
+        <Name>Mass_e-</Name>
         <Value>0.0005109989461</Value>
       </Parameter>
       <QuantumNumber>
@@ -221,28 +164,13 @@
         <Type>ElectronLN</Type>
         <Value>1</Value>
       </QuantumNumber>
-      <QuantumNumber>
-        <Class>Int</Class>
-        <Type>MuonLN</Type>
-        <Value>0</Value>
-      </QuantumNumber>
-      <QuantumNumber>
-        <Class>Int</Class>
-        <Type>TauLN</Type>
-        <Value>0</Value>
-      </QuantumNumber>
-      <QuantumNumber>
-        <Class>Int</Class>
-        <Type>BaryonNumber</Type>
-        <Value>0</Value>
-      </QuantumNumber>
     </Particle>
     <Particle>
       <Name>mu+</Name>
       <Pid>13</Pid>
       <Parameter>
         <Type>Mass</Type>
-        <Name>Mass_muon</Name>
+        <Name>Mass_mu+</Name>
         <Value>0.1056583745</Value>
       </Parameter>
       <QuantumNumber>
@@ -262,23 +190,8 @@
       </QuantumNumber>
       <QuantumNumber>
         <Class>Int</Class>
-        <Type>ElectronLN</Type>
-        <Value>0</Value>
-      </QuantumNumber>
-      <QuantumNumber>
-        <Class>Int</Class>
         <Type>MuonLN</Type>
         <Value>-1</Value>
-      </QuantumNumber>
-      <QuantumNumber>
-        <Class>Int</Class>
-        <Type>TauLN</Type>
-        <Value>0</Value>
-      </QuantumNumber>
-      <QuantumNumber>
-        <Class>Int</Class>
-        <Type>BaryonNumber</Type>
-        <Value>0</Value>
       </QuantumNumber>
     </Particle>
     <Particle>
@@ -286,7 +199,7 @@
       <Pid>-13</Pid>
       <Parameter>
         <Type>Mass</Type>
-        <Name>Mass_muon</Name>
+        <Name>Mass_mu-</Name>
         <Value>0.1056583745</Value>
       </Parameter>
       <QuantumNumber>
@@ -306,23 +219,8 @@
       </QuantumNumber>
       <QuantumNumber>
         <Class>Int</Class>
-        <Type>ElectronLN</Type>
-        <Value>0</Value>
-      </QuantumNumber>
-      <QuantumNumber>
-        <Class>Int</Class>
         <Type>MuonLN</Type>
         <Value>1</Value>
-      </QuantumNumber>
-      <QuantumNumber>
-        <Class>Int</Class>
-        <Type>TauLN</Type>
-        <Value>0</Value>
-      </QuantumNumber>
-      <QuantumNumber>
-        <Class>Int</Class>
-        <Type>BaryonNumber</Type>
-        <Value>0</Value>
       </QuantumNumber>
     </Particle>
     <Particle>
@@ -330,7 +228,7 @@
       <Pid>15</Pid>
       <Parameter>
         <Type>Mass</Type>
-        <Name>Mass_tau</Name>
+        <Name>Mass_tau+</Name>
         <Value>1.77686</Value>
       </Parameter>
       <QuantumNumber>
@@ -350,23 +248,8 @@
       </QuantumNumber>
       <QuantumNumber>
         <Class>Int</Class>
-        <Type>ElectronLN</Type>
-        <Value>0</Value>
-      </QuantumNumber>
-      <QuantumNumber>
-        <Class>Int</Class>
-        <Type>MuonLN</Type>
-        <Value>0</Value>
-      </QuantumNumber>
-      <QuantumNumber>
-        <Class>Int</Class>
         <Type>TauLN</Type>
         <Value>-1</Value>
-      </QuantumNumber>
-      <QuantumNumber>
-        <Class>Int</Class>
-        <Type>BaryonNumber</Type>
-        <Value>0</Value>
       </QuantumNumber>
     </Particle>
     <Particle>
@@ -374,7 +257,7 @@
       <Pid>-15</Pid>
       <Parameter>
         <Type>Mass</Type>
-        <Name>Mass_tau</Name>
+        <Name>Mass_tau-</Name>
         <Value>1.77686</Value>
       </Parameter>
       <QuantumNumber>
@@ -394,23 +277,8 @@
       </QuantumNumber>
       <QuantumNumber>
         <Class>Int</Class>
-        <Type>ElectronLN</Type>
-        <Value>0</Value>
-      </QuantumNumber>
-      <QuantumNumber>
-        <Class>Int</Class>
-        <Type>MuonLN</Type>
-        <Value>0</Value>
-      </QuantumNumber>
-      <QuantumNumber>
-        <Class>Int</Class>
         <Type>TauLN</Type>
         <Value>1</Value>
-      </QuantumNumber>
-      <QuantumNumber>
-        <Class>Int</Class>
-        <Type>BaryonNumber</Type>
-        <Value>0</Value>
       </QuantumNumber>
     </Particle>
 
@@ -420,8 +288,8 @@
       <Pid>12</Pid>
       <Parameter>
         <Type>Mass</Type>
-        <Name>Mass_electron</Name>
-        <Value>1e-9</Value>
+        <Name>Mass_ve</Name>
+        <Value>1e-09</Value>
       </Parameter>
       <QuantumNumber>
         <Class>Spin</Class>
@@ -442,21 +310,6 @@
         <Class>Int</Class>
         <Type>ElectronLN</Type>
         <Value>1</Value>
-      </QuantumNumber>
-      <QuantumNumber>
-        <Class>Int</Class>
-        <Type>MuonLN</Type>
-        <Value>0</Value>
-      </QuantumNumber>
-      <QuantumNumber>
-        <Class>Int</Class>
-        <Type>TauLN</Type>
-        <Value>0</Value>
-      </QuantumNumber>
-      <QuantumNumber>
-        <Class>Int</Class>
-        <Type>BaryonNumber</Type>
-        <Value>0</Value>
       </QuantumNumber>
     </Particle>
     <Particle>
@@ -464,8 +317,8 @@
       <Pid>-12</Pid>
       <Parameter>
         <Type>Mass</Type>
-        <Name>Mass_electron</Name>
-        <Value>1e-9</Value>
+        <Name>Mass_vebar</Name>
+        <Value>1e-09</Value>
       </Parameter>
       <QuantumNumber>
         <Class>Spin</Class>
@@ -486,21 +339,6 @@
         <Class>Int</Class>
         <Type>ElectronLN</Type>
         <Value>-1</Value>
-      </QuantumNumber>
-      <QuantumNumber>
-        <Class>Int</Class>
-        <Type>MuonLN</Type>
-        <Value>0</Value>
-      </QuantumNumber>
-      <QuantumNumber>
-        <Class>Int</Class>
-        <Type>TauLN</Type>
-        <Value>0</Value>
-      </QuantumNumber>
-      <QuantumNumber>
-        <Class>Int</Class>
-        <Type>BaryonNumber</Type>
-        <Value>0</Value>
       </QuantumNumber>
     </Particle>
     <Particle>
@@ -508,8 +346,8 @@
       <Pid>14</Pid>
       <Parameter>
         <Type>Mass</Type>
-        <Name>Mass_muon</Name>
-        <Value>1e-9</Value>
+        <Name>Mass_vmu</Name>
+        <Value>1e-09</Value>
       </Parameter>
       <QuantumNumber>
         <Class>Spin</Class>
@@ -528,23 +366,8 @@
       </QuantumNumber>
       <QuantumNumber>
         <Class>Int</Class>
-        <Type>ElectronLN</Type>
-        <Value>0</Value>
-      </QuantumNumber>
-      <QuantumNumber>
-        <Class>Int</Class>
         <Type>MuonLN</Type>
         <Value>1</Value>
-      </QuantumNumber>
-      <QuantumNumber>
-        <Class>Int</Class>
-        <Type>TauLN</Type>
-        <Value>0</Value>
-      </QuantumNumber>
-      <QuantumNumber>
-        <Class>Int</Class>
-        <Type>BaryonNumber</Type>
-        <Value>0</Value>
       </QuantumNumber>
     </Particle>
     <Particle>
@@ -552,8 +375,8 @@
       <Pid>-14</Pid>
       <Parameter>
         <Type>Mass</Type>
-        <Name>Mass_muon</Name>
-        <Value>1e-9</Value>
+        <Name>Mass_vmubar</Name>
+        <Value>1e-09</Value>
       </Parameter>
       <QuantumNumber>
         <Class>Spin</Class>
@@ -572,23 +395,8 @@
       </QuantumNumber>
       <QuantumNumber>
         <Class>Int</Class>
-        <Type>ElectronLN</Type>
-        <Value>0</Value>
-      </QuantumNumber>
-      <QuantumNumber>
-        <Class>Int</Class>
         <Type>MuonLN</Type>
         <Value>-1</Value>
-      </QuantumNumber>
-      <QuantumNumber>
-        <Class>Int</Class>
-        <Type>TauLN</Type>
-        <Value>0</Value>
-      </QuantumNumber>
-      <QuantumNumber>
-        <Class>Int</Class>
-        <Type>BaryonNumber</Type>
-        <Value>0</Value>
       </QuantumNumber>
     </Particle>
     <Particle>
@@ -596,8 +404,8 @@
       <Pid>16</Pid>
       <Parameter>
         <Type>Mass</Type>
-        <Name>Mass_tau</Name>
-        <Value>1e-9</Value>
+        <Name>Mass_vtau</Name>
+        <Value>1e-09</Value>
       </Parameter>
       <QuantumNumber>
         <Class>Spin</Class>
@@ -616,23 +424,8 @@
       </QuantumNumber>
       <QuantumNumber>
         <Class>Int</Class>
-        <Type>ElectronLN</Type>
-        <Value>0</Value>
-      </QuantumNumber>
-      <QuantumNumber>
-        <Class>Int</Class>
-        <Type>MuonLN</Type>
-        <Value>0</Value>
-      </QuantumNumber>
-      <QuantumNumber>
-        <Class>Int</Class>
         <Type>TauLN</Type>
         <Value>1</Value>
-      </QuantumNumber>
-      <QuantumNumber>
-        <Class>Int</Class>
-        <Type>BaryonNumber</Type>
-        <Value>0</Value>
       </QuantumNumber>
     </Particle>
     <Particle>
@@ -640,8 +433,8 @@
       <Pid>-16</Pid>
       <Parameter>
         <Type>Mass</Type>
-        <Name>Mass_tau</Name>
-        <Value>1e-9</Value>
+        <Name>Mass_vtaubar</Name>
+        <Value>1e-09</Value>
       </Parameter>
       <QuantumNumber>
         <Class>Spin</Class>
@@ -660,23 +453,8 @@
       </QuantumNumber>
       <QuantumNumber>
         <Class>Int</Class>
-        <Type>ElectronLN</Type>
-        <Value>0</Value>
-      </QuantumNumber>
-      <QuantumNumber>
-        <Class>Int</Class>
-        <Type>MuonLN</Type>
-        <Value>0</Value>
-      </QuantumNumber>
-      <QuantumNumber>
-        <Class>Int</Class>
         <Type>TauLN</Type>
         <Value>-1</Value>
-      </QuantumNumber>
-      <QuantumNumber>
-        <Class>Int</Class>
-        <Type>BaryonNumber</Type>
-        <Value>0</Value>
       </QuantumNumber>
     </Particle>
 
@@ -689,7 +467,7 @@
       <Pid>111</Pid>
       <Parameter>
         <Type>Mass</Type>
-        <Name>Mass_neutralPion</Name>
+        <Name>Mass_pi0</Name>
         <Value>0.1349766</Value>
         <Error>0.000006</Error>
       </Parameter>
@@ -724,28 +502,13 @@
         <Value>1</Value>
         <Projection>0</Projection>
       </QuantumNumber>
-      <QuantumNumber>
-        <Class>Int</Class>
-        <Type>BaryonNumber</Type>
-        <Value>0</Value>
-      </QuantumNumber>
-      <QuantumNumber>
-        <Class>Int</Class>
-        <Type>Charm</Type>
-        <Value>0</Value>
-      </QuantumNumber>
-      <QuantumNumber>
-        <Class>Int</Class>
-        <Type>Strangeness</Type>
-        <Value>0</Value>
-      </QuantumNumber>
     </Particle>
     <Particle>
       <Name>pi+</Name>
       <Pid>211</Pid>
       <Parameter>
         <Type>Mass</Type>
-        <Name>Mass_chargedPion</Name>
+        <Name>Mass_pi+</Name>
         <Value>0.13957018</Value>
         <Error>0.00000035</Error>
         <Fix>true</Fix>
@@ -776,28 +539,13 @@
         <Value>1</Value>
         <Projection>1</Projection>
       </QuantumNumber>
-      <QuantumNumber>
-        <Class>Int</Class>
-        <Type>Charm</Type>
-        <Value>0</Value>
-      </QuantumNumber>
-      <QuantumNumber>
-        <Class>Int</Class>
-        <Type>Strangeness</Type>
-        <Value>0</Value>
-      </QuantumNumber>
-      <QuantumNumber>
-        <Class>Int</Class>
-        <Type>BaryonNumber</Type>
-        <Value>0</Value>
-      </QuantumNumber>
     </Particle>
     <Particle>
       <Name>pi-</Name>
       <Pid>-211</Pid>
       <Parameter>
         <Type>Mass</Type>
-        <Name>Mass_chargedPion</Name>
+        <Name>Mass_pi-</Name>
         <Value>0.13957018</Value>
         <Error>0.00000035</Error>
         <Fix>true</Fix>
@@ -827,21 +575,6 @@
         <Type>IsoSpin</Type>
         <Value>1</Value>
         <Projection>-1</Projection>
-      </QuantumNumber>
-      <QuantumNumber>
-        <Class>Int</Class>
-        <Type>Charm</Type>
-        <Value>0</Value>
-      </QuantumNumber>
-      <QuantumNumber>
-        <Class>Int</Class>
-        <Type>Strangeness</Type>
-        <Value>0</Value>
-      </QuantumNumber>
-      <QuantumNumber>
-        <Class>Int</Class>
-        <Type>BaryonNumber</Type>
-        <Value>0</Value>
       </QuantumNumber>
     </Particle>
     <Particle>
@@ -873,11 +606,6 @@
         <Type>CParity</Type>
         <Value>1</Value>
       </QuantumNumber>
-      <QuantumNumber>
-        <Class>Spin</Class>
-        <Type>IsoSpin</Type>
-        <Value>0</Value>
-      </QuantumNumber>
       <DecayInfo>
         <Type>relativisticBreitWigner</Type>
         <FormFactor>
@@ -905,7 +633,7 @@
       <Pid>113</Pid>
       <Parameter>
         <Type>Mass</Type>
-        <Name>Mass_rho770</Name>
+        <Name>Mass_rho(770)0</Name>
         <Value>0.77526</Value>
         <Error>0.00025</Error>
       </Parameter>
@@ -947,7 +675,7 @@
         </FormFactor>
         <Parameter>
           <Type>Width</Type>
-          <Name>Width_rho</Name>
+          <Name>Width_rho(770)0</Name>
           <Value>0.1491</Value>
         </Parameter>
         <Parameter>
@@ -965,7 +693,7 @@
       <Pid>213</Pid>
       <Parameter>
         <Type>Mass</Type>
-        <Name>Mass_rho770</Name>
+        <Name>Mass_rho(770)+</Name>
         <Value>0.77526</Value>
         <Error>0.00025</Error>
       </Parameter>
@@ -1002,7 +730,7 @@
         </FormFactor>
         <Parameter>
           <Type>Width</Type>
-          <Name>Width_rho</Name>
+          <Name>Width_rho(770)+</Name>
           <Value>0.1491</Value>
         </Parameter>
         <Parameter>
@@ -1020,7 +748,7 @@
       <Pid>-213</Pid>
       <Parameter>
         <Type>Mass</Type>
-        <Name>Mass_rho770</Name>
+        <Name>Mass_rho(770)-</Name>
         <Value>0.77526</Value>
         <Error>0.00025</Error>
       </Parameter>
@@ -1050,11 +778,6 @@
         <Value>1</Value>
         <Projection>-1</Projection>
       </QuantumNumber>
-      <QuantumNumber>
-        <Class>Int</Class>
-        <Type>Charm</Type>
-        <Value>0</Value>
-      </QuantumNumber>
       <DecayInfo>
         <Type>relativisticBreitWigner</Type>
         <FormFactor>
@@ -1062,7 +785,7 @@
         </FormFactor>
         <Parameter>
           <Type>Width</Type>
-          <Name>Width_rho</Name>
+          <Name>Width_rho(770)-</Name>
           <Value>0.1491</Value>
         </Parameter>
         <Parameter>
@@ -1080,7 +803,7 @@
       <Pid>223</Pid>
       <Parameter>
         <Type>Mass</Type>
-        <Name>Mass_omega782</Name>
+        <Name>Mass_omega(782)</Name>
         <Value>0.78265</Value>
         <Error>0.00012</Error>
       </Parameter>
@@ -1105,11 +828,6 @@
         <Value>-1</Value>
       </QuantumNumber>
       <QuantumNumber>
-        <Class>Spin</Class>
-        <Type>IsoSpin</Type>
-        <Value>0</Value>
-      </QuantumNumber>
-      <QuantumNumber>
         <Class>Int</Class>
         <Type>GParity</Type>
         <Value>-1</Value>
@@ -1121,7 +839,7 @@
         </FormFactor>
         <Parameter>
           <Type>Width</Type>
-          <Name>Width_omega782</Name>
+          <Name>Width_omega(782)</Name>
           <Value>0.000001491</Value>
         </Parameter>
         <Parameter>
@@ -1139,7 +857,7 @@
       <Pid>9010221</Pid>
       <Parameter>
         <Type>Mass</Type>
-        <Name>mass_f0980</Name>
+        <Name>Mass_f0(980)</Name>
         <Value>0.994</Value>
         <Error>0.001</Error>
         <Fix>true</Fix>
@@ -1165,11 +883,6 @@
         <Value>1</Value>
       </QuantumNumber>
       <QuantumNumber>
-        <Class>Spin</Class>
-        <Type>IsoSpin</Type>
-        <Value>0</Value>
-      </QuantumNumber>
-      <QuantumNumber>
         <Class>Int</Class>
         <Type>GParity</Type>
         <Value>1</Value>
@@ -1181,8 +894,8 @@
         </FormFactor>
         <Parameter>
           <Type>Width</Type>
-          <Name>width_f0980</Name>
-          <Value>0.070</Value>
+          <Name>Width_f0(980)</Name>
+          <Value>0.07</Value>
         </Parameter>
         <Parameter>
           <Type>MesonRadius</Type>
@@ -1199,7 +912,7 @@
       <Pid>9030221</Pid>
       <Parameter>
         <Type>Mass</Type>
-        <Name>mass_f01500</Name>
+        <Name>Mass_f0(1500)</Name>
         <Value>1.505</Value>
         <Error>0.006</Error>
         <Fix>true</Fix>
@@ -1236,7 +949,7 @@
         </FormFactor>
         <Parameter>
           <Type>Width</Type>
-          <Name>width_f01500</Name>
+          <Name>Width_f0(1500)</Name>
           <Value>0.109</Value>
         </Parameter>
         <Parameter>
@@ -1254,7 +967,7 @@
       <Pid>225</Pid>
       <Parameter>
         <Type>Mass</Type>
-        <Name>mass_f21270</Name>
+        <Name>Mass_f2(1270)</Name>
         <Value>1.2751</Value>
         <Error>0.0012</Error>
         <Fix>true</Fix>
@@ -1291,7 +1004,7 @@
         </FormFactor>
         <Parameter>
           <Type>Width</Type>
-          <Name>width_f21270</Name>
+          <Name>Width_f2(1270)</Name>
           <Value>0.185</Value>
         </Parameter>
         <Parameter>
@@ -1309,7 +1022,7 @@
       <Pid>9050225</Pid>
       <Parameter>
         <Type>Mass</Type>
-        <Name>mass_f21950</Name>
+        <Name>Mass_f2(1950)</Name>
         <Value>1.944</Value>
         <Error>0.012</Error>
         <Fix>true</Fix>
@@ -1346,7 +1059,7 @@
         </FormFactor>
         <Parameter>
           <Type>Width</Type>
-          <Name>width_f21950</Name>
+          <Name>Width_f2(1950)</Name>
           <Value>0.472</Value>
         </Parameter>
         <Parameter>
@@ -1364,7 +1077,7 @@
       <Pid>9000111</Pid>
       <Parameter>
         <Type>Mass</Type>
-        <Name>Mass_a0(980)</Name>
+        <Name>Mass_a0(980)0</Name>
         <Value>0.994</Value>
         <Error>0.001</Error>
         <Fix>true</Fix>
@@ -1390,15 +1103,15 @@
         <Value>1</Value>
       </QuantumNumber>
       <QuantumNumber>
+        <Class>Int</Class>
+        <Type>GParity</Type>
+        <Value>-1</Value>
+      </QuantumNumber>
+      <QuantumNumber>
         <Class>Spin</Class>
         <Type>IsoSpin</Type>
         <Value>1</Value>
         <Projection>0</Projection>
-      </QuantumNumber>
-      <QuantumNumber>
-        <Class>Int</Class>
-        <Type>GParity</Type>
-        <Value>-1</Value>
       </QuantumNumber>
       <DecayInfo>
         <Type>flatte</Type>
@@ -1468,15 +1181,15 @@
         <Value>+1</Value>
       </QuantumNumber>
       <QuantumNumber>
+        <Class>Int</Class>
+        <Type>GParity</Type>
+        <Value>-1</Value>
+      </QuantumNumber>
+      <QuantumNumber>
         <Class>Spin</Class>
         <Type>IsoSpin</Type>
         <Value>1</Value>
         <Projection>1</Projection>
-      </QuantumNumber>
-      <QuantumNumber>
-        <Class>Int</Class>
-        <Type>GParity</Type>
-        <Value>-1</Value>
       </QuantumNumber>
       <DecayInfo>
         <Type>flatte</Type>
@@ -1537,15 +1250,15 @@
         <Value>+1</Value>
       </QuantumNumber>
       <QuantumNumber>
+        <Class>Int</Class>
+        <Type>GParity</Type>
+        <Value>-1</Value>
+      </QuantumNumber>
+      <QuantumNumber>
         <Class>Spin</Class>
         <Type>IsoSpin</Type>
         <Value>1</Value>
         <Projection>-1</Projection>
-      </QuantumNumber>
-      <QuantumNumber>
-        <Class>Int</Class>
-        <Type>GParity</Type>
-        <Value>-1</Value>
       </QuantumNumber>
       <DecayInfo>
         <Type>flatte</Type>
@@ -1611,15 +1324,15 @@
         <Value>1</Value>
       </QuantumNumber>
       <QuantumNumber>
+        <Class>Int</Class>
+        <Type>GParity</Type>
+        <Value>-1</Value>
+      </QuantumNumber>
+      <QuantumNumber>
         <Class>Spin</Class>
         <Type>IsoSpin</Type>
         <Value>1</Value>
         <Projection>0</Projection>
-      </QuantumNumber>
-      <QuantumNumber>
-        <Class>Int</Class>
-        <Type>GParity</Type>
-        <Value>-1</Value>
       </QuantumNumber>
       <DecayInfo>
         <Type>relativisticBreitWigner</Type>
@@ -1628,7 +1341,7 @@
         </FormFactor>
         <Parameter>
           <Type>Width</Type>
-          <Name>Width_a2(1320)-</Name>
+          <Name>Width_a2(1320)0</Name>
           <Value>0.00107</Value>
           <Error>0.00005</Error>
           <Fix>true</Fix>
@@ -1674,15 +1387,15 @@
         <Value>1</Value>
       </QuantumNumber>
       <QuantumNumber>
+        <Class>Int</Class>
+        <Type>GParity</Type>
+        <Value>-1</Value>
+      </QuantumNumber>
+      <QuantumNumber>
         <Class>Spin</Class>
         <Type>IsoSpin</Type>
         <Value>1</Value>
         <Projection>1</Projection>
-      </QuantumNumber>
-      <QuantumNumber>
-        <Class>Int</Class>
-        <Type>GParity</Type>
-        <Value>-1</Value>
       </QuantumNumber>
       <DecayInfo>
         <Type>relativisticBreitWigner</Type>
@@ -1691,7 +1404,7 @@
         </FormFactor>
         <Parameter>
           <Type>Width</Type>
-          <Name>Width_a2(1320)-</Name>
+          <Name>Width_a2(1320)+</Name>
           <Value>0.00107</Value>
           <Error>0.00005</Error>
           <Fix>true</Fix>
@@ -1737,15 +1450,15 @@
         <Value>1</Value>
       </QuantumNumber>
       <QuantumNumber>
+        <Class>Int</Class>
+        <Type>GParity</Type>
+        <Value>-1</Value>
+      </QuantumNumber>
+      <QuantumNumber>
         <Class>Spin</Class>
         <Type>IsoSpin</Type>
         <Value>1</Value>
         <Projection>-1</Projection>
-      </QuantumNumber>
-      <QuantumNumber>
-        <Class>Int</Class>
-        <Type>GParity</Type>
-        <Value>-1</Value>
       </QuantumNumber>
       <DecayInfo>
         <Type>relativisticBreitWigner</Type>
@@ -1828,7 +1541,7 @@
       <Pid>-321</Pid>
       <Parameter>
         <Type>Mass</Type>
-        <Name>Mass_chargedKaon</Name>
+        <Name>Mass_K-</Name>
         <Value>0.493677</Value>
         <Fix>true</Fix>
       </Parameter>
@@ -1845,6 +1558,11 @@
       <QuantumNumber>
         <Class>Int</Class>
         <Type>Parity</Type>
+        <Value>-1</Value>
+      </QuantumNumber>
+      <QuantumNumber>
+        <Class>Int</Class>
+        <Type>Strangeness</Type>
         <Value>-1</Value>
       </QuantumNumber>
       <QuantumNumber>
@@ -1853,28 +1571,13 @@
         <Value>0.5</Value>
         <Projection>-0.5</Projection>
       </QuantumNumber>
-      <QuantumNumber>
-        <Class>Int</Class>
-        <Type>BaryonNumber</Type>
-        <Value>0</Value>
-      </QuantumNumber>
-      <QuantumNumber>
-        <Class>Int</Class>
-        <Type>Strangeness</Type>
-        <Value>-1</Value>
-      </QuantumNumber>
-      <QuantumNumber>
-        <Class>Int</Class>
-        <Type>Charm</Type>
-        <Value>0</Value>
-      </QuantumNumber>
     </Particle>
     <Particle>
       <Name>K+</Name>
       <Pid>321</Pid>
       <Parameter>
         <Type>Mass</Type>
-        <Name>Mass_chargedKaon</Name>
+        <Name>Mass_K+</Name>
         <Value>0.493677</Value>
         <Fix>true</Fix>
       </Parameter>
@@ -1894,25 +1597,15 @@
         <Value>-1</Value>
       </QuantumNumber>
       <QuantumNumber>
-        <Class>Spin</Class>
-        <Type>IsoSpin</Type>
-        <Value>0.5</Value>
-        <Projection>0.5</Projection>
-      </QuantumNumber>
-      <QuantumNumber>
-        <Class>Int</Class>
-        <Type>BaryonNumber</Type>
-        <Value>0</Value>
-      </QuantumNumber>
-      <QuantumNumber>
         <Class>Int</Class>
         <Type>Strangeness</Type>
         <Value>1</Value>
       </QuantumNumber>
       <QuantumNumber>
-        <Class>Int</Class>
-        <Type>Charm</Type>
-        <Value>0</Value>
+        <Class>Spin</Class>
+        <Type>IsoSpin</Type>
+        <Value>0.5</Value>
+        <Projection>0.5</Projection>
       </QuantumNumber>
     </Particle>
     <Particle>
@@ -1920,7 +1613,7 @@
       <Pid>310</Pid>
       <Parameter>
         <Type>Mass</Type>
-        <Name>Mass_neutralKaon</Name>
+        <Name>Mass_K_S0</Name>
         <Value>0.497614</Value>
         <Fix>true</Fix>
       </Parameter>
@@ -1945,28 +1638,13 @@
         <Value>0.5</Value>
         <Projection>0.0</Projection>
       </QuantumNumber>
-      <QuantumNumber>
-        <Class>Int</Class>
-        <Type>BaryonNumber</Type>
-        <Value>0</Value>
-      </QuantumNumber>
-      <QuantumNumber>
-        <Class>Int</Class>
-        <Type>Strangeness</Type>
-        <Value>0</Value>
-      </QuantumNumber>
-      <QuantumNumber>
-        <Class>Int</Class>
-        <Type>Charm</Type>
-        <Value>0</Value>
-      </QuantumNumber>
     </Particle>
     <Particle>
       <Name>K_L0</Name>
       <Pid>130</Pid>
       <Parameter>
         <Type>Mass</Type>
-        <Name>Mass_neutralKaon</Name>
+        <Name>Mass_K_L0</Name>
         <Value>0.497614</Value>
         <Fix>true</Fix>
       </Parameter>
@@ -1999,7 +1677,7 @@
       <Pid>411</Pid>
       <Parameter>
         <Type>Mass</Type>
-        <Name>Mass_chargedD</Name>
+        <Name>Mass_D+</Name>
         <Value>1.86958</Value>
         <Fix>true</Fix>
       </Parameter>
@@ -2019,15 +1697,15 @@
         <Value>-1</Value>
       </QuantumNumber>
       <QuantumNumber>
+        <Class>Int</Class>
+        <Type>Charm</Type>
+        <Value>1</Value>
+      </QuantumNumber>
+      <QuantumNumber>
         <Class>Spin</Class>
         <Type>IsoSpin</Type>
         <Value>0.5</Value>
         <Projection>0.5</Projection>
-      </QuantumNumber>
-      <QuantumNumber>
-        <Class>Int</Class>
-        <Type>Charm</Type>
-        <Value>1</Value>
       </QuantumNumber>
       <DecayInfo>
         <Type>relativisticBreitWigner</Type>
@@ -2036,7 +1714,7 @@
         </FormFactor>
         <Parameter>
           <Type>Width</Type>
-          <Name>Width_chargedD</Name>
+          <Name>Width_D+</Name>
           <Value>6.33E-13</Value>
           <Fix>true</Fix>
         </Parameter>
@@ -2055,7 +1733,7 @@
       <Pid>-411</Pid>
       <Parameter>
         <Type>Mass</Type>
-        <Name>Mass_chargedD</Name>
+        <Name>Mass_D-</Name>
         <Value>1.86958</Value>
         <Fix>true</Fix>
       </Parameter>
@@ -2075,15 +1753,15 @@
         <Value>-1</Value>
       </QuantumNumber>
       <QuantumNumber>
+        <Class>Int</Class>
+        <Type>Charm</Type>
+        <Value>-1</Value>
+      </QuantumNumber>
+      <QuantumNumber>
         <Class>Spin</Class>
         <Type>IsoSpin</Type>
         <Value>0.5</Value>
         <Projection>-0.5</Projection>
-      </QuantumNumber>
-      <QuantumNumber>
-        <Class>Int</Class>
-        <Type>Charm</Type>
-        <Value>-1</Value>
       </QuantumNumber>
       <DecayInfo>
         <Type>relativisticBreitWigner</Type>
@@ -2092,7 +1770,7 @@
         </FormFactor>
         <Parameter>
           <Type>Width</Type>
-          <Name>Width_chargedD</Name>
+          <Name>Width_D-</Name>
           <Value>6.33E-13</Value>
           <Fix>true</Fix>
         </Parameter>
@@ -2111,7 +1789,7 @@
       <Pid>421</Pid>
       <Parameter>
         <Type>Mass</Type>
-        <Name>Mass_neutralD</Name>
+        <Name>Mass_D0</Name>
         <Value>1.86483</Value>
         <Fix>true</Fix>
       </Parameter>
@@ -2131,25 +1809,15 @@
         <Value>-1</Value>
       </QuantumNumber>
       <QuantumNumber>
-        <Class>Spin</Class>
-        <Type>IsoSpin</Type>
-        <Value>0.5</Value>
-        <Projection>-0.5</Projection>
-      </QuantumNumber>
-      <QuantumNumber>
         <Class>Int</Class>
         <Type>Charm</Type>
         <Value>1</Value>
       </QuantumNumber>
       <QuantumNumber>
-        <Class>Int</Class>
-        <Type>Strangeness</Type>
-        <Value>0</Value>
-      </QuantumNumber>
-      <QuantumNumber>
-        <Class>Int</Class>
-        <Type>BaryonNumber</Type>
-        <Value>0</Value>
+        <Class>Spin</Class>
+        <Type>IsoSpin</Type>
+        <Value>0.5</Value>
+        <Projection>-0.5</Projection>
       </QuantumNumber>
       <DecayInfo>
         <Type>relativisticBreitWigner</Type>
@@ -2158,7 +1826,7 @@
         </FormFactor>
         <Parameter>
           <Type>Width</Type>
-          <Name>Width_neutralD</Name>
+          <Name>Width_D0</Name>
           <Value>1.605E-12</Value>
           <Fix>true</Fix>
         </Parameter>
@@ -2177,7 +1845,7 @@
       <Pid>-421</Pid>
       <Parameter>
         <Type>Mass</Type>
-        <Name>Mass_neutralD</Name>
+        <Name>Mass_D0bar</Name>
         <Value>1.86483</Value>
         <Fix>true</Fix>
       </Parameter>
@@ -2197,25 +1865,15 @@
         <Value>-1</Value>
       </QuantumNumber>
       <QuantumNumber>
-        <Class>Spin</Class>
-        <Type>IsoSpin</Type>
-        <Value>0.5</Value>
-        <Projection>0.5</Projection>
-      </QuantumNumber>
-      <QuantumNumber>
         <Class>Int</Class>
         <Type>Charm</Type>
         <Value>-1</Value>
       </QuantumNumber>
       <QuantumNumber>
-        <Class>Int</Class>
-        <Type>Strangeness</Type>
-        <Value>0</Value>
-      </QuantumNumber>
-      <QuantumNumber>
-        <Class>Int</Class>
-        <Type>BaryonNumber</Type>
-        <Value>0</Value>
+        <Class>Spin</Class>
+        <Type>IsoSpin</Type>
+        <Value>0.5</Value>
+        <Projection>0.5</Projection>
       </QuantumNumber>
       <DecayInfo>
         <Type>relativisticBreitWigner</Type>
@@ -2224,7 +1882,7 @@
         </FormFactor>
         <Parameter>
           <Type>Width</Type>
-          <Name>Width_neutralD</Name>
+          <Name>Width_D0bar</Name>
           <Value>1.605E-12</Value>
           <Fix>true</Fix>
         </Parameter>
@@ -2263,20 +1921,15 @@
         <Value>-1</Value>
       </QuantumNumber>
       <QuantumNumber>
-        <Class>Spin</Class>
-        <Type>IsoSpin</Type>
-        <Value>0.5</Value>
-        <Projection>-0.5</Projection>
-      </QuantumNumber>
-      <QuantumNumber>
         <Class>Int</Class>
         <Type>Charm</Type>
         <Value>1</Value>
       </QuantumNumber>
       <QuantumNumber>
-        <Class>Int</Class>
-        <Type>BaryonNumber</Type>
-        <Value>0</Value>
+        <Class>Spin</Class>
+        <Type>IsoSpin</Type>
+        <Value>0.5</Value>
+        <Projection>-0.5</Projection>
       </QuantumNumber>
       <DecayInfo>
         <Type>relativisticBreitWigner</Type>
@@ -2324,20 +1977,15 @@
         <Value>-1</Value>
       </QuantumNumber>
       <QuantumNumber>
-        <Class>Spin</Class>
-        <Type>IsoSpin</Type>
-        <Value>0.5</Value>
-        <Projection>0.5</Projection>
-      </QuantumNumber>
-      <QuantumNumber>
         <Class>Int</Class>
         <Type>Charm</Type>
         <Value>-1</Value>
       </QuantumNumber>
       <QuantumNumber>
-        <Class>Int</Class>
-        <Type>BaryonNumber</Type>
-        <Value>0</Value>
+        <Class>Spin</Class>
+        <Type>IsoSpin</Type>
+        <Value>0.5</Value>
+        <Projection>0.5</Projection>
       </QuantumNumber>
       <DecayInfo>
         <Type>relativisticBreitWigner</Type>
@@ -2385,20 +2033,15 @@
         <Value>-1</Value>
       </QuantumNumber>
       <QuantumNumber>
-        <Class>Spin</Class>
-        <Type>IsoSpin</Type>
-        <Value>0.5</Value>
-        <Projection>-0.5</Projection>
-      </QuantumNumber>
-      <QuantumNumber>
         <Class>Int</Class>
         <Type>Charm</Type>
         <Value>-1</Value>
       </QuantumNumber>
       <QuantumNumber>
-        <Class>Int</Class>
-        <Type>BaryonNumber</Type>
-        <Value>0</Value>
+        <Class>Spin</Class>
+        <Type>IsoSpin</Type>
+        <Value>0.5</Value>
+        <Projection>-0.5</Projection>
       </QuantumNumber>
       <DecayInfo>
         <Type>relativisticBreitWigner</Type>
@@ -2446,20 +2089,15 @@
         <Value>-1</Value>
       </QuantumNumber>
       <QuantumNumber>
-        <Class>Spin</Class>
-        <Type>IsoSpin</Type>
-        <Value>0.5</Value>
-        <Projection>0.5</Projection>
-      </QuantumNumber>
-      <QuantumNumber>
         <Class>Int</Class>
         <Type>Charm</Type>
         <Value>1</Value>
       </QuantumNumber>
       <QuantumNumber>
-        <Class>Int</Class>
-        <Type>BaryonNumber</Type>
-        <Value>0</Value>
+        <Class>Spin</Class>
+        <Type>IsoSpin</Type>
+        <Value>0.5</Value>
+        <Projection>0.5</Projection>
       </QuantumNumber>
       <DecayInfo>
         <Type>relativisticBreitWigner</Type>
@@ -2507,20 +2145,15 @@
         <Value>1</Value>
       </QuantumNumber>
       <QuantumNumber>
-        <Class>Spin</Class>
-        <Type>IsoSpin</Type>
-        <Value>0.5</Value>
-        <Projection>-0.5</Projection>
-      </QuantumNumber>
-      <QuantumNumber>
         <Class>Int</Class>
         <Type>Charm</Type>
         <Value>1</Value>
       </QuantumNumber>
       <QuantumNumber>
-        <Class>Int</Class>
-        <Type>BaryonNumber</Type>
-        <Value>0</Value>
+        <Class>Spin</Class>
+        <Type>IsoSpin</Type>
+        <Value>0.5</Value>
+        <Projection>-0.5</Projection>
       </QuantumNumber>
       <DecayInfo>
         <Type>relativisticBreitWigner</Type>
@@ -2549,7 +2182,7 @@
       <Parameter>
         <Type>Mass</Type>
         <Name>Mass_XX</Name>
-        <Value>4.100</Value>
+        <Value>4.1</Value>
         <Fix>true</Fix>
       </Parameter>
       <QuantumNumber>
@@ -2573,19 +2206,14 @@
         <Value>1</Value>
         <Projection>-1</Projection>
       </QuantumNumber>
-      <QuantumNumber>
-        <Class>Int</Class>
-        <Type>BaryonNumber</Type>
-        <Value>0</Value>
-      </QuantumNumber>
     </Particle>
     <Particle>
       <Name>J/psi</Name>
       <Pid>443</Pid>
       <Parameter>
         <Type>Mass</Type>
-        <Name>Mass_jpsi</Name>
-        <Value>3.096900</Value>
+        <Name>Mass_J/psi</Name>
+        <Value>3.0969</Value>
         <Fix>true</Fix>
       </Parameter>
       <QuantumNumber>
@@ -2613,27 +2241,6 @@
         <Type>GParity</Type>
         <Value>-1</Value>
       </QuantumNumber>
-      <QuantumNumber>
-        <Class>Spin</Class>
-        <Type>IsoSpin</Type>
-        <Value>0</Value>
-        <Projection>0</Projection>
-      </QuantumNumber>
-      <QuantumNumber>
-        <Class>Int</Class>
-        <Type>BaryonNumber</Type>
-        <Value>0</Value>
-      </QuantumNumber>
-      <QuantumNumber>
-        <Class>Int</Class>
-        <Type>Charm</Type>
-        <Value>0</Value>
-      </QuantumNumber>
-      <QuantumNumber>
-        <Class>Int</Class>
-        <Type>Strangeness</Type>
-        <Value>0</Value>
-      </QuantumNumber>
       <DecayInfo>
         <Type>relativisticBreitWigner</Type>
         <FormFactor>
@@ -2641,7 +2248,7 @@
         </FormFactor>
         <Parameter>
           <Type>Width</Type>
-          <Name>Width_jpsi</Name>
+          <Name>Width_J/psi</Name>
           <Value>9.29E-05</Value>
           <Fix>true</Fix>
         </Parameter>
@@ -2684,21 +2291,6 @@
         <Type>CParity</Type>
         <Value>-1</Value>
       </QuantumNumber>
-      <QuantumNumber>
-        <Class>Int</Class>
-        <Type>BaryonNumber</Type>
-        <Value>0</Value>
-      </QuantumNumber>
-      <QuantumNumber>
-        <Class>Int</Class>
-        <Type>Charm</Type>
-        <Value>0</Value>
-      </QuantumNumber>
-      <QuantumNumber>
-        <Class>Int</Class>
-        <Type>Strangeness</Type>
-        <Value>0</Value>
-      </QuantumNumber>
       <DecayInfo>
         <Type>relativisticBreitWigner</Type>
         <FormFactor>
@@ -2725,8 +2317,8 @@
       <Pid>1234</Pid>
       <Parameter>
         <Type>Mass</Type>
-        <Name>Mass_chic1</Name>
-        <Value>3.510</Value>
+        <Name>Mass_Chic1</Name>
+        <Value>3.51</Value>
         <Fix>true</Fix>
       </Parameter>
       <QuantumNumber>
@@ -2754,26 +2346,6 @@
         <Type>GParity</Type>
         <Value>1</Value>
       </QuantumNumber>
-      <QuantumNumber>
-        <Class>Spin</Class>
-        <Type>IsoSpin</Type>
-        <Value>0</Value>
-      </QuantumNumber>
-      <QuantumNumber>
-        <Class>Int</Class>
-        <Type>BaryonNumber</Type>
-        <Value>0</Value>
-      </QuantumNumber>
-      <QuantumNumber>
-        <Class>Int</Class>
-        <Type>Charm</Type>
-        <Value>0</Value>
-      </QuantumNumber>
-      <QuantumNumber>
-        <Class>Int</Class>
-        <Type>Strangeness</Type>
-        <Value>0</Value>
-      </QuantumNumber>
       <DecayInfo>
         <Type>relativisticBreitWigner</Type>
         <FormFactor>
@@ -2781,7 +2353,7 @@
         </FormFactor>
         <Parameter>
           <Type>Width</Type>
-          <Name>Width_chic1</Name>
+          <Name>Width_Chic1</Name>
           <Value>0.00084</Value>
           <Fix>true</Fix>
         </Parameter>
@@ -2803,7 +2375,7 @@
       <Pid>2212</Pid>
       <Parameter>
         <Type>Mass</Type>
-        <Name>Mass_proton</Name>
+        <Name>Mass_p</Name>
         <Value>0.938272081</Value>
         <Fix>true</Fix>
       </Parameter>
@@ -2823,25 +2395,15 @@
         <Value>1</Value>
       </QuantumNumber>
       <QuantumNumber>
-        <Class>Spin</Class>
-        <Type>IsoSpin</Type>
-        <Value>0.5</Value>
-        <Projection>0.5</Projection>
-      </QuantumNumber>
-      <QuantumNumber>
         <Class>Int</Class>
         <Type>BaryonNumber</Type>
         <Value>1</Value>
       </QuantumNumber>
       <QuantumNumber>
-        <Class>Int</Class>
-        <Type>Charm</Type>
-        <Value>0</Value>
-      </QuantumNumber>
-      <QuantumNumber>
-        <Class>Int</Class>
-        <Type>Strangeness</Type>
-        <Value>0</Value>
+        <Class>Spin</Class>
+        <Type>IsoSpin</Type>
+        <Value>0.5</Value>
+        <Projection>0.5</Projection>
       </QuantumNumber>
     </Particle>
     <Particle>
@@ -2849,7 +2411,7 @@
       <Pid>-2212</Pid>
       <Parameter>
         <Type>Mass</Type>
-        <Name>Mass_antiproton</Name>
+        <Name>Mass_pbar</Name>
         <Value>0.938272081</Value>
         <Fix>true</Fix>
       </Parameter>
@@ -2869,25 +2431,15 @@
         <Value>-1</Value>
       </QuantumNumber>
       <QuantumNumber>
-        <Class>Spin</Class>
-        <Type>IsoSpin</Type>
-        <Value>0.5</Value>
-        <Projection>-0.5</Projection>
-      </QuantumNumber>
-      <QuantumNumber>
         <Class>Int</Class>
         <Type>BaryonNumber</Type>
         <Value>-1</Value>
       </QuantumNumber>
       <QuantumNumber>
-        <Class>Int</Class>
-        <Type>Charm</Type>
-        <Value>0</Value>
-      </QuantumNumber>
-      <QuantumNumber>
-        <Class>Int</Class>
-        <Type>Strangeness</Type>
-        <Value>0</Value>
+        <Class>Spin</Class>
+        <Type>IsoSpin</Type>
+        <Value>0.5</Value>
+        <Projection>-0.5</Projection>
       </QuantumNumber>
     </Particle>
     <Particle>
@@ -2895,7 +2447,7 @@
       <Pid>2112</Pid>
       <Parameter>
         <Type>Mass</Type>
-        <Name>Mass_neutron</Name>
+        <Name>Mass_n</Name>
         <Value>0.939565413</Value>
         <Fix>true</Fix>
       </Parameter>
@@ -2912,6 +2464,11 @@
       <QuantumNumber>
         <Class>Int</Class>
         <Type>Parity</Type>
+        <Value>1</Value>
+      </QuantumNumber>
+      <QuantumNumber>
+        <Class>Int</Class>
+        <Type>BaryonNumber</Type>
         <Value>1</Value>
       </QuantumNumber>
       <QuantumNumber>
@@ -2920,28 +2477,13 @@
         <Value>0.5</Value>
         <Projection>-0.5</Projection>
       </QuantumNumber>
-      <QuantumNumber>
-        <Class>Int</Class>
-        <Type>BaryonNumber</Type>
-        <Value>1</Value>
-      </QuantumNumber>
-      <QuantumNumber>
-        <Class>Int</Class>
-        <Type>Charm</Type>
-        <Value>0</Value>
-      </QuantumNumber>
-      <QuantumNumber>
-        <Class>Int</Class>
-        <Type>Strangeness</Type>
-        <Value>0</Value>
-      </QuantumNumber>
     </Particle>
     <Particle>
       <Name>nbar</Name>
       <Pid>2112</Pid>
       <Parameter>
         <Type>Mass</Type>
-        <Name>Mass_antineutron</Name>
+        <Name>Mass_nbar</Name>
         <Value>0.939565413</Value>
         <Fix>true</Fix>
       </Parameter>
@@ -2961,25 +2503,15 @@
         <Value>-1</Value>
       </QuantumNumber>
       <QuantumNumber>
-        <Class>Spin</Class>
-        <Type>IsoSpin</Type>
-        <Value>0.5</Value>
-        <Projection>0.5</Projection>
-      </QuantumNumber>
-      <QuantumNumber>
         <Class>Int</Class>
         <Type>BaryonNumber</Type>
         <Value>-1</Value>
       </QuantumNumber>
       <QuantumNumber>
-        <Class>Int</Class>
-        <Type>Charm</Type>
-        <Value>0</Value>
-      </QuantumNumber>
-      <QuantumNumber>
-        <Class>Int</Class>
-        <Type>Strangeness</Type>
-        <Value>0</Value>
+        <Class>Spin</Class>
+        <Type>IsoSpin</Type>
+        <Value>0.5</Value>
+        <Projection>0.5</Projection>
       </QuantumNumber>
     </Particle>
     <Particle>
@@ -2988,7 +2520,7 @@
       <Parameter>
         <Type>Mass</Type>
         <Name>Mass_N(1650)+</Name>
-        <Value>1.650</Value>
+        <Value>1.65</Value>
         <Fix>true</Fix>
       </Parameter>
       <QuantumNumber>
@@ -3007,40 +2539,15 @@
         <Value>-1</Value>
       </QuantumNumber>
       <QuantumNumber>
-        <Class>Spin</Class>
-        <Type>IsoSpin</Type>
-        <Value>0.5</Value>
-        <Projection>0.5</Projection>
-      </QuantumNumber>
-      <QuantumNumber>
         <Class>Int</Class>
         <Type>BaryonNumber</Type>
         <Value>1</Value>
       </QuantumNumber>
       <QuantumNumber>
-        <Class>Int</Class>
-        <Type>Charm</Type>
-        <Value>0</Value>
-      </QuantumNumber>
-      <QuantumNumber>
-        <Class>Int</Class>
-        <Type>Strangeness</Type>
-        <Value>0</Value>
-      </QuantumNumber>
-      <QuantumNumber>
-        <Class>Int</Class>
-        <Type>ElectronLN</Type>
-        <Value>0</Value>
-      </QuantumNumber>
-      <QuantumNumber>
-        <Class>Int</Class>
-        <Type>MuonLN</Type>
-        <Value>0</Value>
-      </QuantumNumber>
-      <QuantumNumber>
-        <Class>Int</Class>
-        <Type>TauLN</Type>
-        <Value>0</Value>
+        <Class>Spin</Class>
+        <Type>IsoSpin</Type>
+        <Value>0.5</Value>
+        <Projection>0.5</Projection>
       </QuantumNumber>
       <DecayInfo>
         <Type>relativisticBreitWigner</Type>
@@ -3067,7 +2574,7 @@
       <Parameter>
         <Type>Mass</Type>
         <Name>Mass_N(1650)-</Name>
-        <Value>1.650</Value>
+        <Value>1.65</Value>
         <Fix>true</Fix>
       </Parameter>
       <QuantumNumber>
@@ -3086,25 +2593,15 @@
         <Value>1</Value>
       </QuantumNumber>
       <QuantumNumber>
-        <Class>Spin</Class>
-        <Type>IsoSpin</Type>
-        <Value>0.5</Value>
-        <Projection>-0.5</Projection>
-      </QuantumNumber>
-      <QuantumNumber>
         <Class>Int</Class>
         <Type>BaryonNumber</Type>
         <Value>-1</Value>
       </QuantumNumber>
       <QuantumNumber>
-        <Class>Int</Class>
-        <Type>Charm</Type>
-        <Value>0</Value>
-      </QuantumNumber>
-      <QuantumNumber>
-        <Class>Int</Class>
-        <Type>Strangeness</Type>
-        <Value>0</Value>
+        <Class>Spin</Class>
+        <Type>IsoSpin</Type>
+        <Value>0.5</Value>
+        <Projection>-0.5</Projection>
       </QuantumNumber>
       <DecayInfo>
         <Type>relativisticBreitWigner</Type>
@@ -3150,25 +2647,15 @@
         <Value>1</Value>
       </QuantumNumber>
       <QuantumNumber>
-        <Class>Spin</Class>
-        <Type>IsoSpin</Type>
-        <Value>1.5</Value>
-        <Projection>1.5</Projection>
-      </QuantumNumber>
-      <QuantumNumber>
         <Class>Int</Class>
         <Type>BaryonNumber</Type>
         <Value>1</Value>
       </QuantumNumber>
       <QuantumNumber>
-        <Class>Int</Class>
-        <Type>Charm</Type>
-        <Value>0</Value>
-      </QuantumNumber>
-      <QuantumNumber>
-        <Class>Int</Class>
-        <Type>Strangeness</Type>
-        <Value>0</Value>
+        <Class>Spin</Class>
+        <Type>IsoSpin</Type>
+        <Value>1.5</Value>
+        <Projection>1.5</Projection>
       </QuantumNumber>
     </Particle>
     <Particle>
@@ -3196,25 +2683,15 @@
         <Value>1</Value>
       </QuantumNumber>
       <QuantumNumber>
-        <Class>Spin</Class>
-        <Type>IsoSpin</Type>
-        <Value>1.5</Value>
-        <Projection>0.5</Projection>
-      </QuantumNumber>
-      <QuantumNumber>
         <Class>Int</Class>
         <Type>BaryonNumber</Type>
         <Value>1</Value>
       </QuantumNumber>
       <QuantumNumber>
-        <Class>Int</Class>
-        <Type>Charm</Type>
-        <Value>0</Value>
-      </QuantumNumber>
-      <QuantumNumber>
-        <Class>Int</Class>
-        <Type>Strangeness</Type>
-        <Value>0</Value>
+        <Class>Spin</Class>
+        <Type>IsoSpin</Type>
+        <Value>1.5</Value>
+        <Projection>0.5</Projection>
       </QuantumNumber>
     </Particle>
     <Particle>
@@ -3242,25 +2719,15 @@
         <Value>1</Value>
       </QuantumNumber>
       <QuantumNumber>
-        <Class>Spin</Class>
-        <Type>IsoSpin</Type>
-        <Value>1.5</Value>
-        <Projection>-0.5</Projection>
-      </QuantumNumber>
-      <QuantumNumber>
         <Class>Int</Class>
         <Type>BaryonNumber</Type>
         <Value>1</Value>
       </QuantumNumber>
       <QuantumNumber>
-        <Class>Int</Class>
-        <Type>Charm</Type>
-        <Value>0</Value>
-      </QuantumNumber>
-      <QuantumNumber>
-        <Class>Int</Class>
-        <Type>Strangeness</Type>
-        <Value>0</Value>
+        <Class>Spin</Class>
+        <Type>IsoSpin</Type>
+        <Value>1.5</Value>
+        <Projection>-0.5</Projection>
       </QuantumNumber>
     </Particle>
     <Particle>
@@ -3288,25 +2755,15 @@
         <Value>1</Value>
       </QuantumNumber>
       <QuantumNumber>
-        <Class>Spin</Class>
-        <Type>IsoSpin</Type>
-        <Value>1.5</Value>
-        <Projection>-1.5</Projection>
-      </QuantumNumber>
-      <QuantumNumber>
         <Class>Int</Class>
         <Type>BaryonNumber</Type>
         <Value>1</Value>
       </QuantumNumber>
       <QuantumNumber>
-        <Class>Int</Class>
-        <Type>Charm</Type>
-        <Value>0</Value>
-      </QuantumNumber>
-      <QuantumNumber>
-        <Class>Int</Class>
-        <Type>Strangeness</Type>
-        <Value>0</Value>
+        <Class>Spin</Class>
+        <Type>IsoSpin</Type>
+        <Value>1.5</Value>
+        <Projection>-1.5</Projection>
       </QuantumNumber>
     </Particle>
 
@@ -3336,24 +2793,14 @@
         <Value>1</Value>
       </QuantumNumber>
       <QuantumNumber>
-        <Class>Spin</Class>
-        <Type>IsoSpin</Type>
-        <Value>0.0</Value>
+        <Class>Int</Class>
+        <Type>Strangeness</Type>
+        <Value>-1</Value>
       </QuantumNumber>
       <QuantumNumber>
         <Class>Int</Class>
         <Type>BaryonNumber</Type>
         <Value>1</Value>
-      </QuantumNumber>
-      <QuantumNumber>
-        <Class>Int</Class>
-        <Type>Charm</Type>
-        <Value>0</Value>
-      </QuantumNumber>
-      <QuantumNumber>
-        <Class>Int</Class>
-        <Type>Strangeness</Type>
-        <Value>-1</Value>
       </QuantumNumber>
     </Particle>
     <Particle>
@@ -3361,7 +2808,7 @@
       <Pid>-3122</Pid>
       <Parameter>
         <Type>Mass</Type>
-        <Name>Mass_antilambda</Name>
+        <Name>Mass_lambdabar</Name>
         <Value>1.115683</Value>
         <Fix>true</Fix>
       </Parameter>
@@ -3381,24 +2828,14 @@
         <Value>-1</Value>
       </QuantumNumber>
       <QuantumNumber>
-        <Class>Spin</Class>
-        <Type>IsoSpin</Type>
-        <Value>0.0</Value>
+        <Class>Int</Class>
+        <Type>Strangeness</Type>
+        <Value>1</Value>
       </QuantumNumber>
       <QuantumNumber>
         <Class>Int</Class>
         <Type>BaryonNumber</Type>
         <Value>-1</Value>
-      </QuantumNumber>
-      <QuantumNumber>
-        <Class>Int</Class>
-        <Type>Charm</Type>
-        <Value>0</Value>
-      </QuantumNumber>
-      <QuantumNumber>
-        <Class>Int</Class>
-        <Type>Strangeness</Type>
-        <Value>1</Value>
       </QuantumNumber>
     </Particle>
     <Particle>
@@ -3426,10 +2863,9 @@
         <Value>1</Value>
       </QuantumNumber>
       <QuantumNumber>
-        <Class>Spin</Class>
-        <Type>IsoSpin</Type>
-        <Value>1.0</Value>
-        <Projection>0.0</Projection>
+        <Class>Int</Class>
+        <Type>Strangeness</Type>
+        <Value>-1</Value>
       </QuantumNumber>
       <QuantumNumber>
         <Class>Int</Class>
@@ -3437,14 +2873,10 @@
         <Value>1</Value>
       </QuantumNumber>
       <QuantumNumber>
-        <Class>Int</Class>
-        <Type>Charm</Type>
-        <Value>0</Value>
-      </QuantumNumber>
-      <QuantumNumber>
-        <Class>Int</Class>
-        <Type>Strangeness</Type>
-        <Value>-1</Value>
+        <Class>Spin</Class>
+        <Type>IsoSpin</Type>
+        <Value>1.0</Value>
+        <Projection>0.0</Projection>
       </QuantumNumber>
       <DecayInfo>
         <Type>relativisticBreitWigner</Type>
@@ -3453,7 +2885,7 @@
         </FormFactor>
         <Parameter>
           <Type>Width</Type>
-          <Name>Width_chic1</Name>
+          <Name>Width_sigma0</Name>
           <Value>0.0000089</Value>
           <Fix>true</Fix>
         </Parameter>
@@ -3484,10 +2916,9 @@
         <Value>1</Value>
       </QuantumNumber>
       <QuantumNumber>
-        <Class>Spin</Class>
-        <Type>IsoSpin</Type>
-        <Value>1.0</Value>
-        <Projection>1.0</Projection>
+        <Class>Int</Class>
+        <Type>Strangeness</Type>
+        <Value>-1</Value>
       </QuantumNumber>
       <QuantumNumber>
         <Class>Int</Class>
@@ -3495,14 +2926,10 @@
         <Value>1</Value>
       </QuantumNumber>
       <QuantumNumber>
-        <Class>Int</Class>
-        <Type>Charm</Type>
-        <Value>0</Value>
-      </QuantumNumber>
-      <QuantumNumber>
-        <Class>Int</Class>
-        <Type>Strangeness</Type>
-        <Value>-1</Value>
+        <Class>Spin</Class>
+        <Type>IsoSpin</Type>
+        <Value>1.0</Value>
+        <Projection>1.0</Projection>
       </QuantumNumber>
     </Particle>
     <Particle>
@@ -3530,10 +2957,9 @@
         <Value>1</Value>
       </QuantumNumber>
       <QuantumNumber>
-        <Class>Spin</Class>
-        <Type>IsoSpin</Type>
-        <Value>1.0</Value>
-        <Projection>-1.0</Projection>
+        <Class>Int</Class>
+        <Type>Strangeness</Type>
+        <Value>-1</Value>
       </QuantumNumber>
       <QuantumNumber>
         <Class>Int</Class>
@@ -3541,14 +2967,10 @@
         <Value>1</Value>
       </QuantumNumber>
       <QuantumNumber>
-        <Class>Int</Class>
-        <Type>Charm</Type>
-        <Value>0</Value>
-      </QuantumNumber>
-      <QuantumNumber>
-        <Class>Int</Class>
-        <Type>Strangeness</Type>
-        <Value>-1</Value>
+        <Class>Spin</Class>
+        <Type>IsoSpin</Type>
+        <Value>1.0</Value>
+        <Projection>-1.0</Projection>
       </QuantumNumber>
     </Particle>
     <Particle>
@@ -3556,7 +2978,7 @@
       <Pid>3322</Pid>
       <Parameter>
         <Type>Mass</Type>
-        <Name>Mass_xi0</Name>
+        <Name>Mass_Xi0</Name>
         <Value>1.31486</Value>
         <Fix>true</Fix>
       </Parameter>
@@ -3576,10 +2998,9 @@
         <Value>1</Value>
       </QuantumNumber>
       <QuantumNumber>
-        <Class>Spin</Class>
-        <Type>IsoSpin</Type>
-        <Value>0.5</Value>
-        <Projection>0.5</Projection>
+        <Class>Int</Class>
+        <Type>Strangeness</Type>
+        <Value>-2</Value>
       </QuantumNumber>
       <QuantumNumber>
         <Class>Int</Class>
@@ -3587,14 +3008,10 @@
         <Value>1</Value>
       </QuantumNumber>
       <QuantumNumber>
-        <Class>Int</Class>
-        <Type>Charm</Type>
-        <Value>0</Value>
-      </QuantumNumber>
-      <QuantumNumber>
-        <Class>Int</Class>
-        <Type>Strangeness</Type>
-        <Value>-2</Value>
+        <Class>Spin</Class>
+        <Type>IsoSpin</Type>
+        <Value>0.5</Value>
+        <Projection>0.5</Projection>
       </QuantumNumber>
     </Particle>
     <Particle>
@@ -3602,7 +3019,7 @@
       <Pid>3312</Pid>
       <Parameter>
         <Type>Mass</Type>
-        <Name>Mass_xi-</Name>
+        <Name>Mass_Xi-</Name>
         <Value>1.32171</Value>
         <Fix>true</Fix>
       </Parameter>
@@ -3622,10 +3039,9 @@
         <Value>1</Value>
       </QuantumNumber>
       <QuantumNumber>
-        <Class>Spin</Class>
-        <Type>IsoSpin</Type>
-        <Value>1.0</Value>
-        <Projection>-0.5</Projection>
+        <Class>Int</Class>
+        <Type>Strangeness</Type>
+        <Value>-2</Value>
       </QuantumNumber>
       <QuantumNumber>
         <Class>Int</Class>
@@ -3633,14 +3049,10 @@
         <Value>1</Value>
       </QuantumNumber>
       <QuantumNumber>
-        <Class>Int</Class>
-        <Type>Charm</Type>
-        <Value>0</Value>
-      </QuantumNumber>
-      <QuantumNumber>
-        <Class>Int</Class>
-        <Type>Strangeness</Type>
-        <Value>-2</Value>
+        <Class>Spin</Class>
+        <Type>IsoSpin</Type>
+        <Value>1.0</Value>
+        <Projection>-0.5</Projection>
       </QuantumNumber>
     </Particle>
   </ParticleList>

--- a/expertsystem/schemas/yaml/particle-list.json
+++ b/expertsystem/schemas/yaml/particle-list.json
@@ -26,7 +26,7 @@
       "type": "object",
       "required": ["Charge", "Spin"],
       "properties": {
-        "Charge": { "type": "number" },
+        "Charge": { "type": "integer" },
         "Spin": { "type": "number" },
         "Parity": { "enum": [-1, 1] },
         "CParity": { "enum": [-1, 1] },

--- a/expertsystem/schemas/yaml/particle-list.json
+++ b/expertsystem/schemas/yaml/particle-list.json
@@ -27,7 +27,7 @@
       "required": ["Charge", "Spin"],
       "properties": {
         "Charge": { "type": "integer" },
-        "Spin": { "type": "number" },
+        "Spin": { "type": "number", "multipleOf": 0.5 },
         "Parity": { "enum": [-1, 1] },
         "CParity": { "enum": [-1, 1] },
         "GParity": { "enum": [-1, 1] },

--- a/expertsystem/state/particle.py
+++ b/expertsystem/state/particle.py
@@ -18,12 +18,7 @@ from typing import (
 
 from numpy import arange
 
-import xmltodict
-
 from expertsystem import io
-from expertsystem.io import (
-    _get_file_extension,
-)  # pylint: disable=protected-access
 from expertsystem.topology.graph import (
     get_final_state_edges,
     get_initial_state_edges,
@@ -304,53 +299,13 @@ def load_particles(filename: str) -> None:
         particle database, the one in the particle database will be
         overwritten.
     """
-    file_extension = _get_file_extension(filename)
-    if file_extension == "xml":
-        _load_particles_from_xml(filename)
-    if file_extension in ["yaml", "yml"]:
-        _load_particles_from_yaml(filename)
+    particle_collection = io.load_particle_collection(filename)
+    new_entries = io.xml.object_to_dict(particle_collection)
+    DATABASE.update(new_entries)
 
 
 def write_particle_database(filename: str) -> None:
     """Write particle database instance to human readable format."""
-    file_extension = _get_file_extension(filename)
-    if file_extension == "xml":
-        _write_particle_database_to_xml(filename)
-    if file_extension in ["yaml", "yml"]:
-        _write_particle_database_to_yaml(filename)
-
-
-def _load_particles_from_xml(file_path: str) -> None:
-    def to_dict(input_ordered_dict: OrderedDict) -> dict:
-        """Convert nested `OrderedDict` to a nested `dict`."""
-        return json.loads(json.dumps(input_ordered_dict))
-
-    name_label = Labels.Name.name
-    with open(file_path, "rb") as xmlfile:
-        full_dict = xmltodict.parse(xmlfile)
-        full_dict = full_dict.get("root", full_dict)
-    for particle_definition in full_dict["ParticleList"]["Particle"]:
-        particle_name = particle_definition[name_label]
-        DATABASE[particle_name] = to_dict(particle_definition)
-
-
-def _write_particle_database_to_xml(file_path: str) -> None:
-    entries = list(DATABASE.values())
-    particle_dict = {"ParticleList": {"Particle": entries}}
-    xmlstring = xmltodict.unparse(
-        {"root": particle_dict}, pretty=True, indent="  "
-    )
-    with open(file_path, "w") as output_file:
-        output_file.write(xmlstring)
-
-
-def _load_particles_from_yaml(filename: str) -> None:
-    particle_collection = io.load_particle_collection(filename)
-    particle_list_xml = io.xml.object_to_dict(particle_collection)
-    DATABASE.update(particle_list_xml)
-
-
-def _write_particle_database_to_yaml(filename: str) -> None:
     particle_collection = io.xml.dict_to_particle_collection(DATABASE)
     io.write(particle_collection, filename)
 

--- a/expertsystem/state/particle.py
+++ b/expertsystem/state/particle.py
@@ -217,7 +217,7 @@ class _IntQNConverter(AbstractQNConverter):
         return {
             self.type_label: qn_type.name,
             self.class_label: QuantumNumberClasses.Int.name,
-            self.value_label: str(qn_value),
+            self.value_label: qn_value,
         }
 
 
@@ -235,7 +235,7 @@ class _FloatQNConverter(AbstractQNConverter):
         return {
             self.type_label: qn_type.name,
             self.class_label: QuantumNumberClasses.Float.name,
-            self.value_label: str(qn_value),
+            self.value_label: qn_value,
         }
 
 
@@ -267,8 +267,8 @@ class _SpinQNConverter(AbstractQNConverter):
         return {
             self.type_label: qn_type.name,
             self.class_label: QuantumNumberClasses.Spin.name,
-            self.value_label: str(qn_value.magnitude()),
-            self.proj_label: str(qn_value.projection()),
+            self.value_label: qn_value.magnitude(),
+            self.proj_label: qn_value.projection(),
         }
 
 

--- a/tests/amplitude/expected_recipe.yml
+++ b/tests/amplitude/expected_recipe.yml
@@ -1347,7 +1347,6 @@ Dynamics:
         Value: 1.0
         Min: 0.0
         Max: 2.0
-        Fix: true
 
   f2(1270):
     Type: RelativisticBreitWigner
@@ -1357,7 +1356,6 @@ Dynamics:
         Value: 1.0
         Min: 0.0
         Max: 2.0
-        Fix: true
 
   f0(1500):
     Type: RelativisticBreitWigner
@@ -1367,7 +1365,6 @@ Dynamics:
         Value: 1.0
         Min: 0.0
         Max: 2.0
-        Fix: true
 
   f2(1950):
     Type: RelativisticBreitWigner
@@ -1377,4 +1374,3 @@ Dynamics:
         Value: 1.0
         Min: 0.0
         Max: 2.0
-        Fix: true

--- a/tests/amplitude/test_yaml_helicity.py
+++ b/tests/amplitude/test_yaml_helicity.py
@@ -70,7 +70,9 @@ class TestHelicityAmplitudeGeneratorYAML:
         assert len(recipe) == 3
 
     def test_particle_section(self):
-        particle_list = self.imported_dict["ParticleList"]
+        particle_list = self.imported_dict.get(
+            "ParticleList", self.imported_dict
+        )
         gamma = particle_list["gamma"]
         assert gamma["PID"] == 22
         assert gamma["Mass"] == 0.0
@@ -105,21 +107,22 @@ class TestHelicityAmplitudeGeneratorYAML:
 
     def test_dynamics_section(self):
         dynamics = self.imported_dict["Dynamics"]
-        assert len(dynamics) == 5
+        assert len(dynamics) == 1
 
         j_psi = dynamics["J/psi"]
         assert j_psi["Type"] == "NonDynamic"
         assert j_psi["FormFactor"]["Type"] == "BlattWeisskopf"
         assert j_psi["FormFactor"]["MesonRadius"] == 1.0
 
-        f0_980 = dynamics["f0(980)"]
-        assert f0_980["Type"] == "RelativisticBreitWigner"
-        assert f0_980["FormFactor"]["Type"] == "BlattWeisskopf"
-        assert f0_980["FormFactor"]["MesonRadius"] == {
-            "Max": 2.0,
-            "Min": 0.0,
-            "Value": 1.0,
-        }
+        f0_980 = dynamics.get("f0(980)", None)
+        if f0_980:
+            assert f0_980["Type"] == "RelativisticBreitWigner"
+            assert f0_980["FormFactor"]["Type"] == "BlattWeisskopf"
+            assert f0_980["FormFactor"]["MesonRadius"] == {
+                "Max": 2.0,
+                "Min": 0.0,
+                "Value": 1.0,
+            }
 
     def test_intensity_section(self):
         intensity = self.imported_dict["Intensity"]
@@ -132,7 +135,7 @@ class TestHelicityAmplitudeGeneratorYAML:
         assert len(intensity["Intensities"]) == 4
 
     @pytest.mark.parametrize(
-        "section", ["ParticleList", "Dynamics", "Kinematics"],
+        "section", ["ParticleList", "Kinematics"],
     )
     def test_expected_recipe_shape(self, section):
         expected_section = equalize_dict(self.expected_dict[section])

--- a/tests/amplitude/test_yaml_helicity.py
+++ b/tests/amplitude/test_yaml_helicity.py
@@ -116,7 +116,6 @@ class TestHelicityAmplitudeGeneratorYAML:
         assert f0_980["Type"] == "RelativisticBreitWigner"
         assert f0_980["FormFactor"]["Type"] == "BlattWeisskopf"
         assert f0_980["FormFactor"]["MesonRadius"] == {
-            "Fix": True,
             "Max": 2.0,
             "Min": 0.0,
             "Value": 1.0,

--- a/tests/io/test_particle_collection.py
+++ b/tests/io/test_particle_collection.py
@@ -3,16 +3,13 @@ from os.path import dirname, realpath
 import pytest
 
 import expertsystem
+from expertsystem import io
+from expertsystem import ui
 from expertsystem.data import (
     MeasuredValue,
     Parity,
     Particle,
     ParticleCollection,
-)
-from expertsystem.io import (
-    load_particle_collection,
-    write,
-    xml,
 )
 from expertsystem.state import particle
 
@@ -35,20 +32,20 @@ J_PSI = Particle(
 
 def test_not_implemented_errors():
     with pytest.raises(NotImplementedError):
-        load_particle_collection(f"{EXPERTSYSTEM_PATH}/../README.md")
+        io.load_particle_collection(f"{EXPERTSYSTEM_PATH}/../README.md")
     with pytest.raises(NotImplementedError):
         dummy = ParticleCollection()
-        write(dummy, f"{EXPERTSYSTEM_PATH}/particle_list.csv")
+        io.write(dummy, f"{EXPERTSYSTEM_PATH}/particle_list.csv")
     with pytest.raises(Exception):
         dummy = ParticleCollection()
-        write(dummy, "no_file_extension")
+        io.write(dummy, "no_file_extension")
     with pytest.raises(NotImplementedError):
-        write(666, "wont_work_anyway.xml")
+        io.write(666, "wont_work_anyway.xml")
 
 
 @pytest.mark.parametrize("input_file", [_XML_FILE, _YAML_FILE])
 def test_load_particle_collection(input_file):
-    particles = load_particle_collection(input_file)
+    particles = io.load_particle_collection(input_file)
     assert len(particles) == 69
     assert "J/psi" in particles
     j_psi = particles["J/psi"]
@@ -60,19 +57,19 @@ def test_load_particle_collection(input_file):
 
 @pytest.mark.parametrize("input_file", [_XML_FILE, _YAML_FILE])
 def test_write_particle_collection(input_file):
-    particles_imported = load_particle_collection(input_file)
+    particles_imported = io.load_particle_collection(input_file)
     file_extension = input_file.split(".")[-1]
     output_file = f"exported_particle_list.{file_extension}"
-    write(particles_imported, output_file)
-    particles_exported = load_particle_collection(output_file)
+    io.write(particles_imported, output_file)
+    particles_exported = io.load_particle_collection(output_file)
     assert particles_imported == particles_exported
 
 
 def test_yaml_to_xml():
-    yaml_particle_collection = load_particle_collection(_YAML_FILE)
+    yaml_particle_collection = io.load_particle_collection(_YAML_FILE)
     xml_file = "particle_list_test.xml"
-    write(yaml_particle_collection, xml_file)
-    xml_particle_collection = load_particle_collection(xml_file)
+    io.write(yaml_particle_collection, xml_file)
+    xml_particle_collection = io.load_particle_collection(xml_file)
     assert xml_particle_collection == yaml_particle_collection
     dummy_particle = Particle(name="0", pid=0, charge=0, spin=0, mass=0)
     yaml_particle_collection.add(dummy_particle)
@@ -80,19 +77,21 @@ def test_yaml_to_xml():
 
 
 def test_equivalence_xml_yaml_particle_list():
-    xml_particle_collection = load_particle_collection(_XML_FILE)
-    yml_particle_collection = load_particle_collection(_YAML_FILE)
+    xml_particle_collection = io.load_particle_collection(_XML_FILE)
+    yml_particle_collection = io.load_particle_collection(_YAML_FILE)
     assert xml_particle_collection == yml_particle_collection
 
 
 class TestInternalParticleDict:
+    ui.load_default_particle_list()
+
     @staticmethod
     def test_particle_validation():
         for item in particle.DATABASE.values():
-            xml.validation.particle(item)
+            io.xml.validation.particle(item)
 
     @staticmethod
     def test_build_particle_from_internal_database():
         definition = particle.DATABASE["J/psi"]
-        j_psi = xml.dict_to_particle(definition)
+        j_psi = io.xml.dict_to_particle(definition)
         assert j_psi == J_PSI

--- a/tests/io/test_particle_collection.py
+++ b/tests/io/test_particle_collection.py
@@ -95,3 +95,8 @@ class TestInternalParticleDict:
         definition = particle.DATABASE["J/psi"]
         j_psi = io.xml.dict_to_particle(definition)
         assert j_psi == J_PSI
+
+    @staticmethod
+    def test_dump_via_particle_collection():
+        particles = io.xml.dict_to_particle_collection(particle.DATABASE)
+        io.write(particles, "DATABASE_via_ParticleCollection.xml")

--- a/tests/state/test_particle.py
+++ b/tests/state/test_particle.py
@@ -25,7 +25,7 @@ class TestFind:
     def test_name_search():
         omega = particle.find_particle("omega")
         assert isinstance(omega, dict)
-        assert omega["Pid"] == "223"
+        assert omega["Pid"] == 223
 
     @staticmethod
     def test_name_slice_search():


### PR DESCRIPTION
_Breaking change: decay info is not added to the recipe anymore! Therefore the tests had to be modified and functionality has been lost. Dynamics has to be added by the user in another phase, but this requires a big change in the interface_

Note also that the values of the internal nested `dict`s of `particle.DATABASE` have become `int`/`float`, not `str`. That's why the `QNConverter` converter classes don't cast to `str` anymore (see also #122)