### PR TITLE
feat: visualize list of StateTransitionGraphs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Output files
 *.gv
+*.pdf
 *.xml
 *.yaml
 *.yml

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -7,6 +7,7 @@
     "editorconfig.editorconfig",
     "esbenp.prettier-vscode",
     "github.vscode-pull-request-github",
+    "joaompinto.vscode-graphviz",
     "lextudio.restructuredtext",
     "ms-python.python",
     "ms-vsliveshare.vsliveshare",

--- a/examples/visualization.ipynb
+++ b/examples/visualization.ipynb
@@ -63,7 +63,7 @@
     "raw_mimetype": "text/restructuredtext"
    },
    "source": [
-    "Now, we use the `~.io.dot.convert_to_dot` function to create a `str` of DOT language:"
+    "Now, we use the `~.io.dot.convert_to_dot` function to create a `str` of DOT language for the list of solutions (`.StateTransitionGraph` instances):"
    ]
   },
   {
@@ -74,7 +74,7 @@
    "source": [
     "from expertsystem import io\n",
     "\n",
-    "dot_source = io.dot.convert_to_dot(solutions[0])"
+    "dot_source = io.dot.convert_to_dot(solutions)"
    ]
   },
   {
@@ -122,7 +122,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "io.write(instance=solutions[0], filename=\"decay_topology.gv\")"
+    "io.write(instance=solutions, filename=\"decay_topologies.gv\")"
    ]
   }
  ],

