### PR TITLE
ci: increase minimal test coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
         run: pytest
 
   documentation:
-    name: Check documentation and links
+    name: Build documentation and run notebooks
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
@@ -74,16 +74,11 @@ jobs:
           python -m pip install --upgrade pip
           pip install .[doc]
           sudo apt-get -y install pandoc
-      - name: Check external links
-        working-directory: doc
-        run: |
-          make linkcheck
       - name: Build documentation and run notebooks
         working-directory: doc
         env:
           NBSPHINX_EXECUTE: YES
-        run: |
-          make html
+        run: make html
 
   style:
     name: Style checks

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -1,0 +1,26 @@
+name: Linkcheck
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  style:
+    name: Check external links
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install .[doc]
+          sudo apt-get -y install pandoc
+      - name: Check external links
+        working-directory: doc
+        run: make linkcheck

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
       - id: check-useless-excludes
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.1.0
+    rev: v3.2.0
     hooks:
       - id: check-ast
       - id: check-case-conflict

--- a/codecov.yml
+++ b/codecov.yml
@@ -10,8 +10,8 @@ coverage:
     project:
       default:
         # basic
-        target: 75% # can't go below 75%
-        threshold: 3% # allow drops by 3%
+        target: 90% # can't go below this percentage
+        threshold: 1% # allow drops by this percentage
         base: auto
         # advanced
         branches: null

--- a/tests/channels/test_d0_to_kskpkm.py
+++ b/tests/channels/test_d0_to_kskpkm.py
@@ -17,7 +17,7 @@ def test_script():
     stm = StateTransitionManager(
         initial_state, final_state, ["a0", "phi", "a2(1320)-"]
     )
-    stm.number_of_threads = 2
+    stm.number_of_threads = 1
 
     graph_interaction_settings_groups = stm.prepare_graphs()
     solutions, _ = stm.find_solutions(graph_interaction_settings_groups)

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ whitelist_externals =
 commands =
     pytest tests {posargs} \
         -m "not slow" \
-        --cov-fail-under=92.4 \
+        --cov-fail-under=90 \
         --cov-report=html \
         --cov-report=xml \
         --cov=expertsystem
@@ -59,7 +59,7 @@ whitelist_externals =
     pytest
 commands =
     pytest tests {posargs} \
-        --cov-fail-under=92.4 \
+        --cov-fail-under=90 \
         --cov-report=html \
         --cov-report=xml \
         --cov=expertsystem

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ whitelist_externals =
 commands =
     pytest tests {posargs} \
         -m "not slow" \
-        --cov-fail-under=70 \
+        --cov-fail-under=92.4 \
         --cov-report=html \
         --cov-report=xml \
         --cov=expertsystem
@@ -59,7 +59,7 @@ whitelist_externals =
     pytest
 commands =
     pytest tests {posargs} \
-        --cov-fail-under=70 \
+        --cov-fail-under=92.4 \
         --cov-report=html \
         --cov-report=xml \
         --cov=expertsystem


### PR DESCRIPTION
This PR allows one to quickly ensure with
```bash
tox -e py  # fast tests only
```
that test coverage does not drop significantly.