### PR TITLE
feat: add write amplitude model from STM

### DIFF
--- a/examples/quickstart.ipynb
+++ b/examples/quickstart.ipynb
@@ -384,12 +384,21 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
+   "cell_type": "raw",
+   "metadata": {
+    "raw_mimetype": "text/restructuredtext"
+   },
    "source": [
-    "Now that we are satisfied with the intermediate resonances, we are all set to\n",
-    "generate an amplitude model! In the end, we write the output to a **recipe\n",
-    "file** in both XML and YAML format, you can use the format you prefer."
+    "Now that we are satisfied with the intermediate resonances, we are all set convert the solutions that the STM found to an amplitude model! This can be done with the `.StateTransitionManager.write_amplitude_model` method."
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {
+    "raw_mimetype": "text/restructuredtext"
+   },
+   "source": [
+    "Depending on the formalism type that you chose :ref:`when constructing the STM <usage/quickstart:1.1. Define the problem set>`, `.write_amplitude_model` will use for instance :class:`.CanonicalAmplitudeGenerator` if you chose to work with formalism type :code:`\"helicity\"`. The output will be written to a **recipe file** in either XML and YAML format. The format is determined form the file extension you use."
    ]
   },
   {
@@ -398,12 +407,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from expertsystem.amplitude.helicity_decay import HelicityAmplitudeGenerator\n",
-    "\n",
-    "amplitude_generator = HelicityAmplitudeGenerator()\n",
-    "amplitude_generator.generate(solutions)\n",
-    "amplitude_generator.write_to_file(\"model.xml\")\n",
-    "amplitude_generator.write_to_file(\"model.yml\")"
+    "stm.write_amplitude_model(solutions, output_file=\"model.xml\")\n",
+    "stm.write_amplitude_model(solutions, output_file=\"model.yml\")"
    ]
   },
   {
@@ -414,19 +419,7 @@
    "source": [
     ".. note::\n",
     "\n",
-    "    In this example, we used the helicity formalism. If you want to work with\n",
-    "    the canonical formalism, you have to:\n",
-    "\n",
-    "    1. Construct a :class:`.StateTransitionManager` with argument\n",
-    "       ``formalism_type='canonical-helicity'``\n",
-    "       instead of\n",
-    "       ``formalism_type='helicity'``.\n",
-    "\n",
-    "    2. Use the :class:`.CanonicalAmplitudeGenerator` instead of the\n",
-    "       :class:`.HelicityAmplitudeGenerator`.\n",
-    "\n",
-    "    Note that you **have to do both**, because otherwise the resulting\n",
-    "    amplitude will not make sense!"
+    "    In this example, we used the helicity formalism. If you want to work with the canonical formalism, you have to construct the :class:`.StateTransitionManager` with argument :code:`formalism_type=\"canonical-helicity\"` instead of :code:`formalism_type=\"helicity\"`."
    ]
   },
   {

--- a/expertsystem/ui/__init__.py
+++ b/expertsystem/ui/__init__.py
@@ -158,6 +158,84 @@ class StateTransitionManager:  # pylint: disable=too-many-instance-attributes
         )
         return graph_settings_groups
 
