### PR TITLE
ci: fix $CONTRIBUTORS in release drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -20,6 +20,6 @@ template: |
 
   $CHANGES
 
-  ## Contributors since $PREVIOUS_TAG
+  ## Contributors since [$PREVIOUS_TAG](https://github.com/ComPWA/expertsystem/releases/tag/$PREVIOUS_TAG)
 
   $CONTRIBUTORS

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -20,4 +20,6 @@ template: |
 
   $CHANGES
 
-  _Contributors since $PREVIOUS_TAG: $CONTRIBUTORS_
+  ## Contributors since $PREVIOUS_TAG
+
+  $CONTRIBUTORS


### PR DESCRIPTION
Last one... hopefully. This should fix:
![image](https://user-images.githubusercontent.com/29308176/91548519-c700c680-e925-11ea-8d85-804f1da36135.png)
