### PR TITLE
refactor!: remove MeasuredValue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 !environment.yml
 !examples/additional_particles.yml
 !expertsystem/particle_list.*
+!tests/amplitude/expected_recipe.yml
 
 # Build output
 *.egg-info/

--- a/expertsystem/amplitude/_yaml_adapter.py
+++ b/expertsystem/amplitude/_yaml_adapter.py
@@ -175,17 +175,6 @@ def _downgrade_float(value: float) -> Union[float, int]:
     return value
 
 
-def _to_parameter(
-    definition: Dict[str, Any]
-) -> Union[float, Dict[str, float]]:
-    """Use for extracting Mass and Width keys."""
-    value = float(definition["Value"])
-    error = float(definition.get("Error", 0.0))
-    if error == 0.0:
-        return value
-    return {"Value": value, "Error": error}
-
-
 def _to_isospin(definition: Dict[str, Any]) -> Union[float, Dict[str, float]]:
     """Isospin is 'stable', so always needs a projection."""
     value = _to_scalar(definition, "Value")

--- a/expertsystem/data.py
+++ b/expertsystem/data.py
@@ -71,26 +71,6 @@ class Spin:
         return self.__projection
 
 
-class MeasuredValue(NamedTuple):
-    """Value with (optional) uncertainty, as reported by a measurement."""
-
-    value: float
-    uncertainty: Optional[float] = None
-
-    def __eq__(self, other: object) -> bool:
-        if isinstance(other, MeasuredValue):
-            return self.value == other.value
-        return self.value == other
-
-    def __float__(self) -> float:
-        return self.value
-
-    def __repr__(self) -> str:
-        if self.uncertainty is None:
-            return str(self.value)
-        return f"{self.value} ± {self.uncertainty}"
-
-
 class Particle(NamedTuple):
     """Immutable data container for particle info."""
 
@@ -98,7 +78,7 @@ class Particle(NamedTuple):
     pid: int
     charge: int
     spin: float
-    mass: MeasuredValue
+    mass: float
     strangeness: int = 0
     charmness: int = 0
     bottomness: int = 0
@@ -107,7 +87,7 @@ class Particle(NamedTuple):
     electron_number: int = 0
     muon_number: int = 0
     tau_number: int = 0
-    width: Optional[MeasuredValue] = None
+    width: Optional[float] = None
     isospin: Optional[Spin] = None
     parity: Optional[Parity] = None
     c_parity: Optional[Parity] = None

