### PR TITLE
fix!: distinguish isospin 0 and None

### DIFF
--- a/expertsystem/io/xml/_build.py
+++ b/expertsystem/io/xml/_build.py
@@ -73,7 +73,7 @@ def build_particle(definition: dict) -> Particle:
 
 def build_spin(definition: dict) -> Spin:
     magnitude = definition["Value"]
-    projection = definition.get("Projection", None)
+    projection = definition.get("Projection", 0.0)
     return Spin(magnitude, projection)
 
 

--- a/expertsystem/io/xml/_build.py
+++ b/expertsystem/io/xml/_build.py
@@ -5,7 +5,6 @@ from typing import (
     Callable,
     Dict,
     List,
-    Optional,
     Tuple,
     Union,
     ValuesView,
@@ -111,7 +110,7 @@ def _xml_to_quantum_number(definition: Dict[str, str]) -> Tuple[str, Any]:
         "Parity": _xml_to_parity,
         "CParity": _xml_to_parity,
         "GParity": _xml_to_parity,
-        "IsoSpin": _xml_to_isospin,
+        "IsoSpin": build_spin,
     }
     type_name = definition["Type"]
     for key, converter in conversion_map.items():
@@ -134,10 +133,3 @@ def _xml_to_int(definition: dict) -> int:
 
 def _xml_to_parity(definition: dict) -> Parity:
     return Parity(_xml_to_int(definition))
-
-
-def _xml_to_isospin(definition: dict) -> Optional[Spin]:
-    spin = build_spin(definition)
-    if spin.magnitude == 0.0:
-        return None
-    return spin