+    def find_solutions(
+        self, graph_setting_groups
+    ):  # pylint: disable=too-many-locals
+        """Check for solutions for a specific set of interaction settings."""
+        results = {}
+        logging.info(
+            "Number of interaction settings groups being processed: %d",
+            len(graph_setting_groups),
+        )
+        for strength, graph_setting_group in sorted(
+            graph_setting_groups.items(), reverse=True
+        ):
+            logging.info(
+                "processing interaction settings group with "
+                f"strength {strength}",
+            )
+            logging.info(f"{graph_setting_group} entries in this group")
+            logging.info(f"running with {self.number_of_threads} threads...")
+
+            temp_results = []
+            progress_bar = IncrementalBar(
+                "Propagating quantum numbers...", max=len(graph_setting_group)
+            )
+            progress_bar.update()
+            if self.number_of_threads > 1:
+                with Pool(self.number_of_threads) as pool:
+                    for result in pool.imap_unordered(
+                        self._propagate_quantum_numbers, graph_setting_group, 1
+                    ):
+                        temp_results.append(result)
+                        progress_bar.next()
+            else:
+                for graph_setting_pair in graph_setting_group:
+                    temp_results.append(
+                        self._propagate_quantum_numbers(graph_setting_pair)
+                    )
+                    progress_bar.next()
+            progress_bar.finish()
+            logging.info("Finished!")
+            if strength not in results:
+                results[strength] = []
+            results[strength].extend(temp_results)
+
+        for key, value in results.items():
+            logging.info(
+                f"number of solutions for strength ({key}) "
+                f"after qn propagation: {sum([len(x[0]) for x in value])}",
+            )
+
+        # remove duplicate solutions, which only differ in the interaction qn S
+        results = remove_duplicate_solutions(
+            results, self.filter_remove_qns, self.filter_ignore_qns
+        )
+
+        node_non_satisfied_rules = []
+        solutions = []
+        for result in results.values():
+            for (tempsolutions, non_satisfied_laws) in result:
+                solutions.extend(tempsolutions)
+                node_non_satisfied_rules.append(non_satisfied_laws)
+        logging.info(f"total number of found solutions: {len(solutions)}")
+        violated_laws = []
+        if len(solutions) == 0:
+            violated_laws = analyse_solution_failure(node_non_satisfied_rules)
+            logging.info(f"violated rules: {violated_laws}")
+
+        # finally perform combinatorics of identical external edges
+        # (initial or final state edges) and prepare graphs for
+        # amplitude generation
+        match_external_edges(solutions)
+        final_solutions = []
+        for sol in solutions:
+            final_solutions.extend(
+                perform_external_edge_identical_particle_combinatorics(sol)
+            )
+
+        return (final_solutions, violated_laws)
+
     def _build_topologies(self):
         all_graphs = self.topology_builder.build_graphs(
             len(self.initial_state), len(self.final_state)
@@ -238,84 +316,6 @@ class StateTransitionManager:  # pylint: disable=too-many-instance-attributes
                 ]
             graph_node_setting_pairs.append((instance, node_settings))
         return graph_node_setting_pairs
