### PR TITLE
build: downgrade to numpy 1.18.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ setup_requires =
     setuptools_scm
 install_requires =
     jsonschema==3.2.0
-    numpy==1.19.0
+    numpy==1.18.0
     particle==0.11.0
     progress==1.5
     PyYAML==5.3


### PR DESCRIPTION
TensorFlow requires numpy<1.19

We'll make a release 0.4.0a1 after this for `tensorwaves`