--- a/expertsystem/io/xml/_dump.py
+++ b/expertsystem/io/xml/_dump.py
@@ -87,7 +87,7 @@ def _to_quantum_number_list(
     for type_name, instance in conversion_map.items():
         if instance is None:
             continue
-        if type_name not in ["Charge", "Spin"] and instance == 0:
+        if type_name not in ["Charge", "Spin", "IsoSpin"] and instance == 0:
             continue
         definition = _qn_to_dict(instance, type_name)
         output.append(definition)

--- a/expertsystem/io/yaml/_build.py
+++ b/expertsystem/io/yaml/_build.py
@@ -85,7 +85,4 @@ def _yaml_to_isospin(
 ) -> Optional[Spin]:
     if definition is None:
         return None
-    spin = build_spin(definition)
-    if spin.magnitude == 0:
-        return None
-    return spin
+    return build_spin(definition)

--- a/expertsystem/io/yaml/_dump.py
+++ b/expertsystem/io/yaml/_dump.py
@@ -41,8 +41,8 @@ def from_particle(particle: Particle) -> dict:
 
 def _to_quantum_number_dict(
     particle: Particle,
-) -> Dict[str, Union[float, int]]:
-    output_dict = {
+) -> Dict[str, Union[float, int, Dict[str, float]]]:
+    output_dict: Dict[str, Union[float, int, Dict[str, float]]] = {
         "Spin": _attempt_to_int(particle.state.spin),
         "Charge": int(particle.state.charge),
     }
@@ -60,7 +60,6 @@ def _to_quantum_number_dict(
         ("ElectronLN", particle.state.electron_lepton_number, int),
         ("MuonLN", particle.state.muon_lepton_number, int),
         ("TauLN", particle.state.tau_lepton_number, int),
-        ("IsoSpin", particle.state.isospin, _from_spin),
     ]
     for key, value, converter in optional_qn:
         if value in [0, None]:
@@ -68,18 +67,18 @@ def _to_quantum_number_dict(
         output_dict[key] = converter(  # type: ignore
             value
         )  # pylint: disable=not-callable
+    if particle.state.isospin is not None:
+        output_dict["IsoSpin"] = _from_spin(particle.state.isospin)
     return output_dict
 
 
 def _from_spin(instance: Spin) -> Union[Dict[str, Union[float, int]], int]:
     if instance.magnitude == 0:
         return 0
-    output = {
+    return {
         "Value": _attempt_to_int(instance.magnitude),
+        "Projection": _attempt_to_int(instance.projection),
     }
-    if instance.projection is not None:
-        output["Projection"] = _attempt_to_int(instance.projection)
-    return output
 
 
 def _attempt_to_int(value: Union[Spin, float]) -> Union[float, int]:

--- a/expertsystem/particle_list.xml
+++ b/expertsystem/particle_list.xml
@@ -102,6 +102,11 @@
         <Type>GParity</Type>
         <Value>-1</Value>
       </QuantumNumber>
+      <QuantumNumber>
+        <Class>Spin</Class>
+        <Type>IsoSpin</Type>
+        <Value>0.0</Value>
+      </QuantumNumber>
     </Particle>
 
 
@@ -599,6 +604,11 @@
         <Type>CParity</Type>
         <Value>1</Value>
       </QuantumNumber>
+      <QuantumNumber>
+        <Class>Spin</Class>
+        <Type>IsoSpin</Type>
+        <Value>0.0</Value>
+      </QuantumNumber>
       <DecayInfo>
         <Type>relativisticBreitWigner</Type>
         <FormFactor>
@@ -815,6 +825,11 @@
         <Type>GParity</Type>
         <Value>-1</Value>
       </QuantumNumber>
+      <QuantumNumber>
+        <Class>Spin</Class>
+        <Type>IsoSpin</Type>
+        <Value>0.0</Value>
+      </QuantumNumber>
       <DecayInfo>
         <Type>relativisticBreitWigner</Type>
         <FormFactor>
@@ -866,6 +881,11 @@
         <Class>Int</Class>
         <Type>GParity</Type>
         <Value>1</Value>
+      </QuantumNumber>
+      <QuantumNumber>
+        <Class>Spin</Class>
+        <Type>IsoSpin</Type>
+        <Value>0.0</Value>
       </QuantumNumber>
       <DecayInfo>
         <Type>relativisticBreitWigner</Type>
@@ -919,6 +939,11 @@
         <Type>GParity</Type>
         <Value>1</Value>
       </QuantumNumber>
+      <QuantumNumber>
+        <Class>Spin</Class>
+        <Type>IsoSpin</Type>
+        <Value>0.0</Value>
+      </QuantumNumber>
       <DecayInfo>
         <Type>relativisticBreitWigner</Type>
         <FormFactor>
@@ -971,6 +996,11 @@
         <Type>GParity</Type>
         <Value>1</Value>
       </QuantumNumber>
+      <QuantumNumber>
+        <Class>Spin</Class>
+        <Type>IsoSpin</Type>
+        <Value>0.0</Value>
+      </QuantumNumber>
       <DecayInfo>
         <Type>relativisticBreitWigner</Type>
         <FormFactor>
@@ -1022,6 +1052,11 @@
         <Class>Int</Class>
         <Type>GParity</Type>
         <Value>1</Value>
+      </QuantumNumber>
+      <QuantumNumber>
+        <Class>Spin</Class>
+        <Type>IsoSpin</Type>
+        <Value>0.0</Value>
       </QuantumNumber>
       <DecayInfo>
         <Type>relativisticBreitWigner</Type>
@@ -1441,6 +1476,11 @@
         <Class>Int</Class>
         <Type>GParity</Type>
         <Value>-1</Value>
+      </QuantumNumber>
+      <QuantumNumber>
+        <Class>Spin</Class>
+        <Type>IsoSpin</Type>
+        <Value>0.0</Value>
       </QuantumNumber>
       <DecayInfo>
         <Type>relativisticBreitWigner</Type>
@@ -2135,6 +2175,11 @@
         <Type>GParity</Type>
         <Value>-1</Value>
       </QuantumNumber>
+      <QuantumNumber>
+        <Class>Spin</Class>
+        <Type>IsoSpin</Type>
+        <Value>0.0</Value>
+      </QuantumNumber>
       <DecayInfo>
         <Type>relativisticBreitWigner</Type>
         <FormFactor>
@@ -2181,6 +2226,11 @@
         <Class>Int</Class>
         <Type>CParity</Type>
         <Value>-1</Value>
+      </QuantumNumber>
+      <QuantumNumber>
+        <Class>Spin</Class>
+        <Type>IsoSpin</Type>
+        <Value>0.0</Value>
       </QuantumNumber>
       <DecayInfo>
         <Type>relativisticBreitWigner</Type>
@@ -2233,6 +2283,11 @@
         <Class>Int</Class>
         <Type>GParity</Type>
         <Value>1</Value>
+      </QuantumNumber>
+      <QuantumNumber>
+        <Class>Spin</Class>
+        <Type>IsoSpin</Type>
+        <Value>0.0</Value>
       </QuantumNumber>
       <DecayInfo>
         <Type>relativisticBreitWigner</Type>
@@ -2677,6 +2732,11 @@
         <Type>BaryonNumber</Type>
         <Value>1</Value>
       </QuantumNumber>
+      <QuantumNumber>
+        <Class>Spin</Class>
+        <Type>IsoSpin</Type>
+        <Value>0.0</Value>
+      </QuantumNumber>
     </Particle>
     <Particle>
       <Name>lambdabar</Name>
@@ -2710,6 +2770,11 @@
         <Class>Int</Class>
         <Type>BaryonNumber</Type>
         <Value>-1</Value>
+      </QuantumNumber>
+      <QuantumNumber>
+        <Class>Spin</Class>
+        <Type>IsoSpin</Type>
+        <Value>0.0</Value>
       </QuantumNumber>
     </Particle>
     <Particle>

--- a/expertsystem/particle_list.yml
+++ b/expertsystem/particle_list.yml
@@ -8,7 +8,6 @@ ParticleList:
       Charge: 0
       Parity: -1
       CParity: -1
-      IsoSpin: 0
 
   W-:
     PID: -24
@@ -172,7 +171,7 @@ ParticleList:
       Charge: 0
       Parity: -1
       CParity: 1
-      IsoSpin: { Value: 0 }
+      IsoSpin: 0
 
   rho(770)0:
     PID: 113
@@ -229,7 +228,7 @@ ParticleList:
       Charge: 0
       Parity: 1
       CParity: 1
-      IsoSpin: { Value: 0 }
+      IsoSpin: 0
       GParity: 1
 
   f0(1500):
@@ -241,6 +240,7 @@ ParticleList:
       Charge: 0
       Parity: 1
       CParity: 1
+      IsoSpin: 0
       GParity: 1
 
   f2(1270):
@@ -252,6 +252,7 @@ ParticleList:
       Charge: 0
       Parity: 1
       CParity: 1
+      IsoSpin: 0
       GParity: 1
 
   f2(1950):
@@ -263,6 +264,7 @@ ParticleList:
       Charge: 0
       Parity: 1
       CParity: 1
+      IsoSpin: 0
       GParity: 1
 
   a0(980)0:
@@ -341,6 +343,7 @@ ParticleList:
       Charge: 0
       Parity: -1
       GParity: -1
+      IsoSpin: 0
 
   K-:
     PID: -321
@@ -509,6 +512,7 @@ ParticleList:
       Charge: 0
       Parity: -1
       CParity: -1
+      IsoSpin: 0
 
   Chic1:
     PID: 1234
@@ -520,7 +524,7 @@ ParticleList:
       Parity: 1
       CParity: 1
       GParity: 1
-      IsoSpin: { Value: 0 }
+      IsoSpin: 0
 
   p:
     PID: 2212

--- a/tests/amplitude/expected_recipe.yml
+++ b/tests/amplitude/expected_recipe.yml
@@ -1241,6 +1241,7 @@ ParticleList:
       Parity: -1
       CParity: -1
       GParity: -1
+      IsoSpin: 0
   f0(1500):
     PID: 9030221
     Mass: 1.505
@@ -1251,6 +1252,7 @@ ParticleList:
       Parity: 1
       CParity: 1
       GParity: 1
+      IsoSpin: 0
   f0(980):
     PID: 9010221
     Mass: 0.994
@@ -1261,6 +1263,7 @@ ParticleList:
       Parity: 1
       CParity: 1
       GParity: 1
+      IsoSpin: 0
   f2(1270):
     PID: 225
     Mass: 1.2751
@@ -1271,6 +1274,7 @@ ParticleList:
       Parity: 1
       CParity: 1
       GParity: 1
+      IsoSpin: 0
   f2(1950):
     PID: 9050225
     Mass: 1.944
@@ -1281,6 +1285,7 @@ ParticleList:
       Parity: 1
       CParity: 1
       GParity: 1
+      IsoSpin: 0
   gamma:
     PID: 22
     Mass: 0.0

--- a/tests/io/test_particle_collection.py
+++ b/tests/io/test_particle_collection.py
@@ -10,6 +10,7 @@ from expertsystem.data import (
     Particle,
     ParticleCollection,
     QuantumState,
+    Spin,
 )
 from expertsystem.state import particle
 
@@ -26,6 +27,7 @@ J_PSI = Particle(
     state=QuantumState[float](
         spin=1,
         charge=0,
+        isospin=Spin(0, 0),
         parity=Parity(-1),
         c_parity=Parity(-1),
         g_parity=Parity(-1),
@@ -65,7 +67,8 @@ def test_write_particle_collection(input_file):
     output_file = f"exported_particle_list.{file_extension}"
     io.write(particles_imported, output_file)
     particles_exported = io.load_particle_collection(output_file)
-    assert particles_imported == particles_exported
+    for name in particles_imported:
+        assert particles_imported[name] == particles_exported[name]
 
 
 def test_yaml_to_xml():
@@ -84,7 +87,8 @@ def test_yaml_to_xml():
 def test_equivalence_xml_yaml_particle_list():
     xml_particle_collection = io.load_particle_collection(_XML_FILE)
     yml_particle_collection = io.load_particle_collection(_YAML_FILE)
-    assert xml_particle_collection == yml_particle_collection
+    for name in xml_particle_collection:
+        assert xml_particle_collection[name] == yml_particle_collection[name]
 
 
 class TestInternalParticleDict:


### PR DESCRIPTION
Set `isospin=Spin(...)` for all hadrons and `None` (undefined) for leptons and bosons.