### PR TITLE
test!: switch to branch coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,5 +34,6 @@ htmlcov/
 # Virtual environments
 *venv/
 
-# Visual Studio Code
+# Settings
+.idea/
 **.code-workspace

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,6 +15,8 @@
   "cSpell.enabled": true,
   "coverage-gutters.coverageFileNames": ["coverage.xml"],
   "coverage-gutters.coverageReportFileName": "**/htmlcov/index.html",
+  "coverage-gutters.showGutterCoverage": false,
+  "coverage-gutters.showLineCoverage": true,
   "editor.rulers": [80],
   "files.associations": {
     "*.inc": "restructuredtext"

--- a/codecov.yml
+++ b/codecov.yml
@@ -24,8 +24,8 @@ coverage:
     patch:
       default:
         # basic
-        target: 0
-        threshold: 0
+        target: 80%
+        threshold: 5%
         base: auto
         # advanced
         branches: null

--- a/codecov.yml
+++ b/codecov.yml
@@ -10,7 +10,7 @@ coverage:
     project:
       default:
         # basic
-        target: 89% # can't go below this percentage
+        target: 85% # can't go below this percentage
         threshold: 1% # allow drops by this percentage
         base: auto
         # advanced

--- a/codecov.yml
+++ b/codecov.yml
@@ -4,13 +4,13 @@ codecov:
 coverage:
   precision: 2
   round: down
-  range: "75...100"
+  range: "80...100"
 
   status:
     project:
       default:
         # basic
-        target: 90% # can't go below this percentage
+        target: 89% # can't go below this percentage
         threshold: 1% # allow drops by this percentage
         base: auto
         # advanced

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ whitelist_externals =
 commands =
     pytest tests {posargs} \
         -m "not slow" \
-        --cov-fail-under=90 \
+        --cov-fail-under=89 \
         --cov-report=html \
         --cov-report=xml \
         --cov=expertsystem
@@ -59,12 +59,13 @@ whitelist_externals =
     pytest
 commands =
     pytest tests {posargs} \
-        --cov-fail-under=90 \
+        --cov-fail-under=89 \
         --cov-report=html \
         --cov-report=xml \
         --cov=expertsystem
 
 [coverage:run]
+branch = True
 omit = */expertsystem/solvers/constraint/*
 source = expertsystem
 


### PR DESCRIPTION
This will lower the test coverage from 93% to 89%, but the lower value is the more accurate. When using [Coverage Gutters](https://marketplace.visualstudio.com/items?itemName=ryanluker.vscode-coverage-gutters) (see [contribute page](https://pwa.readthedocs.io/projects/expertsystem/en/0.3.0-alpha/contribute.html#testing)), branch coverage provides a more reliable overview.

See also https://coverage.readthedocs.io/en/latest/branch.html.

**Progress**
- [x] Switch to pytest-cov branch coverage
- [x] Lower minimal coverage requirement
- [x] Revisit codecov patch settings: no target set