-
-    def find_solutions(
-        self, graph_setting_groups
-    ):  # pylint: disable=too-many-locals
-        """Check for solutions for a specific set of interaction settings."""
-        results = {}
-        logging.info(
-            "Number of interaction settings groups being processed: %d",
-            len(graph_setting_groups),
-        )
-        for strength, graph_setting_group in sorted(
-            graph_setting_groups.items(), reverse=True
-        ):
-            logging.info(
-                "processing interaction settings group with "
-                f"strength {strength}",
-            )
-            logging.info(f"{graph_setting_group} entries in this group")
-            logging.info(f"running with {self.number_of_threads} threads...")
-
-            temp_results = []
-            progress_bar = IncrementalBar(
-                "Propagating quantum numbers...", max=len(graph_setting_group)
-            )
-            progress_bar.update()
-            if self.number_of_threads > 1:
-                with Pool(self.number_of_threads) as pool:
-                    for result in pool.imap_unordered(
-                        self._propagate_quantum_numbers, graph_setting_group, 1
-                    ):
-                        temp_results.append(result)
-                        progress_bar.next()
-            else:
-                for graph_setting_pair in graph_setting_group:
-                    temp_results.append(
-                        self._propagate_quantum_numbers(graph_setting_pair)
-                    )
-                    progress_bar.next()
-            progress_bar.finish()
-            logging.info("Finished!")
-            if strength not in results:
-                results[strength] = []
-            results[strength].extend(temp_results)
-
-        for key, value in results.items():
-            logging.info(
-                f"number of solutions for strength ({key}) "
-                f"after qn propagation: {sum([len(x[0]) for x in value])}",
-            )
-
-        # remove duplicate solutions, which only differ in the interaction qn S
-        results = remove_duplicate_solutions(
-            results, self.filter_remove_qns, self.filter_ignore_qns
-        )
-
-        node_non_satisfied_rules = []
-        solutions = []
-        for result in results.values():
-            for (tempsolutions, non_satisfied_laws) in result:
-                solutions.extend(tempsolutions)
-                node_non_satisfied_rules.append(non_satisfied_laws)
-        logging.info(f"total number of found solutions: {len(solutions)}")
-        violated_laws = []
-        if len(solutions) == 0:
-            violated_laws = analyse_solution_failure(node_non_satisfied_rules)
-            logging.info(f"violated rules: {violated_laws}")
-
-        # finally perform combinatorics of identical external edges
-        # (initial or final state edges) and prepare graphs for
-        # amplitude generation
-        match_external_edges(solutions)
-        final_solutions = []
-        for sol in solutions:
-            final_solutions.extend(
-                perform_external_edge_identical_particle_combinatorics(sol)
-            )
-
-        return (final_solutions, violated_laws)
 
     def _propagate_quantum_numbers(self, state_graph_node_settings_pair):
         propagator = self._initialize_qn_propagator(

--- a/expertsystem/ui/__init__.py
+++ b/expertsystem/ui/__init__.py
@@ -17,6 +17,8 @@ from os import path
 
 from progress.bar import IncrementalBar
 
+from expertsystem.amplitude.canonical_decay import CanonicalAmplitudeGenerator
+from expertsystem.amplitude.helicity_decay import HelicityAmplitudeGenerator
 from expertsystem.state import particle
 from expertsystem.state.propagation import (
     FullPropagator,
@@ -72,6 +74,7 @@ class StateTransitionManager:  # pylint: disable=too-many-instance-attributes
                 f"Formalism type {formalism_type} not implemented."
                 f" Use {allowed_formalism_types} instead."
             )
+        self.__formalism_type = formalism_type
         self.number_of_threads = number_of_threads
         self.propagation_mode = propagation_mode
         self.initial_state = initial_state
@@ -119,6 +122,10 @@ class StateTransitionManager:  # pylint: disable=too-many-instance-attributes
         self.topology_builder = SimpleStateTransitionTopologyBuilder(int_nodes)
 
         load_default_particle_list()
+
+    @property
+    def formalism_type(self) -> str:
+        return self.__formalism_type
 
     def set_topology_builder(self, topology_builder):
         self.topology_builder = topology_builder
@@ -235,6 +242,21 @@ class StateTransitionManager:  # pylint: disable=too-many-instance-attributes
             )
 
         return (final_solutions, violated_laws)
