### PR TITLE
refactor!: move particle combinatorics

### DIFF
--- a/expertsystem/amplitude/canonical_decay.py
+++ b/expertsystem/amplitude/canonical_decay.py
@@ -12,7 +12,6 @@ from expertsystem.state.particle import (
 from .helicity_decay import (
     HelicityAmplitudeGenerator,
     HelicityAmplitudeNameGenerator,
-    generate_particles_string,
 )
 
 
@@ -32,18 +31,6 @@ class CanonicalAmplitudeNameGenerator(HelicityAmplitudeNameGenerator):
 
     That is, using the properties of the decay.
     """
-
-    def _generate_amplitude_coefficient_name(self, graph, node_id):
-        (in_hel_info, out_hel_info) = self._retrieve_helicity_info(
-            graph, node_id
-        )
-        par_name_suffix = (
-            generate_particles_string(in_hel_info, False)
-            + "_to_"
-            + generate_particles_string(out_hel_info, False)
-        )
-        cg_suffix = generate_clebsch_gordan_string(graph, node_id)
-        return par_name_suffix + cg_suffix
 
     def generate_unique_amplitude_name(self, graph, node_id=None):
         name = ""

--- a/expertsystem/amplitude/helicity_decay.py
+++ b/expertsystem/amplitude/helicity_decay.py
@@ -270,7 +270,12 @@ def _get_name_hel_list(graph, edge_ids):
         if temp_hel % 1 == 0:
             temp_hel = int(temp_hel)
         name_hel_list.append((graph.edge_props[i][name_label], temp_hel))
-    return name_hel_list
+
+    # in order to ensure correct naming of amplitude coefficients the list has
+    # to be sorted by name. The same coefficient names have to be created for
+    # two graphs that only differ from a kinematic standpoint
+    # (swapped external edges)
+    return sorted(name_hel_list, key=lambda entry: entry[0])
 
 
 class HelicityAmplitudeNameGenerator(AbstractAmplitudeNameGenerator):

--- a/expertsystem/amplitude/helicity_decay.py
+++ b/expertsystem/amplitude/helicity_decay.py
@@ -18,6 +18,7 @@ from expertsystem.state.particle import (
     InteractionQuantumNumberNames,
     StateQuantumNumberNames,
     get_interaction_property,
+    perform_external_edge_identical_particle_combinatorics,
 )
 
 from . import _yaml_adapter
@@ -497,7 +498,9 @@ class HelicityAmplitudeGenerator(AbstractAmplitudeGenerator):
             for graph in graph_group:
                 self.name_generator.register_amplitude_coefficient_name(graph)
 
-    def generate_amplitude_info(self, graph_groups):
+    def generate_amplitude_info(
+        self, graph_groups
+    ):  # pylint: disable=too-many-locals
         class_label = particle.Labels.Class.name
         name_label = particle.Labels.Name.name
         component_label = particle.Labels.Component.name
@@ -510,9 +513,13 @@ class HelicityAmplitudeGenerator(AbstractAmplitudeGenerator):
             seq_partial_decays = []
 
             for graph in graph_group:
-                seq_partial_decays.append(
-                    self.generate_sequential_decay(graph)
+                sequential_graphs = perform_external_edge_identical_particle_combinatorics(
+                    graph
                 )
+                for seq_graph in sequential_graphs:
+                    seq_partial_decays.append(
+                        self.generate_sequential_decay(seq_graph)
+                    )
 
             # in each coherent amplitude we create a product of partial decays
             coherent_amp_name = "coherent_" + get_graph_group_unique_label(

--- a/expertsystem/state/particle.py
+++ b/expertsystem/state/particle.py
@@ -16,6 +16,7 @@ from typing import (
     Dict,
     List,
     Optional,
+    Set,
     Tuple,
     Union,
 )
@@ -832,3 +833,141 @@ def __merge_qn_props(
         if not qn_found:
             qns.append(qn_entry)
     return qns
+
+
+def match_external_edges(graphs: List[StateTransitionGraph]) -> None:
+    if not isinstance(graphs, list):
+        raise TypeError("graphs argument is not of type list!")
+    if not graphs:
+        return
+    ref_graph_id = 0
+    _match_external_edge_ids(graphs, ref_graph_id, "get_final_state_edges")
+    _match_external_edge_ids(graphs, ref_graph_id, "get_initial_state_edges")
+
+
+def _match_external_edge_ids(  # pylint: disable=too-many-locals
+    graphs: List[StateTransitionGraph],
+    ref_graph_id: int,
+    external_edge_getter_function: str,
+) -> None:
+    ref_graph = graphs[ref_graph_id]
+    # create external edge to particle mapping
+    ref_edge_id_particle_mapping = _create_edge_id_particle_mapping(
+        ref_graph, external_edge_getter_function
+    )
+
+    for graph in graphs[:ref_graph_id] + graphs[ref_graph_id + 1 :]:
+        edge_id_particle_mapping = _create_edge_id_particle_mapping(
+            graph, external_edge_getter_function
+        )
+        # remove matching entries
+        ref_mapping_copy = deepcopy(ref_edge_id_particle_mapping)
+        edge_ids_mapping = {}
+        for key, value in edge_id_particle_mapping.items():
+            if key in ref_mapping_copy and value == ref_mapping_copy[key]:
+                del ref_mapping_copy[key]
+            else:
+                for key_2, value_2 in ref_mapping_copy.items():
+                    if value == value_2:
+                        edge_ids_mapping[key] = key_2
+                        del ref_mapping_copy[key_2]
+                        break
+        if len(ref_mapping_copy) != 0:
+            raise ValueError(
+                "Unable to match graphs, due to inherent graph"
+                " structure mismatch"
+            )
+        swappings = _calculate_swappings(edge_ids_mapping)
+        for edge_id1, edge_id2 in swappings.items():
+            graph.swap_edges(edge_id1, edge_id2)
+
+
+def perform_external_edge_identical_particle_combinatorics(
+    graph: StateTransitionGraph,
+) -> List[StateTransitionGraph]:
+    """Create combinatorics clones of the `.StateTransitionGraph`.
+
+    In case of identical particles in the initial or final state. Only
+    identical particles, which do not enter or exit the same node allow for
+    combinatorics!
+    """
+    if not isinstance(graph, StateTransitionGraph):
+        raise TypeError("graph argument is not of type StateTransitionGraph!")
+    temp_new_graphs = _external_edge_identical_particle_combinatorics(
+        graph, "get_final_state_edges"
+    )
+    new_graphs = []
+    for new_graph in temp_new_graphs:
+        new_graphs.extend(
+            _external_edge_identical_particle_combinatorics(
+                new_graph, "get_initial_state_edges"
+            )
+        )
+    return new_graphs
+
+
+def _external_edge_identical_particle_combinatorics(
+    graph: StateTransitionGraph, external_edge_getter_function: str,
+) -> List[StateTransitionGraph]:
+    # pylint: disable=too-many-locals
+    new_graphs = [graph]
+    edge_particle_mapping = _create_edge_id_particle_mapping(
+        graph, external_edge_getter_function
+    )
+    identical_particle_groups: Dict[str, Set[int]] = {}
+    for key, value in edge_particle_mapping.items():
+        if value not in identical_particle_groups:
+            identical_particle_groups[value] = set()
+        identical_particle_groups[value].add(key)
+    identical_particle_groups = {
+        key: value
+        for key, value in identical_particle_groups.items()
+        if len(value) > 1
+    }
+    # now for each identical particle group perform all permutations
+    for edge_group in identical_particle_groups.values():
+        combinations = permutations(edge_group)
+        graph_combinations = set()
+        ext_edge_combinations = []
+        ref_node_origin = graph.get_originating_node_list(edge_group)
+        for comb in combinations:
+            temp_edge_node_mapping = tuple(sorted(zip(comb, ref_node_origin)))
+            if temp_edge_node_mapping not in graph_combinations:
+                graph_combinations.add(temp_edge_node_mapping)
+                ext_edge_combinations.append(dict(zip(edge_group, comb)))
+        temp_new_graphs = []
+        for new_graph in new_graphs:
+            for combination in ext_edge_combinations:
+                graph_copy = deepcopy(new_graph)
+                swappings = _calculate_swappings(combination)
+                for edge_id1, edge_id2 in swappings.items():
+                    graph_copy.swap_edges(edge_id1, edge_id2)
+                temp_new_graphs.append(graph_copy)
+        new_graphs = temp_new_graphs
+    return new_graphs
+
+
+def _calculate_swappings(id_mapping: Dict[int, int]) -> OrderedDict:
+    """Calculate edge id swappings.
+
+    Its important to use an ordered dict as the swappings do not commute!
+    """
+    swappings: OrderedDict = OrderedDict()
+    for key, value in id_mapping.items():
+        # go through existing swappings and use them
+        newkey = key
+        while newkey in swappings:
+            newkey = swappings[newkey]
+        if value != newkey:
+            swappings[value] = newkey
+    return swappings
+
+
+def _create_edge_id_particle_mapping(
+    graph: StateTransitionGraph, external_edge_getter_function: str,
+) -> Dict[int, str]:
+    name_label = Labels.Name.name
+    return {
+        i: graph.edge_props[i][name_label]
+        for i in getattr(graph, external_edge_getter_function)()
+    }

--- a/expertsystem/ui/__init__.py
+++ b/expertsystem/ui/__init__.py
@@ -27,6 +27,8 @@ from expertsystem.state.particle import (
     StateDefinition,
     filter_particles,
     initialize_graph,
+    match_external_edges,
+    perform_external_edge_identical_particle_combinatorics,
 )
 from expertsystem.state.propagation import (
     FullPropagator,
@@ -53,8 +55,6 @@ from ._system_control import (
     analyse_solution_failure,
     create_interaction_setting_groups,
     filter_interaction_types,
-    match_external_edges,
-    perform_external_edge_identical_particle_combinatorics,
     remove_duplicate_solutions,
 )
 

--- a/expertsystem/ui/__init__.py
+++ b/expertsystem/ui/__init__.py
@@ -28,7 +28,6 @@ from expertsystem.state.particle import (
     filter_particles,
     initialize_graph,
     match_external_edges,
-    perform_external_edge_identical_particle_combinatorics,
 )
 from expertsystem.state.propagation import (
     FullPropagator,
@@ -344,17 +343,8 @@ class StateTransitionManager:  # pylint: disable=too-many-instance-attributes
             violated_laws = analyse_solution_failure(node_non_satisfied_rules)
             logging.info(f"violated rules: {violated_laws}")
 
-        # finally perform combinatorics of identical external edges
-        # (initial or final state edges) and prepare graphs for
-        # amplitude generation
         match_external_edges(solutions)
-        final_solutions = []
-        for sol in solutions:
-            final_solutions.extend(
-                perform_external_edge_identical_particle_combinatorics(sol)
-            )
-
-        return (final_solutions, violated_laws)
+        return (solutions, violated_laws)
 
     def _propagate_quantum_numbers(
         self,

--- a/expertsystem/ui/_system_control.py
+++ b/expertsystem/ui/_system_control.py
@@ -2,19 +2,14 @@
 
 import logging
 from abc import ABC, abstractmethod
-from collections import OrderedDict
 from copy import deepcopy
-from itertools import (
-    permutations,
-    product,
-)
+from itertools import product
 from typing import (
     Any,
     Callable,
     Dict,
     List,
     Optional,
-    Set,
     Tuple,
     Union,
 )
@@ -452,141 +447,3 @@ def _calculate_strength(
     for int_setting in node_interaction_settings.values():
         strength *= int_setting.interaction_strength
     return strength
-
-
-def match_external_edges(graphs: List[StateTransitionGraph]) -> None:
-    if not isinstance(graphs, list):
-        raise TypeError("graphs argument is not of type list!")
-    if not graphs:
-        return
-    ref_graph_id = 0
-    _match_external_edge_ids(graphs, ref_graph_id, "get_final_state_edges")
-    _match_external_edge_ids(graphs, ref_graph_id, "get_initial_state_edges")
-
-
-def _match_external_edge_ids(  # pylint: disable=too-many-locals
-    graphs: List[StateTransitionGraph],
-    ref_graph_id: int,
-    external_edge_getter_function: str,
-) -> None:
-    ref_graph = graphs[ref_graph_id]
-    # create external edge to particle mapping
-    ref_edge_id_particle_mapping = _create_edge_id_particle_mapping(
-        ref_graph, external_edge_getter_function
-    )
-
-    for graph in graphs[:ref_graph_id] + graphs[ref_graph_id + 1 :]:
-        edge_id_particle_mapping = _create_edge_id_particle_mapping(
-            graph, external_edge_getter_function
-        )
-        # remove matching entries
-        ref_mapping_copy = deepcopy(ref_edge_id_particle_mapping)
-        edge_ids_mapping = {}
-        for key, value in edge_id_particle_mapping.items():
-            if key in ref_mapping_copy and value == ref_mapping_copy[key]:
-                del ref_mapping_copy[key]
-            else:
-                for key_2, value_2 in ref_mapping_copy.items():
-                    if value == value_2:
-                        edge_ids_mapping[key] = key_2
-                        del ref_mapping_copy[key_2]
-                        break
-        if len(ref_mapping_copy) != 0:
-            raise ValueError(
-                "Unable to match graphs, due to inherent graph"
-                " structure mismatch"
-            )
-        swappings = _calculate_swappings(edge_ids_mapping)
-        for edge_id1, edge_id2 in swappings.items():
-            graph.swap_edges(edge_id1, edge_id2)
-
-
-def _calculate_swappings(id_mapping: Dict[int, int]) -> OrderedDict:
-    """Calculate edge id swappings.
-
-    Its important to use an ordered dict as the swappings do not commute!
-    """
-    swappings: OrderedDict = OrderedDict()
-    for key, value in id_mapping.items():
-        # go through existing swappings and use them
-        newkey = key
-        while newkey in swappings:
-            newkey = swappings[newkey]
-        if value != newkey:
-            swappings[value] = newkey
-    return swappings
-
-
-def _create_edge_id_particle_mapping(
-    graph: StateTransitionGraph, external_edge_getter_function: str,
-) -> Dict[int, str]:
-    name_label = particle.Labels.Name.name
-    return {
-        i: graph.edge_props[i][name_label]
-        for i in getattr(graph, external_edge_getter_function)()
-    }
-
-
-def perform_external_edge_identical_particle_combinatorics(
-    graph: StateTransitionGraph,
-) -> List[StateTransitionGraph]:
-    """Create combinatorics clones of the `.StateTransitionGraph`.
-
-    In case of identical particles in the initial or final state. Only
-    identical particles, which do not enter or exit the same node allow for
-    combinatorics!
-    """
-    if not isinstance(graph, StateTransitionGraph):
-        raise TypeError("graph argument is not of type StateTransitionGraph!")
-    temp_new_graphs = _external_edge_identical_particle_combinatorics(
-        graph, "get_final_state_edges"
-    )
-    new_graphs = []
-    for new_graph in temp_new_graphs:
-        new_graphs.extend(
-            _external_edge_identical_particle_combinatorics(
-                new_graph, "get_initial_state_edges"
-            )
-        )
-    return new_graphs
-
-
-def _external_edge_identical_particle_combinatorics(
-    graph: StateTransitionGraph, external_edge_getter_function: str,
-) -> List[StateTransitionGraph]:
-    # pylint: disable=too-many-locals
-    new_graphs = [graph]
-    edge_particle_mapping = _create_edge_id_particle_mapping(
-        graph, external_edge_getter_function
-    )
-    identical_particle_groups: Dict[str, Set[int]] = {}
-    for key, value in edge_particle_mapping.items():
-        if value not in identical_particle_groups:
-            identical_particle_groups[value] = set()
-        identical_particle_groups[value].add(key)
-    identical_particle_groups = {
-        key: value
-        for key, value in identical_particle_groups.items()
-        if len(value) > 1
-    }
-    # now for each identical particle group perform all permutations
-    for edge_group in identical_particle_groups.values():
-        combinations = permutations(edge_group)
-        graph_combinations = set()
-        ext_edge_combinations = []
-        ref_node_origin = graph.get_originating_node_list(edge_group)
-        for comb in combinations:
-            temp_edge_node_mapping = tuple(sorted(zip(comb, ref_node_origin)))
-            if temp_edge_node_mapping not in graph_combinations:
-                graph_combinations.add(temp_edge_node_mapping)
-                ext_edge_combinations.append(dict(zip(edge_group, comb)))
-        temp_new_graphs = []
-        for new_graph in new_graphs:
-            for combination in ext_edge_combinations:
-                graph_copy = deepcopy(new_graph)
-                swappings = _calculate_swappings(combination)
-                for edge_id1, edge_id2 in swappings.items():
-                    graph_copy.swap_edges(edge_id1, edge_id2)
-                temp_new_graphs.append(graph_copy)
-        new_graphs = temp_new_graphs
-    return new_graphs

--- a/tests/channels/test_jpsi_to_gamma_pi0_pi0.py
+++ b/tests/channels/test_jpsi_to_gamma_pi0_pi0.py
@@ -23,7 +23,7 @@ logging.getLogger().setLevel(logging.ERROR)
         (["f(0)(1500)"], 4),
         (["f(0)(980)", "f(0)(1500)"], 8),
         (["f(2)(1270)"], 12),
-        (["omega(782)"], 16),
+        (["omega(782)"], 8),
         (
             [
                 "f(0)(980)",
@@ -32,7 +32,7 @@ logging.getLogger().setLevel(logging.ERROR)
                 "f(2)(1950)",
                 "omega(782)",
             ],
-            48,
+            40,
         ),
     ],
 )

--- a/tests/channels/test_jpsi_to_gamma_pi0_pi0.py
+++ b/tests/channels/test_jpsi_to_gamma_pi0_pi0.py
@@ -6,11 +6,11 @@ import logging
 
 import pytest
 
+from expertsystem.state.particle import _create_edge_id_particle_mapping
 from expertsystem.ui import (
     InteractionTypes,
     StateTransitionManager,
 )
-from expertsystem.ui._system_control import _create_edge_id_particle_mapping
 
 
 logging.basicConfig(level=logging.ERROR)

--- a/tests/unit/amplitude/test_parity_prefactor.py
+++ b/tests/unit/amplitude/test_parity_prefactor.py
@@ -48,8 +48,8 @@ class Input(NamedTuple):
             ),
             "J/psi(1S)",
             (
-                "J/psi(1S)_1_to_rho(770)0_1+pi0_0;rho(770)0_1_to_pi-_0+pi+_0;",
-                "J/psi(1S)_1_to_rho(770)0_-1+pi0_0;rho(770)0_-1_to_pi-_0+pi+_0;",
+                "J/psi(1S)_1_to_pi0_0+rho(770)0_1;rho(770)0_1_to_pi+_0+pi-_0;",
+                "J/psi(1S)_1_to_pi0_0+rho(770)0_-1;rho(770)0_-1_to_pi+_0+pi-_0;",
             ),
             -1.0,
         ),  # pylint: disable=too-many-locals

--- a/tests/unit/amplitude/test_yaml_canonical.py
+++ b/tests/unit/amplitude/test_yaml_canonical.py
@@ -50,7 +50,7 @@ def test_particle_section(imported_dict):
 
 def test_parameter_section(imported_dict):
     parameter_list = imported_dict["Parameters"]
-    assert len(parameter_list) == 9
+    assert len(parameter_list) == 5
     for parameter in parameter_list:
         assert "Name" in parameter
         assert "Value" in parameter

--- a/tests/unit/ui/test_system_control.py
+++ b/tests/unit/ui/test_system_control.py
@@ -4,7 +4,10 @@ from expertsystem.state import particle
 from expertsystem.state.particle import (
     CompareGraphElementPropertiesFunctor,
     InteractionQuantumNumberNames,
+    _create_edge_id_particle_mapping,
     create_spin_domain,
+    match_external_edges,
+    perform_external_edge_identical_particle_combinatorics,
 )
 from expertsystem.topology import StateTransitionGraph
 from expertsystem.ui import (
@@ -12,10 +15,7 @@ from expertsystem.ui import (
     StateTransitionManager,
 )
 from expertsystem.ui._system_control import (
-    _create_edge_id_particle_mapping,
     filter_graphs,
-    match_external_edges,
-    perform_external_edge_identical_particle_combinatorics,
     remove_duplicate_solutions,
     require_interaction_property,
 )


### PR DESCRIPTION
Lead-up to #231: the list of solutions by `StateTransitionGraph.find_solutions` now does not contain the kinematic combinatorics anymore. This responsibility has been moved to the amplitude builders.