--- a/expertsystem/io/dot.py
+++ b/expertsystem/io/dot.py
@@ -4,6 +4,8 @@ See :doc:`/usage/visualization` for more info.
 """
 
 from typing import (
+    Any,
+    Callable,
     List,
     Optional,
 )
@@ -44,19 +46,29 @@ _DOT_DEFAULT_EDGE = '    "{}" -> "{}";\n'
 _DOT_LABEL_EDGE = '    "{}" -> "{}" [label="{}"];\n'
 
 
+def embed_dot(func: Callable[[Any], str]) -> Callable[[Any], str]:
+    """Add a DOT head and tail to some DOT content."""
+
+    def wrapper(*args, **kwargs):  # type: ignore
+        dot_source = _DOT_HEAD
+        dot_source += func(*args, **kwargs)
+        dot_source += _DOT_TAIL
+        return dot_source
+
+    return wrapper
+
+
+@embed_dot
 def __graph_list_to_dot(graphs: List[StateTransitionGraph]) -> str:
-    dot_source = _DOT_HEAD
+    dot_source = ""
     for i, graph in enumerate(graphs):
         dot_source += __graph_to_dot_content(graph, prefix=f"g{i}_")
-    dot_source += _DOT_TAIL
     return dot_source
 
 
+@embed_dot
 def __graph_to_dot(graph: StateTransitionGraph) -> str:
-    dot_source = _DOT_HEAD
-    dot_source += __graph_to_dot_content(graph)
-    dot_source += _DOT_TAIL
-    return dot_source
+    return __graph_to_dot_content(graph)
 
 
 def __graph_to_dot_content(

--- a/expertsystem/io/dot.py
+++ b/expertsystem/io/dot.py
@@ -42,7 +42,7 @@ def write(instance: object, filename: str) -> None:
 _DOT_HEAD = """digraph {
     rankdir=LR;
     node [shape=point, width=0];
-    edge [arrowhead=none, labelfloat=true];
+    edge [arrowhead=none];
 """
 _DOT_TAIL = "}\n"
 _DOT_RANK_SAME = "    {{ rank=same {} }};\n"

--- a/expertsystem/io/dot.py
+++ b/expertsystem/io/dot.py
@@ -53,17 +53,25 @@ def __graph_to_dot(graph: StateTransitionGraph) -> str:
         name_list = [f'"{node_name(i)}"' for i in node_edge_ids]
         return ",".join(name_list)
 
+    def edge_label(graph: StateTransitionGraph, edge_id: int) -> str:
+        if edge_id in graph.edge_props:
+            properties = graph.edge_props[edge_id]
+            label = properties.get("Name", i)
+        else:
+            label = str(i)
+        return label
+
     dot_source = _DOT_HEAD
 
     top = graph.get_initial_state_edges()
     outs = graph.get_final_state_edges()
     for i in top:
         dot_source += _DOT_DEFAULT_NODE.format(
-            node_name(i), graph.edge_props.get(i, {}).get("Name", i)
+            node_name(i), edge_label(graph, i)
         )
     for i in outs:
         dot_source += _DOT_DEFAULT_NODE.format(
-            node_name(i), graph.edge_props.get(i, {}).get("Name", i)
+            node_name(i), edge_label(graph, i)
         )
 
     dot_source += _DOT_RANK_SAME.format(format_particle(top))
@@ -77,9 +85,7 @@ def __graph_to_dot(graph: StateTransitionGraph) -> str:
             )
         else:
             dot_source += _DOT_LABEL_EDGE.format(
-                node_name(i, k),
-                node_name(i, j),
-                graph.edge_props.get(i, {}).get("Name", i),
+                node_name(i, k), node_name(i, j), edge_label(graph, i),
             )
 
     dot_source += _DOT_TAIL

--- a/expertsystem/io/dot.py
+++ b/expertsystem/io/dot.py
@@ -39,12 +39,11 @@ def write(instance: object, filename: str) -> None:
         stream.write(output_str)
 
 
-_DOT_HEAD = """
-digraph {
+_DOT_HEAD = """digraph {
     rankdir=LR;
     node [shape=point, width=0];
     edge [arrowhead=none, labelfloat=true];
-    """
+"""
 _DOT_TAIL = "}\n"
 _DOT_RANK_SAME = "    {{ rank=same {} }};\n"
 _DOT_DEFAULT_NODE = '    "{}" [shape=none, label="{}"];\n'

--- a/expertsystem/io/dot.py
+++ b/expertsystem/io/dot.py
@@ -59,11 +59,11 @@ def __graph_to_dot(graph: StateTransitionGraph) -> str:
     outs = graph.get_final_state_edges()
     for i in top:
         dot_source += _DOT_DEFAULT_NODE.format(
-            node_name(i), graph.edge_props[i]["Name"]
+            node_name(i), graph.edge_props.get(i, {}).get("Name", i)
         )
     for i in outs:
         dot_source += _DOT_DEFAULT_NODE.format(
-            node_name(i), graph.edge_props[i]["Name"]
+            node_name(i), graph.edge_props.get(i, {}).get("Name", i)
         )
 
     dot_source += _DOT_RANK_SAME.format(format_particle(top))
@@ -77,7 +77,9 @@ def __graph_to_dot(graph: StateTransitionGraph) -> str:
             )
         else:
             dot_source += _DOT_LABEL_EDGE.format(
-                node_name(i, k), node_name(i, j), graph.edge_props[i]["Name"],
+                node_name(i, k),
+                node_name(i, j),
+                graph.edge_props.get(i, {}).get("Name", i),
             )
 
     dot_source += _DOT_TAIL

--- a/expertsystem/io/dot.py
+++ b/expertsystem/io/dot.py
@@ -33,7 +33,7 @@ def write(instance: object, filename: str) -> None:
 _DOT_HEAD = """
 digraph {
     rankdir=LR;
-    node [shape=point];
+    node [shape=point, width=0];
     edge [arrowhead=none, labelfloat=true];
     """
 _DOT_TAIL = "}\n"

--- a/expertsystem/io/dot.py
+++ b/expertsystem/io/dot.py
@@ -57,6 +57,18 @@ def __graph_to_dot(graph: StateTransitionGraph) -> str:
         if edge_id in graph.edge_props:
             properties = graph.edge_props[edge_id]
             label = properties.get("Name", i)
+            quantum_numbers = properties.get("QuantumNumber", None)
+            if quantum_numbers is not None:
+                spin_projection_candidates = [
+                    number.get("Projection", None)
+                    for number in quantum_numbers
+                    if number["Type"] == "Spin"
+                ]
+                if spin_projection_candidates:
+                    projection = float(spin_projection_candidates[0])
+                    if projection.is_integer():
+                        projection = int(projection)
+                    label += f"[{projection}]"
         else:
             label = str(i)
         return label

--- a/expertsystem/io/dot.py
+++ b/expertsystem/io/dot.py
@@ -57,13 +57,9 @@ def __graph_to_dot(graph: StateTransitionGraph) -> str:
 
     top = graph.get_initial_state_edges()
     outs = graph.get_final_state_edges()
-    for i in top:
+    for edge_id in top + outs:
         dot_source += _DOT_DEFAULT_NODE.format(
-            __node_name(i), __edge_label(graph, i)
-        )
-    for i in outs:
-        dot_source += _DOT_DEFAULT_NODE.format(
-            __node_name(i), __edge_label(graph, i)
+            __node_name(edge_id), __edge_label(graph, edge_id)
         )
 
     dot_source += _DOT_RANK_SAME.format(__format_particle(top))

--- a/expertsystem/state/particle.py
+++ b/expertsystem/state/particle.py
@@ -480,7 +480,7 @@ def initialize_graph(
     empty_topology: StateTransitionGraph,
     initial_state: List[StateDefinition],
     final_state: List[StateDefinition],
-    final_state_groupings: List[List[str]],
+    final_state_groupings: Optional[List[List[str]]] = None,
 ) -> List[StateTransitionGraph]:
     is_edges = empty_topology.get_initial_state_edges()
     if len(initial_state) != len(is_edges):

--- a/tests/unit/io/test_dot.py
+++ b/tests/unit/io/test_dot.py
@@ -11,22 +11,32 @@ def test_dot_syntax(jpsi_to_gamma_pi_pi_helicity_solutions):
         assert pydot.graph_from_dot_data(dot_data) is not None
 
 
-def test_write_dot(jpsi_to_gamma_pi_pi_helicity_solutions):
-    single_graph_filename = "test_write_dot.gv"
-    multi_graph_filename = "test_write_dot_multi.gv"
-    with pytest.raises(NotImplementedError):
+class TestWrite:
+    @staticmethod
+    def test_exception():
+        with pytest.raises(NotImplementedError):
+            io.write(
+                instance="nope, can't write a str", filename="dummy_file.gv",
+            )
+
+    @staticmethod
+    def test_write_single_graph(jpsi_to_gamma_pi_pi_helicity_solutions):
+        output_file = "test_single_graph.gv"
         io.write(
-            instance="nope, can't write a str", filename=single_graph_filename,
+            instance=jpsi_to_gamma_pi_pi_helicity_solutions[0],
+            filename=output_file,
         )
-    io.write(
-        instance=jpsi_to_gamma_pi_pi_helicity_solutions[0],
-        filename=single_graph_filename,
-    )
-    io.write(
-        instance=jpsi_to_gamma_pi_pi_helicity_solutions,
-        filename=multi_graph_filename,
-    )
-    for filename in [single_graph_filename, multi_graph_filename]:
-        with open(filename, "r") as stream:
+        with open(output_file, "r") as stream:
+            dot_data = stream.read()
+        assert pydot.graph_from_dot_data(dot_data) is not None
+
+    @staticmethod
+    def test_write_graph_list(jpsi_to_gamma_pi_pi_helicity_solutions):
+        output_file = "test_graph_list.gv"
+        io.write(
+            instance=jpsi_to_gamma_pi_pi_helicity_solutions,
+            filename=output_file,
+        )
+        with open(output_file, "r") as stream:
             dot_data = stream.read()
         assert pydot.graph_from_dot_data(dot_data) is not None

--- a/tests/unit/io/test_dot.py
+++ b/tests/unit/io/test_dot.py
@@ -12,15 +12,21 @@ def test_dot_syntax(jpsi_to_gamma_pi_pi_helicity_solutions):
 
 
 def test_write_dot(jpsi_to_gamma_pi_pi_helicity_solutions):
-    output_filename = "test_write_dot.gv"
+    single_graph_filename = "test_write_dot.gv"
+    multi_graph_filename = "test_write_dot_multi.gv"
     with pytest.raises(NotImplementedError):
         io.write(
-            instance="nope, can't write a str", filename=output_filename,
+            instance="nope, can't write a str", filename=single_graph_filename,
         )
     io.write(
         instance=jpsi_to_gamma_pi_pi_helicity_solutions[0],
-        filename=output_filename,
+        filename=single_graph_filename,
     )
-    with open(output_filename, "r") as stream:
-        dot_data = stream.read()
-    assert pydot.graph_from_dot_data(dot_data) is not None
+    io.write(
+        instance=jpsi_to_gamma_pi_pi_helicity_solutions,
+        filename=multi_graph_filename,
+    )
+    for filename in [single_graph_filename, multi_graph_filename]:
+        with open(filename, "r") as stream:
+            dot_data = stream.read()
+        assert pydot.graph_from_dot_data(dot_data) is not None

--- a/tests/unit/topology/test_graph.py
+++ b/tests/unit/topology/test_graph.py
@@ -1,0 +1,58 @@
+# pylint: disable=redefined-outer-name
+
+import pytest
+
+from expertsystem import io
+from expertsystem import ui
+from expertsystem.state.particle import initialize_graph
+from expertsystem.topology import StateTransitionGraph
+
+
+def create_dummy_topology() -> StateTransitionGraph:
+    topology = StateTransitionGraph()
+    topology.add_node(0)
+    topology.add_node(1)
+    topology.add_edges([0, 1, 2, 3, 4])
+    topology.attach_edges_to_node_ingoing([0], 0)
+    topology.attach_edges_to_node_ingoing([1], 1)
+    topology.attach_edges_to_node_outgoing([1, 2], 0)
+    topology.attach_edges_to_node_outgoing([3, 4], 1)
+    return topology
+
+
+@pytest.fixture(scope="package")
+def dummy_topology():
+    return create_dummy_topology()
+
+
+def test_initialize_graph(  # pylint: disable=unused-argument
+    dummy_topology, particle_database
+):
+    graphs = initialize_graph(
+        dummy_topology,
+        initial_state=[("J/psi(1S)", [-1, +1])],
+        final_state=["gamma", "pi0", "pi0"],
+    )
+    assert len(graphs) == 8
+    return graphs
+
+
+def visualize_graphs():
+    """Render graphs when running this file directly."""
+    ui.load_default_particles()
+    topology = create_dummy_topology()
+    graphs = test_initialize_graph(topology, None)
+    try:
+        # pylint: disable=import-error,import-outside-toplevel
+        import graphviz  # type: ignore
+
+        for i, graph in enumerate(graphs):
+            dot_source = io.dot.convert_to_dot(graph)
+            vis = graphviz.Source(dot_source, filename=f"graph{i}.gv")
+            vis.render(view=True)
+    except ModuleNotFoundError:
+        pass
+
+
+if __name__ == "__main__":
+    visualize_graphs()

--- a/tests/unit/topology/test_graph.py
+++ b/tests/unit/topology/test_graph.py
@@ -46,10 +46,9 @@ def visualize_graphs():
         # pylint: disable=import-error,import-outside-toplevel
         import graphviz  # type: ignore
 
-        for i, graph in enumerate(graphs):
-            dot_source = io.dot.convert_to_dot(graph)
-            vis = graphviz.Source(dot_source, filename=f"graph{i}.gv")
-            vis.render(view=True)
+        dot_source = io.dot.convert_to_dot(graphs)
+        vis = graphviz.Source(dot_source)
+        vis.view()
     except ModuleNotFoundError:
         pass
 


### PR DESCRIPTION
Previously, DOT visualisation would crash if it got an uninitialised `StateTransitionGraph` (because it doesn't have edge properties). Now, the edge ID is used instead if there are no edge properties. In addition, if there are edge properties, the spin projection is printed as well. A `list` of solutions can now also be rendered in one graphviz file.

A quick demo is available under `test_graph.py`.

Also includes some minor fixes and refactorings to the `particle` submodule.