+
+    def write_amplitude_model(self, solutions: list, output_file: str) -> None:
+        """Generate an amplitude model from the solutions.
+
+        The type of amplitude model (`.HelicityAmplitudeGenerator` or
+        `.CanonicalAmplitudeGenerator`) is determined from the
+        :code:`formalism_type` that was chosen when constructing the
+        `.StateTransitionManager`.
+        """
+        if self.formalism_type == "helicity":
+            amplitude_generator = HelicityAmplitudeGenerator()
+        elif self.formalism_type in ["canonical-helicity", "canonical"]:
+            amplitude_generator = CanonicalAmplitudeGenerator()
+        amplitude_generator.generate(solutions)
+        amplitude_generator.write_to_file(output_file)
 
     def _build_topologies(self):
         all_graphs = self.topology_builder.build_graphs(

--- a/tests/amplitude/test_parity_prefactor.py
+++ b/tests/amplitude/test_parity_prefactor.py
@@ -61,19 +61,17 @@ def test_parity_prefactor(
     related_component_names: Tuple[str, str],
     relative_parity_prefactor: float,
 ) -> None:
-    tbd_manager = StateTransitionManager(
+    stm = StateTransitionManager(
         test_input.initial_state,
         test_input.final_state,
         allowed_intermediate_particles=test_input.intermediate_states,
     )
-    # tbd_manager.number_of_threads = 1
-    tbd_manager.add_final_state_grouping(test_input.final_state_grouping)
-    tbd_manager.set_allowed_interaction_types([InteractionTypes.EM])
-    graph_interaction_settings_groups = tbd_manager.prepare_graphs()
+    # stm.number_of_threads = 1
+    stm.add_final_state_grouping(test_input.final_state_grouping)
+    stm.set_allowed_interaction_types([InteractionTypes.EM])
+    graph_interaction_settings_groups = stm.prepare_graphs()
 
-    (solutions, _) = tbd_manager.find_solutions(
-        graph_interaction_settings_groups
-    )
+    solutions, _ = stm.find_solutions(graph_interaction_settings_groups)
 
     for solution in solutions:
         in_edge = [

--- a/tests/amplitude/test_yaml_canonical.py
+++ b/tests/amplitude/test_yaml_canonical.py
@@ -18,17 +18,15 @@ SCRIPT_PATH = dirname(realpath(__file__))
 
 
 def create_amplitude_generator():
-    tbd_manager = StateTransitionManager(
+    stm = StateTransitionManager(
         initial_state=[("J/psi", [-1, 1])],
         final_state=[("gamma", [-1, 1]), ("pi0", [0]), ("pi0", [0])],
         allowed_intermediate_particles=["f0"],
         formalism_type="canonical-helicity",
     )
-    tbd_manager.set_allowed_interaction_types([InteractionTypes.EM])
-    graph_interaction_settings_groups = tbd_manager.prepare_graphs()
-    solutions, _ = tbd_manager.find_solutions(
-        graph_interaction_settings_groups
-    )
+    stm.set_allowed_interaction_types([InteractionTypes.EM])
+    graph_interaction_settings_groups = stm.prepare_graphs()
+    solutions, _ = stm.find_solutions(graph_interaction_settings_groups)
 
     amplitude_generator = CanonicalAmplitudeGenerator()
     amplitude_generator.generate(solutions)

--- a/tests/amplitude/test_yaml_helicity.py
+++ b/tests/amplitude/test_yaml_helicity.py
@@ -21,14 +21,12 @@ def create_amplitude_generator():
     initial_state = [("J/psi", [-1, 1])]
     final_state = [("gamma", [-1, 1]), ("pi0", [0]), ("pi0", [0])]
 
-    tbd_manager = StateTransitionManager(initial_state, final_state, ["f"])
-    tbd_manager.set_allowed_interaction_types(
+    stm = StateTransitionManager(initial_state, final_state, ["f"])
+    stm.set_allowed_interaction_types(
         [InteractionTypes.Strong, InteractionTypes.EM]
     )
-    graph_interaction_settings_groups = tbd_manager.prepare_graphs()
-    solutions, _ = tbd_manager.find_solutions(
-        graph_interaction_settings_groups
-    )
+    graph_interaction_settings_groups = stm.prepare_graphs()
+    solutions, _ = stm.find_solutions(graph_interaction_settings_groups)
 
     amplitude_generator = HelicityAmplitudeGenerator()
     amplitude_generator.generate(solutions)

--- a/tests/canonical_formalism/test_ls_coupling.py
+++ b/tests/canonical_formalism/test_ls_coupling.py
@@ -117,7 +117,7 @@ def test_canonical_clebsch_gordan_ls_coupling(
         int_settings[InteractionTypes.Strong], ParityConservationHelicity()
     )
 
-    tbd_manager = StateTransitionManager(
+    stm = StateTransitionManager(
         initial_state,
         final_state,
         [],
@@ -125,9 +125,9 @@ def test_canonical_clebsch_gordan_ls_coupling(
         formalism_type=formalism_type,
     )
 
-    tbd_manager.set_allowed_interaction_types([InteractionTypes.Strong])
-    tbd_manager.number_of_threads = 2
-    tbd_manager.filter_remove_qns = []
+    stm.set_allowed_interaction_types([InteractionTypes.Strong])
+    stm.number_of_threads = 2
+    stm.filter_remove_qns = []
 
     l_label = InteractionQuantumNumberNames.L
     s_label = InteractionQuantumNumberNames.S
@@ -142,11 +142,11 @@ def test_canonical_clebsch_gordan_ls_coupling(
             ]
         }
     }
-    graph_node_setting_pairs = tbd_manager.prepare_graphs()
+    graph_node_setting_pairs = stm.prepare_graphs()
     for value in graph_node_setting_pairs.values():
         for edge in value:
             edge[0].node_props = node_props
 
-    solutions = tbd_manager.find_solutions(graph_node_setting_pairs)[0]
+    solutions = stm.find_solutions(graph_node_setting_pairs)[0]
 
     assert len(solutions) == solution_count

--- a/tests/channels/test_d0_to_kskpkm.py
+++ b/tests/channels/test_d0_to_kskpkm.py
@@ -4,7 +4,6 @@
 
 import logging
 
-from expertsystem.amplitude.helicity_decay import HelicityAmplitudeGenerator
 from expertsystem.ui import StateTransitionManager
 
 
@@ -30,9 +29,7 @@ def test_script():
     for solution in solutions:
         print(solution.edge_props[1]["Name"])
 
-    xml_generator = HelicityAmplitudeGenerator()
-    xml_generator.generate(solutions)
-    xml_generator.write_to_file("D0ToKs0KpKm.xml")
+    stm.write_amplitude_model(solutions, "D0ToKs0KpKm.xml")
 
 
 if __name__ == "__main__":

--- a/tests/channels/test_d0_to_kskpkm.py
+++ b/tests/channels/test_d0_to_kskpkm.py
@@ -15,15 +15,13 @@ def test_script():
     initial_state = [("D0", [0])]
     final_state = [("K_S0", [0]), ("K+", [0]), ("K-", [0])]
 
-    tbd_manager = StateTransitionManager(
+    stm = StateTransitionManager(
         initial_state, final_state, ["a0", "phi", "a2(1320)-"]
     )
-    tbd_manager.number_of_threads = 2
+    stm.number_of_threads = 2
 
-    graph_interaction_settings_groups = tbd_manager.prepare_graphs()
-    solutions, _ = tbd_manager.find_solutions(
-        graph_interaction_settings_groups
-    )
+    graph_interaction_settings_groups = stm.prepare_graphs()
+    solutions, _ = stm.find_solutions(graph_interaction_settings_groups)
 
     print("found " + str(len(solutions)) + " solutions!")
     assert len(solutions) == 5

--- a/tests/channels/test_jpsi_to_gammapi0pi0.py
+++ b/tests/channels/test_jpsi_to_gammapi0pi0.py
@@ -23,21 +23,19 @@ from expertsystem.ui._system_control import _create_edge_id_particle_mapping
 def test_script():
     logging.basicConfig(level=logging.INFO)
     # initialize the graph edges (initial and final state)
-    initial_state = [("J/psi", [-1, 1])]
-    final_state = [("gamma", [-1, 1]), ("pi0", [0]), ("pi0", [0])]
 
-    tbd_manager = StateTransitionManager(
-        initial_state, final_state, ["f0", "f2", "omega"]
+    stm = StateTransitionManager(
+        initial_state=[("J/psi", [-1, 1])],
+        final_state=[("gamma", [-1, 1]), ("pi0", [0]), ("pi0", [0])],
+        allowed_intermediate_particles=["f0", "f2", "omega"],
     )
-    tbd_manager.number_of_threads = 2
-    tbd_manager.set_allowed_interaction_types(
+    stm.number_of_threads = 2
+    stm.set_allowed_interaction_types(
         [InteractionTypes.Strong, InteractionTypes.EM]
     )
-    graph_interaction_settings_groups = tbd_manager.prepare_graphs()
+    graph_interaction_settings_groups = stm.prepare_graphs()
 
-    solutions, _ = tbd_manager.find_solutions(
-        graph_interaction_settings_groups
-    )
+    solutions, _ = stm.find_solutions(graph_interaction_settings_groups)
 
     print("found " + str(len(solutions)) + " solutions!")
     assert len(solutions) == 48

--- a/tests/channels/test_nbody_reactions.py
+++ b/tests/channels/test_nbody_reactions.py
@@ -64,7 +64,7 @@ def test_general_reaction(test_input, expected):
     # define all of the different decay scenarios
     print("processing case:" + str(test_input))
 
-    tbd_manager = StateTransitionManager(
+    stm = StateTransitionManager(
         test_input[0],
         test_input[1],
         formalism_type="canonical",
@@ -72,8 +72,8 @@ def test_general_reaction(test_input, expected):
         propagation_mode="full",
     )
 
-    graph_interaction_settings = tbd_manager.prepare_graphs()
-    (solutions, violated_rules) = tbd_manager.find_solutions(
+    graph_interaction_settings = stm.prepare_graphs()
+    (solutions, violated_rules) = stm.find_solutions(
         graph_interaction_settings
     )
 
@@ -106,7 +106,7 @@ def test_em_reactions(test_input, expected):
     # general checks
     print("processing case:" + str(test_input))
 
-    tbd_manager = StateTransitionManager(
+    stm = StateTransitionManager(
         test_input[0],
         test_input[1],
         formalism_type="canonical",
@@ -114,10 +114,10 @@ def test_em_reactions(test_input, expected):
         propagation_mode="full",
     )
 
-    tbd_manager.set_allowed_interaction_types([InteractionTypes.EM])
+    stm.set_allowed_interaction_types([InteractionTypes.EM])
 
-    graph_interaction_settings = tbd_manager.prepare_graphs()
-    _, violated_rules = tbd_manager.find_solutions(graph_interaction_settings)
+    graph_interaction_settings = stm.prepare_graphs()
+    _, violated_rules = stm.find_solutions(graph_interaction_settings)
 
     assert set(violated_rules) == set(expected)
 
@@ -136,7 +136,7 @@ def test_strong_reactions(test_input, expected):
     # general checks
     print("processing case:" + str(test_input))
 
-    tbd_manager = StateTransitionManager(
+    stm = StateTransitionManager(
         test_input[0],
         test_input[1],
         formalism_type="canonical",
@@ -144,9 +144,9 @@ def test_strong_reactions(test_input, expected):
         propagation_mode="full",
     )
 
-    tbd_manager.set_allowed_interaction_types([InteractionTypes.Strong])
+    stm.set_allowed_interaction_types([InteractionTypes.Strong])
 
-    graph_interaction_settings = tbd_manager.prepare_graphs()
-    _, violated_rules = tbd_manager.find_solutions(graph_interaction_settings)
+    graph_interaction_settings = stm.prepare_graphs()
+    _, violated_rules = stm.find_solutions(graph_interaction_settings)
 
     assert set(violated_rules) == set(expected)

--- a/tests/channels/test_y_to_d0d0barpi0pi0.py
+++ b/tests/channels/test_y_to_d0d0barpi0pi0.py
@@ -43,7 +43,7 @@ def test_script_simple():
         create_spin_domain([0, 1, 2], True),
     )
 
-    tbd_manager = StateTransitionManager(
+    stm = StateTransitionManager(
         initial_state,
         final_state,
         ["D*"],
@@ -51,13 +51,13 @@ def test_script_simple():
         formalism_type=formalism_type,
     )
 
-    tbd_manager.set_allowed_interaction_types([InteractionTypes.Strong])
-    # tbd_manager.add_final_state_grouping([['D0', 'pi0'], ['D0bar', 'pi0']])
-    tbd_manager.number_of_threads = 2
+    stm.set_allowed_interaction_types([InteractionTypes.Strong])
+    # stm.add_final_state_grouping([['D0', 'pi0'], ['D0bar', 'pi0']])
+    stm.number_of_threads = 2
 
-    graph_node_setting_pairs = tbd_manager.prepare_graphs()
+    graph_node_setting_pairs = stm.prepare_graphs()
 
-    solutions, _ = tbd_manager.find_solutions(graph_node_setting_pairs)
+    solutions, _ = stm.find_solutions(graph_node_setting_pairs)
 
     print("found " + str(len(solutions)) + " solutions!")
 
@@ -78,7 +78,7 @@ def test_script_simple():
         create_spin_domain([0, 1, 2], True),
     )
 
-    tbd_manager = StateTransitionManager(
+    stm = StateTransitionManager(
         initial_state,
         final_state,
         ["D*"],
@@ -86,11 +86,11 @@ def test_script_simple():
         formalism_type=formalism_type,
     )
 
-    tbd_manager.set_allowed_interaction_types([InteractionTypes.Strong])
-    tbd_manager.number_of_threads = 2
+    stm.set_allowed_interaction_types([InteractionTypes.Strong])
+    stm.number_of_threads = 2
 
-    graph_node_setting_pairs = tbd_manager.prepare_graphs()
-    solutions, _ = tbd_manager.find_solutions(graph_node_setting_pairs)
+    graph_node_setting_pairs = stm.prepare_graphs()
+    solutions, _ = stm.find_solutions(graph_node_setting_pairs)
     print("found " + str(len(solutions)) + " solutions!")
 
     helicity_xml_generator = HelicityAmplitudeGenerator()
@@ -121,7 +121,7 @@ def test_script_full():
         create_spin_domain([0, 1, 2], True),
     )
 
-    tbd_manager = StateTransitionManager(
+    stm = StateTransitionManager(
         initial_state,
         final_state,
         ["D*"],
@@ -129,13 +129,13 @@ def test_script_full():
         formalism_type=formalism_type,
     )
 
-    tbd_manager.set_allowed_interaction_types([InteractionTypes.Strong])
-    tbd_manager.add_final_state_grouping([["D0", "pi0"], ["D0bar", "pi0"]])
-    tbd_manager.number_of_threads = 2
+    stm.set_allowed_interaction_types([InteractionTypes.Strong])
+    stm.add_final_state_grouping([["D0", "pi0"], ["D0bar", "pi0"]])
+    stm.number_of_threads = 2
 
-    graph_node_setting_pairs = tbd_manager.prepare_graphs()
+    graph_node_setting_pairs = stm.prepare_graphs()
 
-    solutions, _ = tbd_manager.find_solutions(graph_node_setting_pairs)
+    solutions, _ = stm.find_solutions(graph_node_setting_pairs)
 
     print("found " + str(len(solutions)) + " solutions!")
 
@@ -156,7 +156,7 @@ def test_script_full():
         create_spin_domain([0, 1, 2], True),
     )
 
-    tbd_manager = StateTransitionManager(
+    stm = StateTransitionManager(
         initial_state,
         final_state,
         ["D*"],
@@ -164,12 +164,12 @@ def test_script_full():
         formalism_type=formalism_type,
     )
 
-    tbd_manager.set_allowed_interaction_types([InteractionTypes.Strong])
-    tbd_manager.add_final_state_grouping([["D0", "pi0"], ["D0bar", "pi0"]])
-    tbd_manager.number_of_threads = 2
+    stm.set_allowed_interaction_types([InteractionTypes.Strong])
+    stm.add_final_state_grouping([["D0", "pi0"], ["D0bar", "pi0"]])
+    stm.number_of_threads = 2
 
-    graph_node_setting_pairs = tbd_manager.prepare_graphs()
-    solutions, _ = tbd_manager.find_solutions(graph_node_setting_pairs)
+    graph_node_setting_pairs = stm.prepare_graphs()
+    solutions, _ = stm.find_solutions(graph_node_setting_pairs)
     print("found " + str(len(solutions)) + " solutions!")
 
     helicity_xml_generator = HelicityAmplitudeGenerator()

--- a/tests/ui/test_systemcontrol.py
+++ b/tests/ui/test_systemcontrol.py
@@ -87,20 +87,20 @@ from expertsystem.ui._system_control import (
 def test_external_edge_initialization(
     initial_state, final_state, final_state_groupings, result_graph_count
 ):
-    tbd_manager = StateTransitionManager(
+    stm = StateTransitionManager(
         initial_state, final_state, [], formalism_type="helicity"
     )
 
-    tbd_manager.set_allowed_interaction_types([InteractionTypes.Strong])
+    stm.set_allowed_interaction_types([InteractionTypes.Strong])
     for group in final_state_groupings:
-        tbd_manager.add_final_state_grouping(group)
-    tbd_manager.number_of_threads = 1
+        stm.add_final_state_grouping(group)
+    stm.number_of_threads = 1
 
     topology_graphs = (
-        tbd_manager._build_topologies()  # pylint: disable=protected-access
+        stm._build_topologies()  # pylint: disable=protected-access
     )
 
-    init_graphs = tbd_manager._create_seed_graphs(  # pylint: disable=protected-access
+    init_graphs = stm._create_seed_graphs(  # pylint: disable=protected-access
         topology_graphs
     )
     assert len(init_graphs) == result_graph_count
@@ -259,17 +259,17 @@ class TestSolutionFilter:  # pylint: disable=no-self-use
     ],
 )
 def test_edge_swap(initial_state, final_state):
-    tbd_manager = StateTransitionManager(
+    stm = StateTransitionManager(
         initial_state, final_state, [], formalism_type="helicity"
     )
 
-    tbd_manager.set_allowed_interaction_types([InteractionTypes.Strong])
-    tbd_manager.number_of_threads = 1
+    stm.set_allowed_interaction_types([InteractionTypes.Strong])
+    stm.number_of_threads = 1
 
     topology_graphs = (
-        tbd_manager._build_topologies()  # pylint: disable=protected-access
+        stm._build_topologies()  # pylint: disable=protected-access
     )
-    init_graphs = tbd_manager._create_seed_graphs(  # pylint: disable=protected-access
+    init_graphs = stm._create_seed_graphs(  # pylint: disable=protected-access
         topology_graphs
     )
 
@@ -305,17 +305,17 @@ def test_edge_swap(initial_state, final_state):
     ],
 )
 def test_match_external_edges(initial_state, final_state):
-    tbd_manager = StateTransitionManager(
+    stm = StateTransitionManager(
         initial_state, final_state, [], formalism_type="helicity"
     )
 
-    tbd_manager.set_allowed_interaction_types([InteractionTypes.Strong])
-    tbd_manager.number_of_threads = 1
+    stm.set_allowed_interaction_types([InteractionTypes.Strong])
+    stm.number_of_threads = 1
 
     topology_graphs = (
-        tbd_manager._build_topologies()  # pylint: disable=protected-access
+        stm._build_topologies()  # pylint: disable=protected-access
     )
-    init_graphs = tbd_manager._create_seed_graphs(  # pylint: disable=protected-access
+    init_graphs = stm._create_seed_graphs(  # pylint: disable=protected-access
         topology_graphs
     )
 
@@ -375,20 +375,20 @@ def test_match_external_edges(initial_state, final_state):
 def test_external_edge_identical_particle_combinatorics(
     initial_state, final_state, final_state_groupings, result_graph_count
 ):
-    tbd_manager = StateTransitionManager(
+    stm = StateTransitionManager(
         initial_state, final_state, [], formalism_type="helicity"
     )
 
-    tbd_manager.set_allowed_interaction_types([InteractionTypes.Strong])
+    stm.set_allowed_interaction_types([InteractionTypes.Strong])
     for group in final_state_groupings:
-        tbd_manager.add_final_state_grouping(group)
-    tbd_manager.number_of_threads = 1
+        stm.add_final_state_grouping(group)
+    stm.number_of_threads = 1
 
     topology_graphs = (
-        tbd_manager._build_topologies()  # pylint: disable=protected-access
+        stm._build_topologies()  # pylint: disable=protected-access
     )
 
-    init_graphs = tbd_manager._create_seed_graphs(  # pylint: disable=protected-access
+    init_graphs = stm._create_seed_graphs(  # pylint: disable=protected-access
         topology_graphs
     )
     match_external_edges(init_graphs)


### PR DESCRIPTION
Closes #91 

Amplitude model recipe writing can now be done directly from the STM. This removes the need to first create e.g. a `HelicityAmplitudeGenerator`.