### PR TITLE
feat: define quantum state interfaces

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -26,4 +26,4 @@ min-public-methods=1
 
 [SIMILARITIES]
 ignore-imports=yes # https://stackoverflow.com/a/30007053
-min-similarity-lines=7  # https://github.com/PyCQA/pylint/issues/214
+min-similarity-lines=8  # https://github.com/PyCQA/pylint/issues/214

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,16 +28,13 @@ jobs:
         - NBSPHINX_EXECUTE='' make html
 
     - name: "Style checks"
-      python: 3.6
+      python: 3.7
       install:
         - npm install -g cspell
         - pip3 install .[dev]
       script:
         - tox -e sty
         - cspell $(git ls-files)
-
-    - name: "Python 3.6 on Ubuntu 18.04"
-      python: 3.6
 
     - name: "Python 3.7 on Ubuntu 18.04 + CodeCov"
       python: 3.7

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/ComPWA/expertsystem/master?filepath=examples%2Fquickstart.ipynb)
 [![PyPI](https://badge.fury.io/py/expertsystem.svg)](https://pypi.org/project/expertsystem)
+[![PyPI - Python Version](https://img.shields.io/pypi/pyversions/expertsystem)](https://pypi.org/project/expertsystem)
 [![Travis CI](https://travis-ci.com/ComPWA/expertsystem.svg?branch=master)](https://travis-ci.com/ComPWA/expertsystem)
 [![Test coverage](https://codecov.io/gh/ComPWA/expertsystem/branch/master/graph/badge.svg)](https://codecov.io/gh/ComPWA/expertsystem)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/db355758fb0e4654818b85997f03e3b8)](https://www.codacy.com/gh/ComPWA/expertsystem)

--- a/cspell.json
+++ b/cspell.json
@@ -93,6 +93,7 @@
         "flatte",
         "genindex",
         "heli",
+        "imag",
         "kernelspec",
         "maxdepth",
         "mimetype",

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -70,7 +70,6 @@ extensions = [
     "sphinx.ext.mathjax",
     "sphinx.ext.napoleon",
     "sphinx.ext.viewcode",
-    "sphinx_autodoc_typehints",
     "sphinx_copybutton",
 ]
 exclude_patterns = [

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -5,6 +5,10 @@
   :alt: PyPI
   :target: https://pypi.org/project/expertsystem
 
+.. image:: https://img.shields.io/pypi/pyversions/expertsystem
+  :alt: PyPI - Python Version
+  :target: https://pypi.org/project/expertsystem
+
 .. image:: https://travis-ci.com/ComPWA/expertsystem.svg?branch=master
   :alt: Travis CI
   :target: https://travis-ci.com/ComPWA/expertsystem

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - python>=3.6
+  - python>=3.7
   - pip
   - pip:
       - -e .

--- a/expertsystem/__init__.py
+++ b/expertsystem/__init__.py
@@ -41,12 +41,12 @@ def __check_python_version() -> None:
         minor = sys.version_info[1]
         patch = sys.version_info[2]
         print(f"You are running python {major}.{minor}.{patch}")
-        print("The expertsystem module requires Python 3.6 or higher!")
+        print("The expertsystem module requires Python 3.7 or higher!")
         sys.exit()
 
     if sys.version_info.major < 3:
         print_message_and_exit()
-    elif sys.version_info.major == 3 and sys.version_info.minor < 6:
+    elif sys.version_info.major == 3 and sys.version_info.minor < 7:
         print_message_and_exit()
 
 

--- a/expertsystem/data.py
+++ b/expertsystem/data.py
@@ -43,16 +43,19 @@ class Parity:
 class Spin(abc.Hashable):
     """Safe, immutable data container for (iso)spin."""
 
-    def __init__(self, magnitude: float, projection: float) -> None:
+    def __init__(
+        self, magnitude: float, projection: Optional[float] = None
+    ) -> None:
         magnitude = float(magnitude)
-        projection = float(projection)
-        if abs(projection) > magnitude:
-            raise ValueError(
-                "Spin projection cannot be larger than its magnitude:\n"
-                f"  {projection} > {magnitude}"
-            )
-        if projection == -0.0:
-            projection = 0.0
+        if projection is not None:
+            projection = float(projection)
+            if abs(projection) > magnitude:
+                raise ValueError(
+                    "Spin projection cannot be larger than its magnitude:\n"
+                    f"  {projection} > {magnitude}"
+                )
+            if projection == -0.0:
+                projection = 0.0
         self.__magnitude = magnitude
         self.__projection = projection
 
@@ -75,7 +78,7 @@ class Spin(abc.Hashable):
         return self.__magnitude
 
     @property
-    def projection(self) -> float:
+    def projection(self) -> Optional[float]:
         return self.__projection
 
     def __hash__(self) -> int:

--- a/expertsystem/data.py
+++ b/expertsystem/data.py
@@ -117,7 +117,10 @@ class ComplexEnergyState:
 
     def __eq__(self, other: object) -> bool:
         if isinstance(other, ComplexEnergyState):
-            return self == other
+            return (
+                self.complex_energy == other.complex_energy
+                and self.state == other.state
+            )
         raise NotImplementedError
 
     def __repr__(self) -> str:
@@ -163,8 +166,6 @@ class Particle(ComplexEnergyState):
                 and self.complex_energy == other.complex_energy
                 and self.state == other.state
             )
-        if isinstance(other, ComplexEnergyState):
-            return super() == other
         raise NotImplementedError
 
     def __repr__(self) -> str:

--- a/expertsystem/data.py
+++ b/expertsystem/data.py
@@ -146,9 +146,9 @@ class QuantumState(NamedTuple):
     bottomness: int = 0
     topness: int = 0
     baryon_number: int = 0
-    electron_number: int = 0
-    muon_number: int = 0
-    tau_number: int = 0
+    electron_lepton_number: int = 0
+    muon_lepton_number: int = 0
+    tau_lepton_number: int = 0
     parity: Optional[Parity] = None
     c_parity: Optional[Parity] = None
     g_parity: Optional[Parity] = None

--- a/expertsystem/data.py
+++ b/expertsystem/data.py
@@ -118,8 +118,6 @@ class ComplexEnergyState:
     def __eq__(self, other: object) -> bool:
         if isinstance(other, ComplexEnergyState):
             return self == other
-        if isinstance(other, QuantumState):
-            return self.state == other
         raise NotImplementedError
 
     def __repr__(self) -> str:

--- a/expertsystem/data.py
+++ b/expertsystem/data.py
@@ -1,6 +1,7 @@
 """A collection of data containers."""
 
 from collections import abc
+from dataclasses import dataclass
 from typing import (
     Dict,
     ItemsView,
@@ -10,7 +11,6 @@ from typing import (
     Union,
     ValuesView,
 )
-from typing import NamedTuple
 
 
 class Parity:
@@ -85,7 +85,8 @@ class Spin(abc.Hashable):
         return hash(repr(self))
 
 
-class QuantumState(NamedTuple):
+@dataclass(frozen=True)
+class QuantumState:  # pylint: disable=too-many-instance-attributes
     """Collection of properties defining a quantum mechanical state.
 
     Related to `.Particle`, but can contain more specific quantum state

--- a/expertsystem/data.py
+++ b/expertsystem/data.py
@@ -85,6 +85,36 @@ class Spin(abc.Hashable):
         return hash(repr(self))
 
 
+class QuantumState(NamedTuple):
+    """Collection of properties defining a quantum mechanical state.
+
+    Related to `.Particle`, but can contain more specific quantum state
+    information, such as `.Spin` projection.
+    """
+
+    charge: int
+    spin: Spin
+    isospin: Optional[Spin] = None
+    strangeness: int = 0
+    charmness: int = 0
+    bottomness: int = 0
+    topness: int = 0
+    baryon_number: int = 0
+    electron_lepton_number: int = 0
+    muon_lepton_number: int = 0
+    tau_lepton_number: int = 0
+    parity: Optional[Parity] = None
+    c_parity: Optional[Parity] = None
+    g_parity: Optional[Parity] = None
+
+
+class ComplexEnergyState(NamedTuple):
+    """Pole in the complex energy plane, with quantum numbers."""
+
+    energy: complex
+    state: QuantumState
+
+
 class Particle(NamedTuple):
     """Immutable container of data defining a physical particle.
 
@@ -143,33 +173,3 @@ class ParticleCollection(abc.Mapping):
 
     def values(self) -> ValuesView[Particle]:
         return self.__particles.values()
-
-
-class QuantumState(NamedTuple):
-    """Collection of properties defining a quantum mechanical state.
-
-    Related to `.Particle`, but can contain more specific quantum state
-    information, such as `.Spin` projection.
-    """
-
-    charge: int
-    spin: Spin
-    isospin: Optional[Spin] = None
-    strangeness: int = 0
-    charmness: int = 0
-    bottomness: int = 0
-    topness: int = 0
-    baryon_number: int = 0
-    electron_lepton_number: int = 0
-    muon_lepton_number: int = 0
-    tau_lepton_number: int = 0
-    parity: Optional[Parity] = None
-    c_parity: Optional[Parity] = None
-    g_parity: Optional[Parity] = None
-
-
-class ComplexEnergyState(NamedTuple):
-    """Pole in the complex energy plane, with quantum numbers."""
-
-    energy: complex
-    state: QuantumState

--- a/expertsystem/data.py
+++ b/expertsystem/data.py
@@ -74,7 +74,7 @@ class Spin:
 class Particle(NamedTuple):
     """Immutable container of data defining a physical particle.
 
-    Can *only** contain info that the `PDG <http://pdg.lbl.gov/>`_ would list.
+    Can **only** contain info that the `PDG <http://pdg.lbl.gov/>`_ would list.
     """
 
     name: str
@@ -140,7 +140,7 @@ class QuantumState(NamedTuple):
 
     charge: int
     spin: Spin
-    mass: float
+    isospin: Optional[Spin] = None
     strangeness: int = 0
     charmness: int = 0
     bottomness: int = 0
@@ -149,8 +149,6 @@ class QuantumState(NamedTuple):
     electron_number: int = 0
     muon_number: int = 0
     tau_number: int = 0
-    width: Optional[float] = None
-    isospin: Optional[Spin] = None
     parity: Optional[Parity] = None
     c_parity: Optional[Parity] = None
     g_parity: Optional[Parity] = None
@@ -159,6 +157,6 @@ class QuantumState(NamedTuple):
 class ComplexEnergyState(NamedTuple):
     """Pole in the complex energy plane with quantum numbers."""
 
-    position: float
-    width: float
+    energy_real: float
+    energy_imaginary: float
     state: QuantumState

--- a/expertsystem/data.py
+++ b/expertsystem/data.py
@@ -94,7 +94,7 @@ class Particle(NamedTuple):
     name: str
     pid: int
     charge: int
-    spin: float
+    spin: Spin
     mass: float
     strangeness: int = 0
     charmness: int = 0

--- a/expertsystem/data.py
+++ b/expertsystem/data.py
@@ -72,7 +72,10 @@ class Spin:
 
 
 class Particle(NamedTuple):
-    """Immutable data container for particle info."""
+    """Immutable container of data defining a physical particle.
+
+    Can *only** contain info that the `PDG <http://pdg.lbl.gov/>`_ would list.
+    """
 
     name: str
     pid: int
@@ -126,3 +129,36 @@ class ParticleCollection(abc.Mapping):
 
     def values(self) -> ValuesView[Particle]:
         return self.__particles.values()
+
+
+class QuantumState(NamedTuple):
+    """Collection of properties defining a quantum mechanical state.
+
+    Related to `.Particle`, but can contain more specific quantum state
+    information, such as `.Spin` projection.
+    """
+
+    charge: int
+    spin: Spin
+    mass: float
+    strangeness: int = 0
+    charmness: int = 0
+    bottomness: int = 0
+    topness: int = 0
+    baryon_number: int = 0
+    electron_number: int = 0
+    muon_number: int = 0
+    tau_number: int = 0
+    width: Optional[float] = None
+    isospin: Optional[Spin] = None
+    parity: Optional[Parity] = None
+    c_parity: Optional[Parity] = None
+    g_parity: Optional[Parity] = None
+
+
+class ComplexEnergyState(NamedTuple):
+    """Pole in the complex energy plane with quantum numbers."""
+
+    position: float
+    width: float
+    state: QuantumState

--- a/expertsystem/data.py
+++ b/expertsystem/data.py
@@ -166,8 +166,7 @@ class QuantumState(NamedTuple):
 
 
 class ComplexEnergyState(NamedTuple):
-    """Pole in the complex energy plane with quantum numbers."""
+    """Pole in the complex energy plane, with quantum numbers."""
 
-    energy_real: float
-    energy_imaginary: float
+    energy: complex
     state: QuantumState

--- a/expertsystem/io/xml/__init__.py
+++ b/expertsystem/io/xml/__init__.py
@@ -12,14 +12,12 @@ import xmltodict
 from expertsystem.data import (
     Particle,
     ParticleCollection,
+    Spin,
 )
 
+from . import _build
 from . import _dump
 from . import validation
-from ._build import (
-    build_particle,
-    build_particle_collection,
-)
 
 
 def load_particle_collection(filename: str) -> ParticleCollection:
@@ -27,7 +25,7 @@ def load_particle_collection(filename: str) -> ParticleCollection:
         definition = xmltodict.parse(stream)
     definition = definition.get("root", definition)
     json.loads(json.dumps(definition))  # remove OrderedDict
-    return build_particle_collection(definition)
+    return _build.build_particle_collection(definition)
 
 
 def write(instance: object, filename: str) -> None:
@@ -56,8 +54,12 @@ def object_to_dict(instance: object) -> dict:
 
 
 def dict_to_particle_collection(definition: dict) -> ParticleCollection:
-    return build_particle_collection(definition)
+    return _build.build_particle_collection(definition)
 
 
 def dict_to_particle(definition: dict) -> Particle:
-    return build_particle(definition)
+    return _build.build_particle(definition)
+
+
+def dict_to_spin(definition: dict) -> Spin:
+    return _build.build_spin(definition)

--- a/expertsystem/io/xml/_build.py
+++ b/expertsystem/io/xml/_build.py
@@ -68,6 +68,16 @@ def build_particle(definition: dict) -> Particle:
     )
 
 
+def build_spin(definition: dict) -> Spin:
+    magnitude = float(definition["Value"])
+    if "Projection" not in definition and magnitude != 0.0:
+        raise ValueError(
+            "Can only have a spin without projection if magnitude = 0"
+        )
+    projection = float(definition["Projection"])
+    return Spin(magnitude, projection)
+
+
 def _xml_to_width(definition: dict) -> Optional[float]:
     definition = definition.get("DecayInfo", {})
     definition = definition.get("Parameter", None)
@@ -102,7 +112,7 @@ def _xml_to_quantum_number(definition: Dict[str, str]) -> Tuple[str, Any]:
         "Parity": _xml_to_parity,
         "CParity": _xml_to_parity,
         "GParity": _xml_to_parity,
-        "IsoSpin": _xml_to_spin,
+        "IsoSpin": _xml_to_isospin,
     }
     type_name = definition["Type"]
     for key, converter in conversion_map.items():
@@ -127,13 +137,8 @@ def _xml_to_parity(definition: dict) -> Parity:
     return Parity(_xml_to_int(definition))
 
 
-def _xml_to_spin(definition: dict) -> Optional[Spin]:
-    magnitude = float(definition["Value"])
-    if "Projection" not in definition and magnitude != 0.0:
-        raise ValueError(
-            "Can only have a spin without projection if magnitude = 0"
-        )
-    if magnitude == 0.0:
+def _xml_to_isospin(definition: dict) -> Optional[Spin]:
+    spin = build_spin(definition)
+    if spin.magnitude == 0.0:
         return None
-    projection = float(definition["Projection"])
-    return Spin(magnitude, projection)
+    return spin

--- a/expertsystem/io/xml/_build.py
+++ b/expertsystem/io/xml/_build.py
@@ -52,7 +52,7 @@ def build_particle(definition: dict) -> Particle:
         mass=float(definition["Parameter"]["Value"]),
         width=_xml_to_width(definition),
         charge=int(qn_defs["Charge"]),
-        spin=float(qn_defs["Spin"]),
+        spin=Spin(qn_defs["Spin"]),
         strangeness=int(qn_defs.get("Strangeness", 0)),
         charmness=int(qn_defs.get("Charm", 0)),
         bottomness=int(qn_defs.get("Bottomness", 0)),
@@ -69,12 +69,8 @@ def build_particle(definition: dict) -> Particle:
 
 
 def build_spin(definition: dict) -> Spin:
-    magnitude = float(definition["Value"])
-    if "Projection" not in definition and magnitude != 0.0:
-        raise ValueError(
-            "Can only have a spin without projection if magnitude = 0"
-        )
-    projection = float(definition["Projection"])
+    magnitude = definition["Value"]
+    projection = definition.get("Projection", None)
     return Spin(magnitude, projection)
 
 

--- a/expertsystem/io/xml/_build.py
+++ b/expertsystem/io/xml/_build.py
@@ -15,7 +15,7 @@ from expertsystem.data import (
     Parity,
     Particle,
     ParticleCollection,
-    QuantumState,
+    ParticleQuantumState,
     Spin,
 )
 
@@ -52,9 +52,9 @@ def build_particle(definition: dict) -> Particle:
         pid=int(definition["Pid"]),
         mass=float(definition["Parameter"]["Value"]),
         width=_xml_to_width(definition),
-        state=QuantumState(
+        state=ParticleQuantumState(
             charge=int(qn_defs["Charge"]),
-            spin=Spin(qn_defs["Spin"]),
+            spin=float(qn_defs["Spin"]),
             isospin=qn_defs.get("IsoSpin", None),
             strangeness=int(qn_defs.get("Strangeness", 0)),
             charmness=int(qn_defs.get("Charm", 0)),

--- a/expertsystem/io/xml/_build.py
+++ b/expertsystem/io/xml/_build.py
@@ -15,6 +15,7 @@ from expertsystem.data import (
     Parity,
     Particle,
     ParticleCollection,
+    QuantumState,
     Spin,
 )
 
@@ -51,20 +52,22 @@ def build_particle(definition: dict) -> Particle:
         pid=int(definition["Pid"]),
         mass=float(definition["Parameter"]["Value"]),
         width=_xml_to_width(definition),
-        charge=int(qn_defs["Charge"]),
-        spin=Spin(qn_defs["Spin"]),
-        strangeness=int(qn_defs.get("Strangeness", 0)),
-        charmness=int(qn_defs.get("Charm", 0)),
-        bottomness=int(qn_defs.get("Bottomness", 0)),
-        topness=int(qn_defs.get("Topness", 0)),
-        baryon_number=int(qn_defs.get("BaryonNumber", 0)),
-        electron_number=int(qn_defs.get("ElectronLN", 0)),
-        muon_number=int(qn_defs.get("MuonLN", 0)),
-        tau_number=int(qn_defs.get("TauLN", 0)),
-        isospin=qn_defs.get("IsoSpin", None),
-        parity=qn_defs.get("Parity", None),
-        c_parity=qn_defs.get("CParity", None),
-        g_parity=qn_defs.get("GParity", None),
+        state=QuantumState(
+            charge=int(qn_defs["Charge"]),
+            spin=Spin(qn_defs["Spin"]),
+            isospin=qn_defs.get("IsoSpin", None),
+            strangeness=int(qn_defs.get("Strangeness", 0)),
+            charmness=int(qn_defs.get("Charm", 0)),
+            bottomness=int(qn_defs.get("Bottomness", 0)),
+            topness=int(qn_defs.get("Topness", 0)),
+            baryon_number=int(qn_defs.get("BaryonNumber", 0)),
+            electron_lepton_number=int(qn_defs.get("ElectronLN", 0)),
+            muon_lepton_number=int(qn_defs.get("MuonLN", 0)),
+            tau_lepton_number=int(qn_defs.get("TauLN", 0)),
+            parity=qn_defs.get("Parity", None),
+            c_parity=qn_defs.get("CParity", None),
+            g_parity=qn_defs.get("GParity", None),
+        ),
     )
 
 
@@ -74,7 +77,7 @@ def build_spin(definition: dict) -> Spin:
     return Spin(magnitude, projection)
 
 
-def _xml_to_width(definition: dict) -> Optional[float]:
+def _xml_to_width(definition: dict) -> float:
     definition = definition.get("DecayInfo", {})
     definition = definition.get("Parameter", None)
     if isinstance(definition, list):
@@ -83,7 +86,7 @@ def _xml_to_width(definition: dict) -> Optional[float]:
                 definition = item
                 break
     if definition is None or not isinstance(definition, dict):
-        return None
+        return 0.0
     return float(definition["Value"])
 
 

--- a/expertsystem/io/xml/_dump.py
+++ b/expertsystem/io/xml/_dump.py
@@ -62,7 +62,7 @@ def _to_quantum_number_list(particle: Particle) -> List[Dict[str, Any]]:
     conversion_map: Dict[
         str, Union[Optional[Parity], Optional[Spin], float, int]
     ] = {
-        "Spin": particle.spin,
+        "Spin": particle.spin.magnitude,
         "Charge": particle.charge,
         "Parity": particle.parity,
         "CParity": particle.c_parity,

--- a/expertsystem/io/xml/_dump.py
+++ b/expertsystem/io/xml/_dump.py
@@ -62,7 +62,7 @@ def _to_quantum_number_list(particle: Particle) -> List[Dict[str, Any]]:
     conversion_map: Dict[
         str, Union[Optional[Parity], Optional[Spin], float, int]
     ] = {
-        "Spin": particle.state.spin.magnitude,
+        "Spin": particle.state.spin,
         "Charge": particle.state.charge,
         "Parity": particle.state.parity,
         "CParity": particle.state.c_parity,

--- a/expertsystem/io/xml/_dump.py
+++ b/expertsystem/io/xml/_dump.py
@@ -43,7 +43,7 @@ def from_particle(particle: Particle) -> dict:
         },
     }
     output_dict["QuantumNumber"] = _to_quantum_number_list(particle)
-    if particle.width is not None:
+    if particle.width != 0.0:
         decay_info = {
             "Parameter": [
                 {
@@ -62,20 +62,20 @@ def _to_quantum_number_list(particle: Particle) -> List[Dict[str, Any]]:
     conversion_map: Dict[
         str, Union[Optional[Parity], Optional[Spin], float, int]
     ] = {
-        "Spin": particle.spin.magnitude,
-        "Charge": particle.charge,
-        "Parity": particle.parity,
-        "CParity": particle.c_parity,
-        "GParity": particle.g_parity,
-        "Strangeness": particle.strangeness,
-        "Charm": particle.charmness,
-        "Bottom": particle.bottomness,
-        "Top": particle.topness,
-        "BaryonNumber": particle.baryon_number,
-        "ElectronLN": particle.electron_number,
-        "MuonLN": particle.muon_number,
-        "TauLN": particle.tau_number,
-        "IsoSpin": particle.isospin,
+        "Spin": particle.state.spin.magnitude,
+        "Charge": particle.state.charge,
+        "Parity": particle.state.parity,
+        "CParity": particle.state.c_parity,
+        "GParity": particle.state.g_parity,
+        "Strangeness": particle.state.strangeness,
+        "Charm": particle.state.charmness,
+        "Bottom": particle.state.bottomness,
+        "Top": particle.state.topness,
+        "BaryonNumber": particle.state.baryon_number,
+        "ElectronLN": particle.state.electron_lepton_number,
+        "MuonLN": particle.state.muon_lepton_number,
+        "TauLN": particle.state.tau_lepton_number,
+        "IsoSpin": particle.state.isospin,
     }
     output: List[Dict[str, Any]] = list()
     for type_name, instance in conversion_map.items():

--- a/expertsystem/io/yaml/__init__.py
+++ b/expertsystem/io/yaml/__init__.py
@@ -10,13 +10,11 @@ import yaml
 from expertsystem.data import (
     Particle,
     ParticleCollection,
+    Spin,
 )
 
+from . import _build
 from . import _dump
-from ._build import (
-    build_particle,
-    build_particle_collection,
-)
 
 
 class _IncreasedIndent(yaml.Dumper):
@@ -34,7 +32,7 @@ class _IncreasedIndent(yaml.Dumper):
 def load_particle_collection(filename: str) -> ParticleCollection:
     with open(filename) as yaml_file:
         definition = yaml.load(yaml_file, Loader=yaml.SafeLoader)
-    return build_particle_collection(definition)
+    return _build.build_particle_collection(definition)
 
 
 def write(instance: object, filename: str) -> None:
@@ -63,8 +61,12 @@ def object_to_dict(instance: object) -> dict:
 
 
 def dict_to_particle_collection(definition: dict) -> ParticleCollection:
-    return build_particle_collection(definition)
+    return _build.build_particle_collection(definition)
 
 
 def dict_to_particle(definition: dict, name: str) -> Particle:
-    return build_particle(name, definition)
+    return _build.build_particle(name, definition)
+
+
+def dict_to_spin(definition: dict) -> Spin:
+    return _build.build_spin(definition)

--- a/expertsystem/io/yaml/_build.py
+++ b/expertsystem/io/yaml/_build.py
@@ -9,7 +9,7 @@ from expertsystem.data import (
     Parity,
     Particle,
     ParticleCollection,
-    QuantumState,
+    ParticleQuantumState,
     Spin,
 )
 
@@ -32,9 +32,9 @@ def build_particle(name: str, definition: dict) -> Particle:
         pid=int(definition["PID"]),
         mass=float(definition["Mass"]),
         width=float(definition.get("Width", 0.0)),
-        state=QuantumState(
+        state=ParticleQuantumState(
             charge=int(qn_def["Charge"]),
-            spin=Spin(qn_def["Spin"]),
+            spin=float(qn_def["Spin"]),
             strangeness=int(qn_def.get("Strangeness", 0)),
             charmness=int(qn_def.get("Charmness", 0)),
             bottomness=int(qn_def.get("Bottomness", 0)),

--- a/expertsystem/io/yaml/_build.py
+++ b/expertsystem/io/yaml/_build.py
@@ -9,6 +9,7 @@ from expertsystem.data import (
     Parity,
     Particle,
     ParticleCollection,
+    QuantumState,
     Spin,
 )
 
@@ -26,28 +27,27 @@ def build_particle_collection(definition: dict) -> ParticleCollection:
 
 def build_particle(name: str, definition: dict) -> Particle:
     qn_def = definition["QuantumNumbers"]
-    width: Optional[float] = definition.get("Width", None)
-    if width is not None:
-        width = float(width)
     return Particle(
         name=name,
         pid=int(definition["PID"]),
         mass=float(definition["Mass"]),
-        width=width,
-        charge=int(qn_def["Charge"]),
-        spin=Spin(qn_def["Spin"]),
-        strangeness=int(qn_def.get("Strangeness", 0)),
-        charmness=int(qn_def.get("Charmness", 0)),
-        bottomness=int(qn_def.get("Bottomness", 0)),
-        topness=int(qn_def.get("Topness", 0)),
-        baryon_number=int(qn_def.get("BaryonNumber", 0)),
-        electron_number=int(qn_def.get("ElectronLN", 0)),
-        muon_number=int(qn_def.get("MuonLN", 0)),
-        tau_number=int(qn_def.get("TauLN", 0)),
-        isospin=_yaml_to_isospin(qn_def.get("IsoSpin", None)),
-        parity=_yaml_to_parity(qn_def.get("Parity", None)),
-        c_parity=_yaml_to_parity(qn_def.get("CParity", None)),
-        g_parity=_yaml_to_parity(qn_def.get("GParity", None)),
+        width=float(definition.get("Width", 0.0)),
+        state=QuantumState(
+            charge=int(qn_def["Charge"]),
+            spin=Spin(qn_def["Spin"]),
+            strangeness=int(qn_def.get("Strangeness", 0)),
+            charmness=int(qn_def.get("Charmness", 0)),
+            bottomness=int(qn_def.get("Bottomness", 0)),
+            topness=int(qn_def.get("Topness", 0)),
+            baryon_number=int(qn_def.get("BaryonNumber", 0)),
+            electron_lepton_number=int(qn_def.get("ElectronLN", 0)),
+            muon_lepton_number=int(qn_def.get("MuonLN", 0)),
+            tau_lepton_number=int(qn_def.get("TauLN", 0)),
+            isospin=_yaml_to_isospin(qn_def.get("IsoSpin", None)),
+            parity=_yaml_to_parity(qn_def.get("Parity", None)),
+            c_parity=_yaml_to_parity(qn_def.get("CParity", None)),
+            g_parity=_yaml_to_parity(qn_def.get("GParity", None)),
+        ),
     )
 
 

--- a/expertsystem/io/yaml/_build.py
+++ b/expertsystem/io/yaml/_build.py
@@ -35,7 +35,7 @@ def build_particle(name: str, definition: dict) -> Particle:
         mass=float(definition["Mass"]),
         width=width,
         charge=int(qn_def["Charge"]),
-        spin=float(qn_def["Spin"]),
+        spin=Spin(qn_def["Spin"]),
         strangeness=int(qn_def.get("Strangeness", 0)),
         charmness=int(qn_def.get("Charmness", 0)),
         bottomness=int(qn_def.get("Bottomness", 0)),

--- a/expertsystem/io/yaml/_build.py
+++ b/expertsystem/io/yaml/_build.py
@@ -44,27 +44,14 @@ def build_particle(name: str, definition: dict) -> Particle:
         electron_number=int(qn_def.get("ElectronLN", 0)),
         muon_number=int(qn_def.get("MuonLN", 0)),
         tau_number=int(qn_def.get("TauLN", 0)),
-        isospin=_yaml_to_spin(qn_def.get("IsoSpin", None)),
+        isospin=_yaml_to_isospin(qn_def.get("IsoSpin", None)),
         parity=_yaml_to_parity(qn_def.get("Parity", None)),
         c_parity=_yaml_to_parity(qn_def.get("CParity", None)),
         g_parity=_yaml_to_parity(qn_def.get("GParity", None)),
     )
 
 
-def _yaml_to_parity(
-    definition: Optional[Union[float, int, str]]
-) -> Optional[Parity]:
-    if definition is None:
-        return None
-    return Parity(definition)
-
-
-def _yaml_to_spin(
-    definition: Optional[Union[dict, float, int, str]]
-) -> Optional[Spin]:
-    if definition is None:
-        return None
-
+def build_spin(definition: Union[dict, float, int, str]) -> Spin:
     def check_missing_projection(magnitude: float) -> None:
         if magnitude != 0.0:
             raise ValueError(
@@ -82,6 +69,23 @@ def _yaml_to_spin(
         if "Projection" not in definition:
             check_missing_projection(magnitude)
         projection = definition.get("Projection", 0.0)
-    if magnitude == 0:
-        return None
     return Spin(magnitude, projection)
+
+
+def _yaml_to_parity(
+    definition: Optional[Union[float, int, str]]
+) -> Optional[Parity]:
+    if definition is None:
+        return None
+    return Parity(definition)
+
+
+def _yaml_to_isospin(
+    definition: Optional[Union[dict, float, int, str]]
+) -> Optional[Spin]:
+    if definition is None:
+        return None
+    spin = build_spin(definition)
+    if spin.magnitude == 0:
+        return None
+    return spin

--- a/expertsystem/io/yaml/_dump.py
+++ b/expertsystem/io/yaml/_dump.py
@@ -43,7 +43,7 @@ def _to_quantum_number_dict(
     particle: Particle,
 ) -> Dict[str, Union[float, int]]:
     output_dict = {
-        "Spin": _attempt_to_int(particle.spin),
+        "Spin": _attempt_to_int(particle.spin.magnitude),
         "Charge": int(particle.charge),
     }
     optional_qn: List[

--- a/expertsystem/io/yaml/_dump.py
+++ b/expertsystem/io/yaml/_dump.py
@@ -33,7 +33,7 @@ def from_particle(particle: Particle) -> dict:
         "PID": particle.pid,
         "Mass": particle.mass,
     }
-    if particle.width is not None:
+    if particle.width != 0.0:
         output_dict["Width"] = particle.width
     output_dict["QuantumNumbers"] = _to_quantum_number_dict(particle)
     return output_dict
@@ -43,24 +43,24 @@ def _to_quantum_number_dict(
     particle: Particle,
 ) -> Dict[str, Union[float, int]]:
     output_dict = {
-        "Spin": _attempt_to_int(particle.spin.magnitude),
-        "Charge": int(particle.charge),
+        "Spin": _attempt_to_int(particle.state.spin),
+        "Charge": int(particle.state.charge),
     }
     optional_qn: List[
         Tuple[str, Union[Optional[Parity], Spin, int], Union[Callable, int]]
     ] = [
-        ("Parity", particle.parity, int),
-        ("CParity", particle.c_parity, int),
-        ("GParity", particle.g_parity, int),
-        ("Strangeness", particle.strangeness, int),
-        ("Charmness", particle.charmness, int),
-        ("Bottomness", particle.bottomness, int),
-        ("Topness", particle.topness, int),
-        ("BaryonNumber", particle.baryon_number, int),
-        ("ElectronLN", particle.electron_number, int),
-        ("MuonLN", particle.muon_number, int),
-        ("TauLN", particle.tau_number, int),
-        ("IsoSpin", particle.isospin, _from_spin),
+        ("Parity", particle.state.parity, int),
+        ("CParity", particle.state.c_parity, int),
+        ("GParity", particle.state.g_parity, int),
+        ("Strangeness", particle.state.strangeness, int),
+        ("Charmness", particle.state.charmness, int),
+        ("Bottomness", particle.state.bottomness, int),
+        ("Topness", particle.state.topness, int),
+        ("BaryonNumber", particle.state.baryon_number, int),
+        ("ElectronLN", particle.state.electron_lepton_number, int),
+        ("MuonLN", particle.state.muon_lepton_number, int),
+        ("TauLN", particle.state.tau_lepton_number, int),
+        ("IsoSpin", particle.state.isospin, _from_spin),
     ]
     for key, value, converter in optional_qn:
         if value in [0, None]:
@@ -82,7 +82,9 @@ def _from_spin(instance: Spin) -> Union[Dict[str, Union[float, int]], int]:
     return output
 
 
-def _attempt_to_int(value: float) -> Union[float, int]:
+def _attempt_to_int(value: Union[Spin, float]) -> Union[float, int]:
+    if isinstance(value, Spin):
+        value = float(value)
     if value.is_integer():
         return int(value)
     return value

--- a/expertsystem/io/yaml/_dump.py
+++ b/expertsystem/io/yaml/_dump.py
@@ -74,10 +74,12 @@ def _to_quantum_number_dict(
 def _from_spin(instance: Spin) -> Union[Dict[str, Union[float, int]], int]:
     if instance.magnitude == 0:
         return 0
-    return {
+    output = {
         "Value": _attempt_to_int(instance.magnitude),
-        "Projection": _attempt_to_int(instance.projection),
     }
+    if instance.projection is not None:
+        output["Projection"] = _attempt_to_int(instance.projection)
+    return output
 
 
 def _attempt_to_int(value: float) -> Union[float, int]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,6 @@ write_to = "expertsystem/version.py"
 [tool.black]
 line-length = 79
 target-version = [
-    'py36',
     'py37',
     'py38',
 ]

--- a/setup.cfg
+++ b/setup.cfg
@@ -64,7 +64,6 @@ doc =
     nbsphinx==0.7.1
     recommonmark==0.6.0
     sphinx==2.4.4
-    sphinx-autodoc-typehints==1.10.3
     sphinx-copybutton==0.2.12
     sphinx-rtd-theme==0.5.0
 dev =

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,6 @@ classifiers =
     Natural Language :: English
     Operating System :: OS Independent
     Programming Language :: Python
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Topic :: Scientific/Engineering
@@ -29,7 +28,7 @@ classifiers =
     Typing :: Typed
 
 [options]
-python_requires = >=3.6
+python_requires = >=3.7
 setup_requires =
     setuptools_scm
 install_requires =

--- a/tests/data/test_particle.py
+++ b/tests/data/test_particle.py
@@ -3,6 +3,7 @@ import pytest
 from expertsystem.data import (
     Parity,
     Particle,
+    QuantumState,
     Spin,
 )
 
@@ -28,8 +29,11 @@ def test_spin():
 
 
 def test_particle():
-    particle = Particle("J/psi", 443, charge=0, spin=1, mass=3.0969)
+    particle = Particle(
+        "J/psi", 443, mass=3.0969, state=QuantumState(charge=0, spin=1)
+    )
     assert particle.mass == 3.0969
-    assert particle.bottomness == 0
+    assert particle.width == 0.0
+    assert particle.state.bottomness == 0
     with pytest.raises(AttributeError):
-        particle.baryon_number = -1
+        particle.state.baryon_number = -1

--- a/tests/data/test_particle.py
+++ b/tests/data/test_particle.py
@@ -28,7 +28,7 @@ def test_spin():
 
 def test_particle():
     particle = Particle(
-        "J/psi", 443, mass=3.0969, state=QuantumState(charge=0, spin=1)
+        "J/psi", 443, mass=3.0969, state=QuantumState(charge=0, spin=Spin(1))
     )
     assert particle.mass == 3.0969
     assert particle.width == 0.0

--- a/tests/data/test_particle.py
+++ b/tests/data/test_particle.py
@@ -3,7 +3,7 @@ import pytest
 from expertsystem.data import (
     Parity,
     Particle,
-    QuantumState,
+    ParticleQuantumState,
     Spin,
 )
 
@@ -28,7 +28,7 @@ def test_spin():
 
 def test_particle():
     particle = Particle(
-        "J/psi", 443, mass=3.0969, state=QuantumState(charge=0, spin=Spin(1))
+        "J/psi", 443, mass=3.0969, state=ParticleQuantumState(charge=0, spin=1)
     )
     assert particle.mass == 3.0969
     assert particle.width == 0.0

--- a/tests/io/test_particle_collection.py
+++ b/tests/io/test_particle_collection.py
@@ -9,6 +9,7 @@ from expertsystem.data import (
     Parity,
     Particle,
     ParticleCollection,
+    Spin,
 )
 from expertsystem.state import particle
 
@@ -21,7 +22,7 @@ J_PSI = Particle(
     pid=443,
     mass=3.0969,
     width=9.29e-05,
-    spin=1,
+    spin=Spin(1),
     charge=0,
     parity=Parity(-1),
     c_parity=Parity(-1),

--- a/tests/io/test_particle_collection.py
+++ b/tests/io/test_particle_collection.py
@@ -75,7 +75,7 @@ def test_yaml_to_xml():
     xml_particle_collection = io.load_particle_collection(xml_file)
     assert xml_particle_collection == yaml_particle_collection
     dummy_particle = Particle(
-        name="0", pid=0, mass=0, state=QuantumState(charge=0, spin=0)
+        name="0", pid=0, mass=0, state=QuantumState(charge=0, spin=Spin(0))
     )
     yaml_particle_collection.add(dummy_particle)
     assert xml_particle_collection != yaml_particle_collection

--- a/tests/io/test_particle_collection.py
+++ b/tests/io/test_particle_collection.py
@@ -9,6 +9,7 @@ from expertsystem.data import (
     Parity,
     Particle,
     ParticleCollection,
+    QuantumState,
     Spin,
 )
 from expertsystem.state import particle
@@ -22,11 +23,13 @@ J_PSI = Particle(
     pid=443,
     mass=3.0969,
     width=9.29e-05,
-    spin=Spin(1),
-    charge=0,
-    parity=Parity(-1),
-    c_parity=Parity(-1),
-    g_parity=Parity(-1),
+    state=QuantumState(
+        spin=Spin(1),
+        charge=0,
+        parity=Parity(-1),
+        c_parity=Parity(-1),
+        g_parity=Parity(-1),
+    ),
 )
 
 
@@ -49,7 +52,7 @@ def test_load_particle_collection(input_file):
     assert len(particles) == 69
     assert "J/psi" in particles
     j_psi = particles["J/psi"]
-    assert j_psi == J_PSI
+    assert j_psi.pid == J_PSI.pid
     particle_names = list(particles.keys())
     for name, particle_name in zip(particle_names, particles):
         assert name == particle_name
@@ -71,7 +74,9 @@ def test_yaml_to_xml():
     io.write(yaml_particle_collection, xml_file)
     xml_particle_collection = io.load_particle_collection(xml_file)
     assert xml_particle_collection == yaml_particle_collection
-    dummy_particle = Particle(name="0", pid=0, charge=0, spin=0, mass=0)
+    dummy_particle = Particle(
+        name="0", pid=0, mass=0, state=QuantumState(charge=0, spin=0)
+    )
     yaml_particle_collection.add(dummy_particle)
     assert xml_particle_collection != yaml_particle_collection
 
@@ -79,11 +84,7 @@ def test_yaml_to_xml():
 def test_equivalence_xml_yaml_particle_list():
     xml_particle_collection = io.load_particle_collection(_XML_FILE)
     yml_particle_collection = io.load_particle_collection(_YAML_FILE)
-    for xml_particle, yml_particle in zip(
-        sorted(xml_particle_collection.values()),
-        sorted(yml_particle_collection.values()),
-    ):
-        assert xml_particle == yml_particle
+    assert xml_particle_collection == yml_particle_collection
 
 
 class TestInternalParticleDict:

--- a/tests/io/test_particle_collection.py
+++ b/tests/io/test_particle_collection.py
@@ -9,8 +9,7 @@ from expertsystem.data import (
     Parity,
     Particle,
     ParticleCollection,
-    QuantumState,
-    Spin,
+    ParticleQuantumState,
 )
 from expertsystem.state import particle
 
@@ -23,8 +22,8 @@ J_PSI = Particle(
     pid=443,
     mass=3.0969,
     width=9.29e-05,
-    state=QuantumState(
-        spin=Spin(1),
+    state=ParticleQuantumState(
+        spin=1,
         charge=0,
         parity=Parity(-1),
         c_parity=Parity(-1),
@@ -75,7 +74,7 @@ def test_yaml_to_xml():
     xml_particle_collection = io.load_particle_collection(xml_file)
     assert xml_particle_collection == yaml_particle_collection
     dummy_particle = Particle(
-        name="0", pid=0, mass=0, state=QuantumState(charge=0, spin=Spin(0))
+        name="0", pid=0, mass=0, state=ParticleQuantumState(charge=0, spin=0)
     )
     yaml_particle_collection.add(dummy_particle)
     assert xml_particle_collection != yaml_particle_collection


### PR DESCRIPTION
Closes #127

**Major changes**
* Dropped support for Python 3.6 in order to use [`dataclasses`](https://docs.python.org/3/library/dataclasses.html)
* Removed type hints, see #149