--- a/expertsystem/io/xml/_build.py
+++ b/expertsystem/io/xml/_build.py
@@ -12,7 +12,6 @@ from typing import (
 )
 
 from expertsystem.data import (
-    MeasuredValue,
     Parity,
     Particle,
     ParticleCollection,
@@ -50,7 +49,7 @@ def build_particle(definition: dict) -> Particle:
     return Particle(
         name=str(definition["Name"]),
         pid=int(definition["Pid"]),
-        mass=_xml_to_measured_value(definition["Parameter"]),
+        mass=float(definition["Parameter"]["Value"]),
         width=_xml_to_width(definition),
         charge=int(qn_defs["Charge"]),
         spin=float(qn_defs["Spin"]),
@@ -69,15 +68,7 @@ def build_particle(definition: dict) -> Particle:
     )
 
 
-def _xml_to_measured_value(definition: dict) -> MeasuredValue:
-    if "Error" not in definition:
-        return MeasuredValue(float(definition["Value"]))
-    return MeasuredValue(
-        float(definition["Value"]), float(definition["Error"])
-    )
-
-
-def _xml_to_width(definition: dict) -> Optional[MeasuredValue]:
+def _xml_to_width(definition: dict) -> Optional[float]:
     definition = definition.get("DecayInfo", {})
     definition = definition.get("Parameter", None)
     if isinstance(definition, list):
@@ -87,7 +78,7 @@ def _xml_to_width(definition: dict) -> Optional[MeasuredValue]:
                 break
     if definition is None or not isinstance(definition, dict):
         return None
-    return _xml_to_measured_value(definition)
+    return float(definition["Value"])
 
 
 def _xml_qn_list_to_qn_object(definitions: List[dict],) -> Dict[str, Any]:

--- a/expertsystem/io/xml/_dump.py
+++ b/expertsystem/io/xml/_dump.py
@@ -16,7 +16,6 @@ from typing import (
 )
 
 from expertsystem.data import (
-    MeasuredValue,
     Parity,
     Particle,
     ParticleCollection,
@@ -37,34 +36,26 @@ def from_particle(particle: Particle) -> dict:
     output_dict = {
         "Name": particle.name,
         "Pid": particle.pid,
-        "Parameter": _from_measured_value(
-            particle.mass, name=f"Mass_{particle.name}"
-        ),
+        "Parameter": {
+            "Type": "Mass",
+            "Name": f"Mass_{particle.name}",
+            "Value": particle.mass,
+        },
     }
     output_dict["QuantumNumber"] = _to_quantum_number_list(particle)
     if particle.width is not None:
         decay_info = {
             "Parameter": [
-                _from_measured_value(
-                    particle.width, name=f"Width_{particle.name}"
-                )
+                {
+                    "Type": "Width",
+                    "Name": f"Width_{particle.name}",
+                    "Value": particle.width,
+                },
             ]
         }
         output_dict["DecayInfo"] = decay_info
     validation.particle(output_dict)
     return output_dict
-
-
-def _from_measured_value(instance: MeasuredValue, name: str) -> dict:
-    type_name = name.split("_")[0]
-    output = {
-        "Type": type_name,
-        "Name": name,
-        "Value": instance.value,
-    }
-    if instance.uncertainty is not None:
-        output["Error"] = instance.uncertainty
-    return output
 
 
 def _to_quantum_number_list(particle: Particle) -> List[Dict[str, Any]]:

--- a/expertsystem/io/yaml/_build.py
+++ b/expertsystem/io/yaml/_build.py
@@ -6,7 +6,6 @@ from typing import (
 )
 
 from expertsystem.data import (
-    MeasuredValue,
     Parity,
     Particle,
     ParticleCollection,
@@ -27,11 +26,14 @@ def build_particle_collection(definition: dict) -> ParticleCollection:
 
 def build_particle(name: str, definition: dict) -> Particle:
     qn_def = definition["QuantumNumbers"]
+    width: Optional[float] = definition.get("Width", None)
+    if width is not None:
+        width = float(width)
     return Particle(
         name=name,
         pid=int(definition["PID"]),
-        mass=_yaml_to_measured_value(definition["Mass"]),
-        width=_yaml_to_measured_value_optional(definition.get("Width", None)),
+        mass=float(definition["Mass"]),
+        width=width,
         charge=int(qn_def["Charge"]),
         spin=float(qn_def["Spin"]),
         strangeness=int(qn_def.get("Strangeness", 0)),
@@ -47,26 +49,6 @@ def build_particle(name: str, definition: dict) -> Particle:
         c_parity=_yaml_to_parity(qn_def.get("CParity", None)),
         g_parity=_yaml_to_parity(qn_def.get("GParity", None)),
     )
-
-
-def _yaml_to_measured_value(
-    definition: Union[dict, float, int, str]
-) -> MeasuredValue:
-    if isinstance(definition, (float, int, str)):
-        return MeasuredValue(float(definition))
-    if "Error" not in definition:
-        return MeasuredValue(float(definition["Value"]))
-    return MeasuredValue(
-        float(definition["Value"]), float(definition["Error"])
-    )
-
-
-def _yaml_to_measured_value_optional(
-    definition: Optional[Union[dict, float, int, str]]
-) -> Optional[MeasuredValue]:
-    if definition is None:
-        return None
-    return _yaml_to_measured_value(definition)
 
 
 def _yaml_to_parity(

--- a/expertsystem/io/yaml/_dump.py
+++ b/expertsystem/io/yaml/_dump.py
@@ -2,6 +2,7 @@
 
 from typing import (
     Callable,
+    Dict,
     List,
     Optional,
     Tuple,
@@ -9,7 +10,6 @@ from typing import (
 )
 
 from expertsystem.data import (
-    MeasuredValue,
     Parity,
     Particle,
     ParticleCollection,
@@ -29,17 +29,19 @@ def from_particle_collection(particles: ParticleCollection) -> dict:
 
 
 def from_particle(particle: Particle) -> dict:
-    output_dict = {
+    output_dict: Dict[str, Union[float, int, dict]] = {
         "PID": particle.pid,
-        "Mass": _from_measured_value(particle.mass),
+        "Mass": particle.mass,
     }
     if particle.width is not None:
-        output_dict["Width"] = _from_measured_value(particle.width)
+        output_dict["Width"] = particle.width
     output_dict["QuantumNumbers"] = _to_quantum_number_dict(particle)
     return output_dict
 
 
-def _to_quantum_number_dict(particle: Particle) -> dict:
+def _to_quantum_number_dict(
+    particle: Particle,
+) -> Dict[str, Union[float, int]]:
     output_dict = {
         "Spin": _attempt_to_int(particle.spin),
         "Charge": int(particle.charge),
@@ -69,16 +71,7 @@ def _to_quantum_number_dict(particle: Particle) -> dict:
     return output_dict
 
 
-def _from_measured_value(instance: MeasuredValue) -> Union[dict, float]:
-    if instance.uncertainty is None:
-        return _attempt_to_int(instance.value)
-    return {
-        "Value": instance.value,
-        "Error": instance.uncertainty,
-    }
-
-
-def _from_spin(instance: Spin) -> Union[dict, int]:
+def _from_spin(instance: Spin) -> Union[Dict[str, Union[float, int]], int]:
     if instance.magnitude == 0:
         return 0
     return {

--- a/expertsystem/particle_list.xml
+++ b/expertsystem/particle_list.xml
@@ -468,7 +468,6 @@
         <Type>Mass</Type>
         <Name>Mass_pi0</Name>
         <Value>0.1349766</Value>
-        <Error>0.000006</Error>
       </Parameter>
       <QuantumNumber>
         <Class>Spin</Class>
@@ -509,7 +508,6 @@
         <Type>Mass</Type>
         <Name>Mass_pi+</Name>
         <Value>0.13957018</Value>
-        <Error>0.00000035</Error>
       </Parameter>
       <QuantumNumber>
         <Class>Spin</Class>
@@ -545,7 +543,6 @@
         <Type>Mass</Type>
         <Name>Mass_pi-</Name>
         <Value>0.13957018</Value>
-        <Error>0.00000035</Error>
       </Parameter>
       <QuantumNumber>
         <Class>Spin</Class>
@@ -581,7 +578,6 @@
         <Type>Mass</Type>
         <Name>Mass_eta</Name>
         <Value>0.547862</Value>
-        <Error>0.000017</Error>
       </Parameter>
       <QuantumNumber>
         <Class>Spin</Class>
@@ -612,7 +608,6 @@
           <Type>Width</Type>
           <Name>Width_eta</Name>
           <Value>0.00000131</Value>
-          <Error>0.00000005</Error>
         </Parameter>
         <Parameter>
           <Type>MesonRadius</Type>
@@ -630,7 +625,6 @@
         <Type>Mass</Type>
         <Name>Mass_rho(770)0</Name>
         <Value>0.77526</Value>
-        <Error>0.00025</Error>
       </Parameter>
       <QuantumNumber>
         <Class>Spin</Class>
@@ -689,7 +683,6 @@
         <Type>Mass</Type>
         <Name>Mass_rho(770)+</Name>
         <Value>0.77526</Value>
-        <Error>0.00025</Error>
       </Parameter>
       <QuantumNumber>
         <Class>Spin</Class>
@@ -743,7 +736,6 @@
         <Type>Mass</Type>
         <Name>Mass_rho(770)-</Name>
         <Value>0.77526</Value>
-        <Error>0.00025</Error>
       </Parameter>
       <QuantumNumber>
         <Class>Spin</Class>
@@ -797,7 +789,6 @@
         <Type>Mass</Type>
         <Name>Mass_omega(782)</Name>
         <Value>0.78265</Value>
-        <Error>0.00012</Error>
       </Parameter>
       <QuantumNumber>
         <Class>Spin</Class>
@@ -850,7 +841,6 @@
         <Type>Mass</Type>
         <Name>Mass_f0(980)</Name>
         <Value>0.994</Value>
-        <Error>0.001</Error>
       </Parameter>
       <QuantumNumber>
         <Class>Spin</Class>
@@ -903,7 +893,6 @@
         <Type>Mass</Type>
         <Name>Mass_f0(1500)</Name>
         <Value>1.505</Value>
-        <Error>0.006</Error>
       </Parameter>
       <QuantumNumber>
         <Class>Spin</Class>
@@ -956,7 +945,6 @@
         <Type>Mass</Type>
         <Name>Mass_f2(1270)</Name>
         <Value>1.2751</Value>
-        <Error>0.0012</Error>
       </Parameter>
       <QuantumNumber>
         <Class>Spin</Class>
@@ -1009,7 +997,6 @@
         <Type>Mass</Type>
         <Name>Mass_f2(1950)</Name>
         <Value>1.944</Value>
-        <Error>0.012</Error>
       </Parameter>
       <QuantumNumber>
         <Class>Spin</Class>
@@ -1062,7 +1049,6 @@
         <Type>Mass</Type>
         <Name>Mass_a0(980)0</Name>
         <Value>0.994</Value>
-        <Error>0.001</Error>
       </Parameter>
       <QuantumNumber>
         <Class>Spin</Class>
@@ -1104,7 +1090,6 @@
           <Type>Coupling</Type>
           <Name>gKK_a0(980)</Name>
           <Value>3.121343843602647</Value>
-          <Error>0.001</Error>
           <ParticleA>K+</ParticleA>
           <ParticleB>K-</ParticleB>
         </Parameter>
@@ -1112,7 +1097,6 @@
           <Type>Coupling</Type>
           <Name>gEtaPi_a0(980)</Name>
           <Value>2.66</Value>
-          <Error>0.001</Error>
           <ParticleA>eta</ParticleA>
           <ParticleB>pi0</ParticleB>
         </Parameter>
@@ -1120,7 +1104,6 @@
           <Type>Coupling</Type>
           <Name>gKK_a0(980)</Name>
           <Value>3.121343843602647</Value>
-          <Error>0.001</Error>
           <ParticleA>K_S0</ParticleA>
           <ParticleB>K_S0</ParticleB>
         </Parameter>
@@ -1140,7 +1123,6 @@
         <Type>Mass</Type>
         <Name>Mass_a0(980)+</Name>
         <Value>0.994</Value>
-        <Error>0.001</Error>
       </Parameter>
       <QuantumNumber>
         <Class>Spin</Class>
@@ -1177,7 +1159,6 @@
           <Type>Coupling</Type>
           <Name>gKK_a0(980)</Name>
           <Value>3.121343843602647</Value>
-          <Error>0.001</Error>
           <ParticleA>K_S0</ParticleA>
           <ParticleB>K+</ParticleB>
         </Parameter>
@@ -1185,7 +1166,6 @@
           <Type>Coupling</Type>
           <Name>gEtaPi_a0(980)</Name>
           <Value>2.66</Value>
-          <Error>0.001</Error>
           <ParticleA>eta</ParticleA>
           <ParticleB>pi0</ParticleB>
         </Parameter>
@@ -1205,7 +1185,6 @@
         <Type>Mass</Type>
         <Name>Mass_a0(980)-</Name>
         <Value>0.994</Value>
-        <Error>0.001</Error>
       </Parameter>
       <QuantumNumber>
         <Class>Spin</Class>
@@ -1242,7 +1221,6 @@
           <Type>Coupling</Type>
           <Name>gKK_a0(980)</Name>
           <Value>3.121343843602647</Value>
-          <Error>0.001</Error>
           <ParticleA>K_S0</ParticleA>
           <ParticleB>K+</ParticleB>
         </Parameter>
@@ -1250,7 +1228,6 @@
           <Type>Coupling</Type>
           <Name>gEtaPi_a0(980)</Name>
           <Value>2.66</Value>
-          <Error>0.001</Error>
           <ParticleA>eta</ParticleA>
           <ParticleB>pi0</ParticleB>
         </Parameter>
@@ -1270,7 +1247,6 @@
         <Type>Mass</Type>
         <Name>Mass_a2(1320)0</Name>
         <Value>1.3184</Value>
-        <Error>0.0005</Error>
       </Parameter>
       <QuantumNumber>
         <Class>Spin</Class>
@@ -1312,7 +1288,6 @@
           <Type>Width</Type>
           <Name>Width_a2(1320)0</Name>
           <Value>0.00107</Value>
-          <Error>0.00005</Error>
         </Parameter>
         <Parameter>
           <Type>MesonRadius</Type>
@@ -1330,7 +1305,6 @@
         <Type>Mass</Type>
         <Name>Mass_a2(1320)+</Name>
         <Value>1.3184</Value>
-        <Error>0.0005</Error>
       </Parameter>
       <QuantumNumber>
         <Class>Spin</Class>
@@ -1372,7 +1346,6 @@
           <Type>Width</Type>
           <Name>Width_a2(1320)+</Name>
           <Value>0.00107</Value>
-          <Error>0.00005</Error>
         </Parameter>
         <Parameter>
           <Type>MesonRadius</Type>
@@ -1390,7 +1363,6 @@
         <Type>Mass</Type>
         <Name>Mass_a2(1320)-</Name>
         <Value>1.3184</Value>
-        <Error>0.0005</Error>
       </Parameter>
       <QuantumNumber>
         <Class>Spin</Class>
@@ -1432,7 +1404,6 @@
           <Type>Width</Type>
           <Name>Width_a2(1320)-</Name>
           <Value>0.00107</Value>
-          <Error>0.00005</Error>
         </Parameter>
         <Parameter>
           <Type>MesonRadius</Type>
@@ -1450,7 +1421,6 @@
         <Type>Mass</Type>
         <Name>Mass_phi(1020)</Name>
         <Value>1.019461</Value>
-        <Error>0.000019</Error>
       </Parameter>
       <QuantumNumber>
         <Class>Spin</Class>
@@ -1481,7 +1451,6 @@
           <Type>Width</Type>
           <Name>Width_phi(1020)</Name>
           <Value>0.004266</Value>
-          <Error>0.000031</Error>
         </Parameter>
         <Parameter>
           <Type>MesonRadius</Type>

--- a/expertsystem/particle_list.yml
+++ b/expertsystem/particle_list.yml
@@ -12,21 +12,21 @@ ParticleList:
 
   W-:
     PID: -24
-    Mass: { Value: 80.385 }
+    Mass: 80.385
     QuantumNumbers:
       Spin: 1
       Charge: -1
 
   W+:
     PID: 24
-    Mass: { Value: 80.385 }
+    Mass: 80.385
     QuantumNumbers:
       Spin: 1
       Charge: 1
 
   e+:
     PID: 11
-    Mass: { Value: 0.0005109989461 }
+    Mass: 0.0005109989461
     QuantumNumbers:
       Spin: 0.5
       Charge: 1
@@ -35,7 +35,7 @@ ParticleList:
 
   e-:
     PID: -11
-    Mass: { Value: 0.0005109989461 }
+    Mass: 0.0005109989461
     QuantumNumbers:
       Spin: 0.5
       Charge: -1
@@ -44,7 +44,7 @@ ParticleList:
 
   mu+:
     PID: 13
-    Mass: { Value: 0.1056583745 }
+    Mass: 0.1056583745
     QuantumNumbers:
       Spin: 0.5
       Charge: 1
@@ -53,7 +53,7 @@ ParticleList:
 
   mu-:
     PID: -13
-    Mass: { Value: 0.1056583745 }
+    Mass: 0.1056583745
     QuantumNumbers:
       Spin: 0.5
       Charge: -1
@@ -62,7 +62,7 @@ ParticleList:
 
   tau+:
     PID: 15
-    Mass: { Value: 1.77686 }
+    Mass: 1.77686
     QuantumNumbers:
       Spin: 0.5
       Charge: 1
@@ -71,7 +71,7 @@ ParticleList:
 
   tau-:
     PID: -15
-    Mass: { Value: 1.77686 }
+    Mass: 1.77686
     QuantumNumbers:
       Spin: 0.5
       Charge: -1
@@ -80,7 +80,7 @@ ParticleList:
 
   ve:
     PID: 12
-    Mass: { Value: 1.0e-09 }
+    Mass: 1.0e-09
     QuantumNumbers:
       Spin: 0.5
       Charge: 0
@@ -89,7 +89,7 @@ ParticleList:
 
   vebar:
     PID: -12
-    Mass: { Value: 1.0e-09 }
+    Mass: 1.0e-09
     QuantumNumbers:
       Spin: 0.5
       Charge: 0
@@ -98,7 +98,7 @@ ParticleList:
 
   vmu:
     PID: 14
-    Mass: { Value: 1.0e-09 }
+    Mass: 1.0e-09
     QuantumNumbers:
       Spin: 0.5
       Charge: 0
@@ -107,7 +107,7 @@ ParticleList:
 
   vmubar:
     PID: -14
-    Mass: { Value: 1.0e-09 }
+    Mass: 1.0e-09
     QuantumNumbers:
       Spin: 0.5
       Charge: 0
@@ -116,7 +116,7 @@ ParticleList:
 
   vtau:
     PID: 16
-    Mass: { Value: 1.0e-09 }
+    Mass: 1.0e-09
     QuantumNumbers:
       Spin: 0.5
       Charge: 0
@@ -125,7 +125,7 @@ ParticleList:
 
   vtaubar:
     PID: -16
-    Mass: { Value: 1.0e-09 }
+    Mass: 1.0e-09
     QuantumNumbers:
       Spin: 0.5
       Charge: 0
@@ -134,7 +134,7 @@ ParticleList:
 
   pi0:
     PID: 111
-    Mass: { Value: 0.1349766, Error: 0.000006 }
+    Mass: 0.1349766
     QuantumNumbers:
       Spin: 0
       Charge: 0
@@ -145,7 +145,7 @@ ParticleList:
 
   pi+:
     PID: 211
-    Mass: { Value: 0.13957018, Error: 0.00000035 }
+    Mass: 0.13957018
     QuantumNumbers:
       Spin: 0
       Charge: +1
@@ -155,7 +155,7 @@ ParticleList:
 
   pi-:
     PID: -211
-    Mass: { Value: 0.13957018, Error: 0.00000035 }
+    Mass: 0.13957018
     QuantumNumbers:
       Spin: 0
       Charge: -1
@@ -165,8 +165,8 @@ ParticleList:
 
   eta:
     PID: 221
-    Mass: { Value: 0.547862, Error: 0.000017 }
-    Width: { Value: 0.00000131, Error: 0.00000005 }
+    Mass: 0.547862
+    Width: 0.00000131
     QuantumNumbers:
       Spin: 0
       Charge: 0
@@ -176,8 +176,8 @@ ParticleList:
 
   rho(770)0:
     PID: 113
-    Mass: { Value: 0.77526, Error: 0.00025 }
-    Width: { Value: 0.1491 }
+    Mass: 0.77526
+    Width: 0.1491
     QuantumNumbers:
       Spin: 1
       Charge: 0
@@ -188,8 +188,8 @@ ParticleList:
 
   rho(770)+:
     PID: 213
-    Mass: { Value: 0.77526, Error: 0.00025 }
-    Width: { Value: 0.1491 }
+    Mass: 0.77526
+    Width: 0.1491
     QuantumNumbers:
       Spin: 1
       Charge: +1
@@ -199,8 +199,8 @@ ParticleList:
 
   rho(770)-:
     PID: -213
-    Mass: { Value: 0.77526, Error: 0.00025 }
-    Width: { Value: 0.1491 }
+    Mass: 0.77526
+    Width: 0.1491
     QuantumNumbers:
       Spin: 1
       Charge: -1
@@ -210,8 +210,8 @@ ParticleList:
 
   omega(782):
     PID: 223
-    Mass: { Value: 0.78265, Error: 0.00012 }
-    Width: { Value: 0.000001491 }
+    Mass: 0.78265
+    Width: 0.000001491
     QuantumNumbers:
       Spin: 1
       Charge: 0
@@ -222,8 +222,8 @@ ParticleList:
 
   f0(980):
     PID: 9010221
-    Mass: { Value: 0.994, Error: 0.001 }
-    Width: { Value: 0.070 }
+    Mass: 0.994
+    Width: 0.070
     QuantumNumbers:
       Spin: 0
       Charge: 0
@@ -234,8 +234,8 @@ ParticleList:
 
   f0(1500):
     PID: 9030221
-    Mass: { Value: 1.505, Error: 0.006 }
-    Width: { Value: 0.109 }
+    Mass: 1.505
+    Width: 0.109
     QuantumNumbers:
       Spin: 0
       Charge: 0
@@ -245,8 +245,8 @@ ParticleList:
 
   f2(1270):
     PID: 225
-    Mass: { Value: 1.2751, Error: 0.0012 }
-    Width: { Value: 0.185 }
+    Mass: 1.2751
+    Width: 0.185
     QuantumNumbers:
       Spin: 2
       Charge: 0
@@ -256,8 +256,8 @@ ParticleList:
 
   f2(1950):
     PID: 9050225
-    Mass: { Value: 1.944, Error: 0.012 }
-    Width: { Value: 0.472 }
+    Mass: 1.944
+    Width: 0.472
     QuantumNumbers:
       Spin: 2
       Charge: 0
@@ -267,7 +267,7 @@ ParticleList:
 
   a0(980)0:
     PID: 9000111
-    Mass: { Value: 0.994, Error: 0.001 }
+    Mass: 0.994
     QuantumNumbers:
       Spin: 0
       Charge: 0
@@ -278,7 +278,7 @@ ParticleList:
 
   a0(980)+:
     PID: 9000211
-    Mass: { Value: 0.994, Error: 0.001 }
+    Mass: 0.994
     QuantumNumbers:
       Spin: 0
       Charge: 1
@@ -288,7 +288,7 @@ ParticleList:
 
   a0(980)-:
     PID: 9000211
-    Mass: { Value: 0.994, Error: 0.001 }
+    Mass: 0.994
     QuantumNumbers:
       Spin: 0
       Charge: -1
@@ -298,8 +298,8 @@ ParticleList:
 
   a2(1320)0:
     PID: 115
-    Mass: { Value: 1.3184, Error: 0.0005 }
-    Width: { Value: 0.00107, Error: 0.00005 }
+    Mass: 1.3184
+    Width: 0.00107
     QuantumNumbers:
       Spin: 2
       Charge: 0
@@ -310,8 +310,8 @@ ParticleList:
 
   a2(1320)+:
     PID: 215
-    Mass: { Value: 1.3184, Error: 0.0005 }
-    Width: { Value: 0.00107, Error: 0.00005 }
+    Mass: 1.3184
+    Width: 0.00107
     QuantumNumbers:
       Spin: 2
       Charge: 1
@@ -322,8 +322,8 @@ ParticleList:
 
   a2(1320)-:
     PID: -215
-    Mass: { Value: 1.3184, Error: 0.0005 }
-    Width: { Value: 0.00107, Error: 0.00005 }
+    Mass: 1.3184
+    Width: 0.00107
     QuantumNumbers:
       Spin: 2
       Charge: -1
@@ -334,8 +334,8 @@ ParticleList:
 
   phi(1020):
     PID: 333
-    Mass: { Value: 1.019461, Error: 0.000019 }
-    Width: { Value: 0.004266, Error: 0.000031 }
+    Mass: 1.019461
+    Width: 0.004266
     QuantumNumbers:
       Spin: 1
       Charge: 0
@@ -344,7 +344,7 @@ ParticleList:
 
   K-:
     PID: -321
-    Mass: { Value: 0.493677 }
+    Mass: 0.493677
     QuantumNumbers:
       Spin: 0
       Charge: -1
@@ -354,7 +354,7 @@ ParticleList:
 
   K+:
     PID: 321
-    Mass: { Value: 0.493677 }
+    Mass: 0.493677
     QuantumNumbers:
       Spin: 0
       Charge: 1
@@ -364,7 +364,7 @@ ParticleList:
 
   K_S0:
     PID: 310
-    Mass: { Value: 0.497614 }
+    Mass: 0.497614
     QuantumNumbers:
       Spin: 0
       Charge: 0
@@ -373,7 +373,7 @@ ParticleList:
 
   K_L0:
     PID: 130
-    Mass: { Value: 0.497614 }
+    Mass: 0.497614
     QuantumNumbers:
       Spin: 0
       Charge: 0
@@ -382,8 +382,8 @@ ParticleList:
 
   D+:
     PID: 411
-    Mass: { Value: 1.86958 }
-    Width: { Value: 6.33E-13 }
+    Mass: 1.86958
+    Width: 6.33E-13
     QuantumNumbers:
       Spin: 0
       Charge: +1
@@ -393,8 +393,8 @@ ParticleList:
 
   D-:
     PID: -411
-    Mass: { Value: 1.86958 }
-    Width: { Value: 6.33E-13 }
+    Mass: 1.86958
+    Width: 6.33E-13
     QuantumNumbers:
       Spin: 0
       Charge: -1
@@ -404,8 +404,8 @@ ParticleList:
 
   D0:
     PID: 421
-    Mass: { Value: 1.86483 }
-    Width: { Value: 1.605E-12 }
+    Mass: 1.86483
+    Width: 1.605E-12
     QuantumNumbers:
       Spin: 0
       Charge: 0
@@ -415,8 +415,8 @@ ParticleList:
 
   D0bar:
     PID: -421
-    Mass: { Value: 1.86483 }
-    Width: { Value: 1.605E-12 }
+    Mass: 1.86483
+    Width: 1.605E-12
     QuantumNumbers:
       Spin: 0
       Charge: 0
@@ -426,8 +426,8 @@ ParticleList:
 
   D*(2007)0:
     PID: 423
-    Mass: { Value: 2.007 }
-    Width: { Value: 0.001 }
+    Mass: 2.007
+    Width: 0.001
     QuantumNumbers:
       Spin: 1
       Charge: 0
@@ -437,8 +437,8 @@ ParticleList:
 
   D*(2007)0bar:
     PID: -423
-    Mass: { Value: 2.007 }
-    Width: { Value: 0.001 }
+    Mass: 2.007
+    Width: 0.001
     QuantumNumbers:
       Spin: 1
       Charge: 0
@@ -448,8 +448,8 @@ ParticleList:
 
   D*(2010)-:
     PID: -413
-    Mass: { Value: 2.01 }
-    Width: { Value: 83.4E-6 }
+    Mass: 2.01
+    Width: 83.4E-6
     QuantumNumbers:
       Spin: 1
       Charge: -1
@@ -459,8 +459,8 @@ ParticleList:
 
   D*(2010)+:
     PID: 413
-    Mass: { Value: 2.01 }
-    Width: { Value: 83.4E-6 }
+    Mass: 2.01
+    Width: 83.4E-6
     QuantumNumbers:
       Spin: 1
       Charge: 1
@@ -470,8 +470,8 @@ ParticleList:
 
   D1(2420)0:
     PID: 10423
-    Mass: { Value: 2.4214 }
-    Width: { Value: 27.4E-3 }
+    Mass: 2.4214
+    Width: 27.4E-3
     QuantumNumbers:
       Spin: 1
       Charge: 0
@@ -481,7 +481,7 @@ ParticleList:
 
   XX:
     PID: 1111
-    Mass: { Value: 4.100 }
+    Mass: 4.100
     QuantumNumbers:
       Spin: 1
       Charge: -1
@@ -490,8 +490,8 @@ ParticleList:
 
   J/psi:
     PID: 443
-    Mass: { Value: 3.096900 }
-    Width: { Value: 9.29E-05 }
+    Mass: 3.096900
+    Width: 9.29E-05
     QuantumNumbers:
       Spin: 1
       Charge: 0
@@ -502,8 +502,8 @@ ParticleList:
 
   Y:
     PID: 11443
-    Mass: { Value: 4.300 }
-    Width: { Value: 9.29E-05 }
+    Mass: 4.300
+    Width: 9.29E-05
     QuantumNumbers:
       Spin: 1
       Charge: 0
@@ -512,8 +512,8 @@ ParticleList:
 
   Chic1:
     PID: 1234
-    Mass: { Value: 3.510 }
-    Width: { Value: 0.00084 }
+    Mass: 3.510
+    Width: 0.00084
     QuantumNumbers:
       Spin: 1
       Charge: 0
@@ -524,7 +524,7 @@ ParticleList:
 
   p:
     PID: 2212
-    Mass: { Value: 0.938272081 }
+    Mass: 0.938272081
     QuantumNumbers:
       Spin: 0.5
       Charge: 1
@@ -534,7 +534,7 @@ ParticleList:
 
   pbar:
     PID: -2212
-    Mass: { Value: 0.938272081 }
+    Mass: 0.938272081
     QuantumNumbers:
       Spin: 0.5
       Charge: -1
@@ -544,7 +544,7 @@ ParticleList:
 
   n:
     PID: 2112
-    Mass: { Value: 0.939565413 }
+    Mass: 0.939565413
     QuantumNumbers:
       Spin: 0.5
       Charge: 0
@@ -554,7 +554,7 @@ ParticleList:
 
   nbar:
     PID: 2112
-    Mass: { Value: 0.939565413 }
+    Mass: 0.939565413
     QuantumNumbers:
       Spin: 0.5
       Charge: 0
@@ -564,8 +564,8 @@ ParticleList:
 
   N(1650)+:
     PID: 3112212
-    Mass: { Value: 1.650 }
-    Width: { Value: 0.125 }
+    Mass: 1.650
+    Width: 0.125
     QuantumNumbers:
       Spin: 0.5
       Charge: 1
@@ -575,8 +575,8 @@ ParticleList:
 
   N(1650)-:
     PID: -3112212
-    Mass: { Value: 1.650 }
-    Width: { Value: 0.125 }
+    Mass: 1.650
+    Width: 0.125
     QuantumNumbers:
       Spin: 0.5
       Charge: -1
@@ -586,7 +586,7 @@ ParticleList:
 
   Delta(1232)++:
     PID: 2224
-    Mass: { Value: 1.232 }
+    Mass: 1.232
     QuantumNumbers:
       Spin: 1.5
       Charge: 2
@@ -596,7 +596,7 @@ ParticleList:
 
   Delta(1232)+:
     PID: 2214
-    Mass: { Value: 1.232 }
+    Mass: 1.232
     QuantumNumbers:
       Spin: 1.5
       Charge: 1
@@ -606,7 +606,7 @@ ParticleList:
 
   Delta(1232)0:
     PID: 2114
-    Mass: { Value: 1.232 }
+    Mass: 1.232
     QuantumNumbers:
       Spin: 1.5
       Charge: 0
@@ -616,7 +616,7 @@ ParticleList:
 
   Delta(1232)-:
     PID: 1114
-    Mass: { Value: 1.232 }
+    Mass: 1.232
     QuantumNumbers:
       Spin: 1.5
       Charge: -1
@@ -626,7 +626,7 @@ ParticleList:
 
   lambda:
     PID: 3122
-    Mass: { Value: 1.115683 }
+    Mass: 1.115683
     QuantumNumbers:
       Spin: 0.5
       Charge: 0
@@ -637,7 +637,7 @@ ParticleList:
 
   lambdabar:
     PID: -3122
-    Mass: { Value: 1.115683 }
+    Mass: 1.115683
     QuantumNumbers:
       Spin: 0.5
       Charge: 0
@@ -648,8 +648,8 @@ ParticleList:
 
   sigma0:
     PID: 3212
-    Mass: { Value: 1.192642 }
-    Width: { Value: 0.0000089 }
+    Mass: 1.192642
+    Width: 0.0000089
     QuantumNumbers:
       Spin: 0.5
       Charge: 0
@@ -660,7 +660,7 @@ ParticleList:
 
   sigma+:
     PID: 3222
-    Mass: { Value: 1.18937 }
+    Mass: 1.18937
     QuantumNumbers:
       Spin: 0.5
       Charge: 1
@@ -671,7 +671,7 @@ ParticleList:
 
   sigma-:
     PID: 3112
-    Mass: { Value: 1.197449 }
+    Mass: 1.197449
     QuantumNumbers:
       Spin: 0.5
       Charge: -1
@@ -682,7 +682,7 @@ ParticleList:
 
   Xi0:
     PID: 3322
-    Mass: { Value: 1.31486 }
+    Mass: 1.31486
     QuantumNumbers:
       Spin: 0.5
       Charge: 0
@@ -693,7 +693,7 @@ ParticleList:
 
   Xi-:
     PID: 3312
-    Mass: { Value: 1.32171 }
+    Mass: 1.32171
     QuantumNumbers:
       Spin: 0.5
       Charge: -1

--- a/expertsystem/schemas/yaml/particle-list.json
+++ b/expertsystem/schemas/yaml/particle-list.json
@@ -11,8 +11,8 @@
       "required": ["PID", "Mass", "QuantumNumbers"],
       "properties": {
         "PID": { "type": "integer" },
-        "Mass": { "$ref": "#/definitions/MeasuredValue" },
-        "Width": { "$ref": "#/definitions/MeasuredValue" },
+        "Mass": { "type": "number" },
+        "Width": { "type": "number" },
         "QuantumNumbers": { "$ref": "#/definitions/QuantumNumbers" }
       },
       "additionalProperties": false
@@ -55,20 +55,6 @@
         }
       },
       "additionalProperties": false
-    },
-    "MeasuredValue": {
-      "anyOf": [
-        { "$ref": "#/definitions/Scalar" },
-        {
-          "type": "object",
-          "required": ["Value"],
-          "properties": {
-            "Value": { "$ref": "#/definitions/Scalar" },
-            "Error": { "$ref": "#/definitions/Scalar" }
-          },
-          "additionalProperties": false
-        }
-      ]
     },
     "Scalar": {
       "anyOf": [

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,3 +1,0 @@
-*.xml
-*.yaml
-*.yml

--- a/tests/amplitude/expected_recipe.yml
+++ b/tests/amplitude/expected_recipe.yml
@@ -1275,7 +1275,7 @@ ParticleList:
       GParity: -1
   f0(1500):
     PID: 9030221
-    Mass: { Value: 1.505, Error: 0.006 }
+    Mass: 1.505
     Width: 0.109
     QuantumNumbers:
       Spin: 0
@@ -1285,7 +1285,7 @@ ParticleList:
       GParity: 1
   f0(980):
     PID: 9010221
-    Mass: { Value: 0.994, Error: 0.001 }
+    Mass: 0.994
     Width: 0.070
     QuantumNumbers:
       Spin: 0
@@ -1295,7 +1295,7 @@ ParticleList:
       GParity: 1
   f2(1270):
     PID: 225
-    Mass: { Value: 1.2751, Error: 0.0012 }
+    Mass: 1.2751
     Width: 0.185
     QuantumNumbers:
       Spin: 2
@@ -1305,7 +1305,7 @@ ParticleList:
       GParity: 1
   f2(1950):
     PID: 9050225
-    Mass: { Value: 1.944, Error: 0.012 }
+    Mass: 1.944
     Width: 0.472
     QuantumNumbers:
       Spin: 2
@@ -1323,7 +1323,7 @@ ParticleList:
       CParity: -1
   pi0:
     PID: 111
-    Mass: { Value: 0.1349766, Error: 0.000006 }
+    Mass: 0.1349766
     QuantumNumbers:
       Spin: 0
       Charge: 0

--- a/tests/data/test_particle.py
+++ b/tests/data/test_particle.py
@@ -1,7 +1,6 @@
 import pytest
 
 from expertsystem.data import (
-    MeasuredValue,
     Parity,
     Particle,
     Spin,
@@ -28,21 +27,9 @@ def test_spin():
     assert isospin.projection == -0.5
 
 
-def test_measured_value():
-    value = MeasuredValue(5.2, 0.15)
-    assert value == 5.2
-    assert float(value) == 5.2
-    assert str(value) == "5.2 ± 0.15"
-    value = MeasuredValue(1)
-    assert str(value) == "1"
-
-
 def test_particle():
-    particle = Particle(
-        "J/psi", 443, charge=0, spin=1, mass=MeasuredValue(3.0969)
-    )
+    particle = Particle("J/psi", 443, charge=0, spin=1, mass=3.0969)
     assert particle.mass == 3.0969
-    assert particle.mass.uncertainty is None
     assert particle.bottomness == 0
     with pytest.raises(AttributeError):
         particle.baryon_number = -1

--- a/tests/io/test_particle_collection.py
+++ b/tests/io/test_particle_collection.py
@@ -6,7 +6,6 @@ import expertsystem
 from expertsystem import io
 from expertsystem import ui
 from expertsystem.data import (
-    MeasuredValue,
     Parity,
     Particle,
     ParticleCollection,
@@ -20,8 +19,8 @@ _YAML_FILE = f"{EXPERTSYSTEM_PATH}/particle_list.yml"
 J_PSI = Particle(
     name="J/psi",
     pid=443,
-    mass=MeasuredValue(3.0969),
-    width=MeasuredValue(9.29e-05),
+    mass=3.0969,
+    width=9.29e-05,
     spin=1,
     charge=0,
     parity=Parity(-1),
@@ -79,7 +78,11 @@ def test_yaml_to_xml():
 def test_equivalence_xml_yaml_particle_list():
     xml_particle_collection = io.load_particle_collection(_XML_FILE)
     yml_particle_collection = io.load_particle_collection(_YAML_FILE)
-    assert xml_particle_collection == yml_particle_collection
+    for xml_particle, yml_particle in zip(
+        sorted(xml_particle_collection.values()),
+        sorted(yml_particle_collection.values()),
+    ):
+        assert xml_particle == yml_particle
 
 
 class TestInternalParticleDict:


### PR DESCRIPTION
Particle mass and width have become `float`, that is, the uncertainty in these attributes (embedded through `MeasuredValue`) is not available anymore, as it is not used internally by the `expertsystem`.

Closes #123