### PR TITLE
refactor!: remove QuantumState classes

### DIFF
--- a/examples/particles.ipynb
+++ b/examples/particles.ipynb
@@ -122,8 +122,8 @@
     "{\n",
     "    item.name\n",
     "    for item in particle_db.values()\n",
-    "    if item.state.strangeness == 1\n",
-    "    and item.state.spin >= 1\n",
+    "    if item.strangeness == 1\n",
+    "    and item.spin >= 1\n",
     "    and item.mass > 1.8\n",
     "    and item.mass < 1.9\n",
     "}"

--- a/expertsystem/data.py
+++ b/expertsystem/data.py
@@ -3,11 +3,8 @@
 __all__ = [  # fix order in API
     "ParticleCollection",
     "Particle",
-    "ComplexEnergyState",
-    "QuantumState",
     "Parity",
     "Spin",
-    "ComplexEnergy",
     "create_antiparticle",
     "create_particle",
     "GellmannNishijima",
@@ -19,12 +16,10 @@ from collections import abc
 from dataclasses import dataclass
 from typing import (
     Dict,
-    Generic,
     ItemsView,
     Iterator,
     KeysView,
     Optional,
-    TypeVar,
     Union,
     ValuesView,
 )
@@ -116,20 +111,18 @@ class Spin(abc.Hashable):
         return hash(repr(self))
 
 
-_T = TypeVar("_T", float, Spin)
-
-
 @dataclass(frozen=True)
-class QuantumState(
-    Generic[_T]
-):  # pylint: disable=too-many-instance-attributes
-    """Set of quantum numbers with a **generic type spin**.
+class Particle:  # pylint: disable=too-many-instance-attributes
+    """Immutable container of data defining a physical particle.
 
-    This is to make spin projection required in `.QuantumState` and unavailable
-    in `.Particle`.
+    Can **only** contain info that the `PDG <http://pdg.lbl.gov/>`_ would list.
+    Particles do NOT contain spin projection information.
     """
 
-    spin: _T
+    name: str
+    pid: int
+    energy: complex
+    spin: float
     charge: int = 0
     isospin: Optional[Spin] = None
     strangeness: int = 0
@@ -144,103 +137,31 @@ class QuantumState(
     c_parity: Optional[Parity] = None
     g_parity: Optional[Parity] = None
 
-
-class ComplexEnergy:
-    """Defines a complex valued energy.
-
-    Resembles a position (pole) in the complex energy plane.
-    """
-
-    def __init__(self, energy: complex):
-        self.__energy = complex(energy)
-
-    @property
-    def complex_energy(self) -> complex:
-        return self.__energy
-
     @property
     def mass(self) -> float:
-        return self.__energy.real
+        return self.energy.real
 
     @property
     def width(self) -> float:
-        return self.__energy.imag
+        return self.energy.imag
 
-    def __eq__(self, other: object) -> bool:
-        if isinstance(other, ComplexEnergy):
-            return self.complex_energy == other.complex_energy
-        raise NotImplementedError
-
-    def __repr__(self) -> str:
-        return f"{self.__class__.__name__}{self.complex_energy}"
-
-
-class ComplexEnergyState(ComplexEnergy):
-    """Pole in the complex energy plane, with quantum numbers."""
-
-    def __init__(self, energy: complex, state: QuantumState[Spin]):
-        super().__init__(energy)
-        self.state: QuantumState[Spin] = state
-
-    def __repr__(self) -> str:
-        return f"{self.__class__.__name__}{self.complex_energy, self.state}"
-
-
-class Particle(ComplexEnergy):
-    """Immutable container of data defining a physical particle.
-
-    Can **only** contain info that the `PDG <http://pdg.lbl.gov/>`_ would list.
-    """
-
-    def __init__(  # pylint: disable=too-many-arguments
-        self,
-        name: str,
-        pid: int,
-        state: QuantumState[float],
-        mass: float,
-        width: float = 0.0,
-    ):
+    def __post_init__(self) -> None:
         if (
-            state.isospin is not None
-            and GellmannNishijima.compute_charge(state) != state.charge
+            self.isospin is not None
+            and GellmannNishijima.compute_charge(self) != self.charge
         ):
             raise ValueError(
-                f"Cannot construct particle {name} because its quantum numbers"
+                f"Cannot construct particle {self.name} because its quantum numbers"
                 " don't agree with the Gell-Mann–Nishijima formula:\n"
-                f"  Q[{state.charge}] != "
-                f"Iz[{state.isospin.projection}] + 1/2 "
-                f"(B[{state.baryon_number}] + "
-                f" S[{state.strangeness}] + "
-                f" C[{state.charmness}] +"
-                f" B'[{state.bottomness}] +"
-                f" T[{state.strangeness}]"
+                f"  Q[{self.charge}] != "
+                f"Iz[{self.isospin.projection}] + 1/2 "
+                f"(B[{self.baryon_number}] + "
+                f" S[{self.strangeness}] + "
+                f" C[{self.charmness}] +"
+                f" B'[{self.bottomness}] +"
+                f" T[{self.strangeness}]"
                 ")"
             )
-        super().__init__(complex(mass, width))
-        self.__name: str = name
-        self.__pid: int = pid
-        self.state: QuantumState[float] = state
-
-    @property
-    def name(self) -> str:
-        return self.__name
-
-    @property
-    def pid(self) -> int:
-        return self.__pid
-
-    def __eq__(self, other: object) -> bool:
-        if isinstance(other, Particle):
-            return (
-                self.name == other.name
-                and self.pid == other.pid
-                and super().__eq__(other)
-                and self.state == other.state
-            )
-        raise NotImplementedError
-
-    def __repr__(self) -> str:
-        return f"{self.__class__.__name__}{self.name, self.pid, self.state, self.mass, self.width}"
 
 
 class GellmannNishijima:
@@ -254,16 +175,16 @@ class GellmannNishijima:
 
     where
     :math:`Q` is charge (computed),
-    :math:`I_3` is `.Spin.projection`,
-    :math:`B` is `~.QuantumState.baryon_number`,
-    :math:`S` is `~.QuantumState.strangeness`,
-    :math:`C` is `~.QuantumState.charmness`,
-    :math:`B'` is `~.QuantumState.bottomness`, and
-    :math:`T` is `~.QuantumState.topness`.
+    :math:`I_3` is `.Spin.projection` of `~.Particle.isospin`,
+    :math:`B` is `~.Particle.baryon_number`,
+    :math:`S` is `~.Particle.strangeness`,
+    :math:`C` is `~.Particle.charmness`,
+    :math:`B'` is `~.Particle.bottomness`, and
+    :math:`T` is `~.Particle.topness`.
     """
 
     @staticmethod
-    def compute_charge(state: QuantumState) -> Optional[float]:
+    def compute_charge(state: Particle) -> Optional[float]:
         """Compute charge using the Gell-Mann–Nishijima formula.
 
         If isospin is not `None`, returns the value :math:`Q`: computed with
@@ -271,6 +192,10 @@ class GellmannNishijima:
         """
         if state.isospin is None:
             return None
+        if state.isospin.projection is None:
+            raise ValueError(
+                "Isospin projection must be defined if a magnitude is defined!"
+            )
         computed_charge = state.isospin.projection + 0.5 * (
             state.baryon_number
             + state.strangeness
@@ -424,90 +349,75 @@ def create_particle(  # pylint: disable=too-many-arguments,too-many-locals
     parity: Optional[int] = None,
     c_parity: Optional[int] = None,
     g_parity: Optional[int] = None,
-    state: Optional[QuantumState[float]] = None,
 ) -> Particle:
-    if state is not None:
-        new_state = state
-    else:
-        new_state = QuantumState[float](
-            spin=spin if spin else template_particle.state.spin,
-            charge=charge if charge else template_particle.state.charge,
-            strangeness=strangeness
-            if strangeness
-            else template_particle.state.strangeness,
-            charmness=charmness
-            if charmness
-            else template_particle.state.charmness,
-            bottomness=bottomness
-            if bottomness
-            else template_particle.state.bottomness,
-            topness=topness if topness else template_particle.state.topness,
-            baryon_number=baryon_number
-            if baryon_number
-            else template_particle.state.baryon_number,
-            electron_lepton_number=electron_lepton_number
-            if electron_lepton_number
-            else template_particle.state.electron_lepton_number,
-            muon_lepton_number=muon_lepton_number
-            if muon_lepton_number
-            else template_particle.state.muon_lepton_number,
-            tau_lepton_number=tau_lepton_number
-            if tau_lepton_number
-            else template_particle.state.tau_lepton_number,
-            isospin=template_particle.state.isospin
-            if isospin is None
-            else template_particle.state.isospin,
-            parity=template_particle.state.parity
-            if parity is None
-            else Parity(parity),
-            c_parity=template_particle.state.c_parity
-            if c_parity is None
-            else Parity(c_parity),
-            g_parity=template_particle.state.g_parity
-            if g_parity is None
-            else Parity(g_parity),
-        )
-    new_particle = Particle(
+    return Particle(
         name=name if name else template_particle.name,
         pid=pid if pid else template_particle.pid,
-        mass=mass if mass else template_particle.mass,
-        width=width if width else template_particle.width,
-        state=new_state,
+        energy=complex(
+            mass if mass else template_particle.mass,
+            width if width else template_particle.width,
+        ),
+        spin=spin if spin else template_particle.spin,
+        charge=charge if charge else template_particle.charge,
+        strangeness=strangeness
+        if strangeness
+        else template_particle.strangeness,
+        charmness=charmness if charmness else template_particle.charmness,
+        bottomness=bottomness if bottomness else template_particle.bottomness,
+        topness=topness if topness else template_particle.topness,
+        baryon_number=baryon_number
+        if baryon_number
+        else template_particle.baryon_number,
+        electron_lepton_number=electron_lepton_number
+        if electron_lepton_number
+        else template_particle.electron_lepton_number,
+        muon_lepton_number=muon_lepton_number
+        if muon_lepton_number
+        else template_particle.muon_lepton_number,
+        tau_lepton_number=tau_lepton_number
+        if tau_lepton_number
+        else template_particle.tau_lepton_number,
+        isospin=template_particle.isospin
+        if isospin is None
+        else template_particle.isospin,
+        parity=template_particle.parity if parity is None else Parity(parity),
+        c_parity=template_particle.c_parity
+        if c_parity is None
+        else Parity(c_parity),
+        g_parity=template_particle.g_parity
+        if g_parity is None
+        else Parity(g_parity),
     )
-    return new_particle
 
 
 def create_antiparticle(
     template_particle: Particle, new_name: str = None
 ) -> Particle:
     isospin: Optional[Spin] = None
-    if template_particle.state.isospin:
-        isospin = -template_particle.state.isospin
+    if template_particle.isospin:
+        isospin = -template_particle.isospin
     parity: Optional[Parity] = None
-    if template_particle.state.parity is not None:
-        if template_particle.state.spin.is_integer():
-            parity = template_particle.state.parity
+    if template_particle.parity is not None:
+        if template_particle.spin.is_integer():
+            parity = template_particle.parity
         else:
-            parity = -template_particle.state.parity
+            parity = -template_particle.parity
     return Particle(
         name=new_name if new_name else "anti-" + template_particle.name,
         pid=-template_particle.pid,
-        mass=template_particle.mass,
-        width=template_particle.width,
-        state=QuantumState[float](
-            charge=-template_particle.state.charge,
-            spin=template_particle.state.spin,
-            isospin=isospin,
-            strangeness=-template_particle.state.strangeness,
-            charmness=-template_particle.state.charmness,
-            bottomness=-template_particle.state.bottomness,
-            topness=-template_particle.state.topness,
-            baryon_number=-template_particle.state.baryon_number,
-            electron_lepton_number=-template_particle.state.electron_lepton_number,
-            muon_lepton_number=-template_particle.state.muon_lepton_number,
-            tau_lepton_number=-template_particle.state.tau_lepton_number,
-            parity=parity,
-            c_parity=template_particle.state.c_parity,
-            g_parity=template_particle.state.g_parity,
-        ),
+        energy=complex(template_particle.mass, template_particle.width),
+        charge=-template_particle.charge,
+        spin=template_particle.spin,
+        isospin=isospin,
+        strangeness=-template_particle.strangeness,
+        charmness=-template_particle.charmness,
+        bottomness=-template_particle.bottomness,
+        topness=-template_particle.topness,
+        baryon_number=-template_particle.baryon_number,
+        electron_lepton_number=-template_particle.electron_lepton_number,
+        muon_lepton_number=-template_particle.muon_lepton_number,
+        tau_lepton_number=-template_particle.tau_lepton_number,
+        parity=parity,
+        c_parity=template_particle.c_parity,
+        g_parity=template_particle.g_parity,
     )

--- a/expertsystem/data.py
+++ b/expertsystem/data.py
@@ -115,14 +115,17 @@ class Spin(abc.Hashable):
 class Particle:  # pylint: disable=too-many-instance-attributes
     """Immutable container of data defining a physical particle.
 
-    Can **only** contain info that the `PDG <http://pdg.lbl.gov/>`_ would list.
-    Particles do NOT contain spin projection information.
+    A Particle is defined by the minimum set of the quantum numbers that every
+    possible instances of that particle have in common (the "static" quantum
+    numbers of the particle). A "non-static" quantum number is the spin
+    projection. Hence Particles do NOT contain spin projection information.
     """
 
     name: str
     pid: int
-    energy: complex
     spin: float
+    mass: float
+    width: float = 0.0
     charge: int = 0
     isospin: Optional[Spin] = None
     strangeness: int = 0
@@ -138,12 +141,8 @@ class Particle:  # pylint: disable=too-many-instance-attributes
     g_parity: Optional[Parity] = None
 
     @property
-    def mass(self) -> float:
-        return self.energy.real
-
-    @property
-    def width(self) -> float:
-        return self.energy.imag
+    def energy(self) -> complex:
+        return complex(self.mass, self.width)
 
     def __post_init__(self) -> None:
         if (
@@ -353,10 +352,8 @@ def create_particle(  # pylint: disable=too-many-arguments,too-many-locals
     return Particle(
         name=name if name else template_particle.name,
         pid=pid if pid else template_particle.pid,
-        energy=complex(
-            mass if mass else template_particle.mass,
-            width if width else template_particle.width,
-        ),
+        mass=mass if mass else template_particle.mass,
+        width=width if width else template_particle.width,
         spin=spin if spin else template_particle.spin,
         charge=charge if charge else template_particle.charge,
         strangeness=strangeness
@@ -405,7 +402,8 @@ def create_antiparticle(
     return Particle(
         name=new_name if new_name else "anti-" + template_particle.name,
         pid=-template_particle.pid,
-        energy=complex(template_particle.mass, template_particle.width),
+        mass=template_particle.mass,
+        width=template_particle.width,
         charge=-template_particle.charge,
         spin=template_particle.spin,
         isospin=isospin,

--- a/expertsystem/io/_pdg.py
+++ b/expertsystem/io/_pdg.py
@@ -60,10 +60,8 @@ def __convert_pdg_instance(pdg_particle: PdgDatabase) -> Particle:
     return Particle(
         name=str(pdg_particle.name),
         pid=int(pdg_particle.pdgid),
-        energy=complex(
-            convert_mass_width(pdg_particle.mass),
-            convert_mass_width(pdg_particle.width),
-        ),
+        mass=convert_mass_width(pdg_particle.mass),
+        width=convert_mass_width(pdg_particle.width),
         charge=int(pdg_particle.charge),
         spin=float(pdg_particle.J),
         strangeness=quark_numbers[0],

--- a/expertsystem/io/_pdg.py
+++ b/expertsystem/io/_pdg.py
@@ -16,7 +16,6 @@ from expertsystem.data import (
     Parity,
     Particle,
     ParticleCollection,
-    QuantumState,
     Spin,
 )
 
@@ -61,24 +60,24 @@ def __convert_pdg_instance(pdg_particle: PdgDatabase) -> Particle:
     return Particle(
         name=str(pdg_particle.name),
         pid=int(pdg_particle.pdgid),
-        mass=convert_mass_width(pdg_particle.mass),
-        width=convert_mass_width(pdg_particle.width),
-        state=QuantumState[float](
-            charge=int(pdg_particle.charge),
-            spin=float(pdg_particle.J),
-            strangeness=quark_numbers[0],
-            charmness=quark_numbers[1],
-            bottomness=quark_numbers[2],
-            topness=quark_numbers[3],
-            baryon_number=__compute_baryonnumber(pdg_particle),
-            electron_lepton_number=lepton_numbers[0],
-            muon_lepton_number=lepton_numbers[1],
-            tau_lepton_number=lepton_numbers[2],
-            isospin=__create_isospin(pdg_particle),
-            parity=parity,
-            c_parity=__create_parity(pdg_particle.C),
-            g_parity=__create_parity(pdg_particle.G),
+        energy=complex(
+            convert_mass_width(pdg_particle.mass),
+            convert_mass_width(pdg_particle.width),
         ),
+        charge=int(pdg_particle.charge),
+        spin=float(pdg_particle.J),
+        strangeness=quark_numbers[0],
+        charmness=quark_numbers[1],
+        bottomness=quark_numbers[2],
+        topness=quark_numbers[3],
+        baryon_number=__compute_baryonnumber(pdg_particle),
+        electron_lepton_number=lepton_numbers[0],
+        muon_lepton_number=lepton_numbers[1],
+        tau_lepton_number=lepton_numbers[2],
+        isospin=__create_isospin(pdg_particle),
+        parity=parity,
+        c_parity=__create_parity(pdg_particle.C),
+        g_parity=__create_parity(pdg_particle.G),
     )
 
 

--- a/expertsystem/io/xml/__init__.py
+++ b/expertsystem/io/xml/__init__.py
@@ -10,7 +10,6 @@ import json
 import xmltodict
 
 from expertsystem.data import (
-    ComplexEnergyState,
     Particle,
     ParticleCollection,
     Spin,
@@ -49,7 +48,7 @@ def write(instance: object, filename: str) -> None:
 def object_to_dict(instance: object) -> dict:
     if isinstance(instance, ParticleCollection):
         return _dump.from_particle_collection(instance)
-    if isinstance(instance, (ComplexEnergyState, Particle)):
+    if isinstance(instance, (Particle)):
         return _dump.from_particle_state(instance)
     raise NotImplementedError
 

--- a/expertsystem/io/xml/_build.py
+++ b/expertsystem/io/xml/_build.py
@@ -14,7 +14,6 @@ from expertsystem.data import (
     Parity,
     Particle,
     ParticleCollection,
-    QuantumState,
     Spin,
 )
 
@@ -49,24 +48,23 @@ def build_particle(definition: dict) -> Particle:
     return Particle(
         name=str(definition["Name"]),
         pid=int(definition["Pid"]),
-        mass=float(definition["Parameter"]["Value"]),
-        width=_xml_to_width(definition),
-        state=QuantumState[float](
-            charge=int(qn_defs["Charge"]),
-            spin=float(qn_defs["Spin"]),
-            isospin=qn_defs.get("IsoSpin", None),
-            strangeness=int(qn_defs.get("Strangeness", 0)),
-            charmness=int(qn_defs.get("Charmness", 0)),
-            bottomness=int(qn_defs.get("Bottomness", 0)),
-            topness=int(qn_defs.get("Topness", 0)),
-            baryon_number=int(qn_defs.get("BaryonNumber", 0)),
-            electron_lepton_number=int(qn_defs.get("ElectronLN", 0)),
-            muon_lepton_number=int(qn_defs.get("MuonLN", 0)),
-            tau_lepton_number=int(qn_defs.get("TauLN", 0)),
-            parity=qn_defs.get("Parity", None),
-            c_parity=qn_defs.get("CParity", None),
-            g_parity=qn_defs.get("GParity", None),
+        energy=complex(
+            float(definition["Parameter"]["Value"]), _xml_to_width(definition)
         ),
+        charge=int(qn_defs["Charge"]),
+        spin=float(qn_defs["Spin"]),
+        isospin=qn_defs.get("IsoSpin", None),
+        strangeness=int(qn_defs.get("Strangeness", 0)),
+        charmness=int(qn_defs.get("Charmness", 0)),
+        bottomness=int(qn_defs.get("Bottomness", 0)),
+        topness=int(qn_defs.get("Topness", 0)),
+        baryon_number=int(qn_defs.get("BaryonNumber", 0)),
+        electron_lepton_number=int(qn_defs.get("ElectronLN", 0)),
+        muon_lepton_number=int(qn_defs.get("MuonLN", 0)),
+        tau_lepton_number=int(qn_defs.get("TauLN", 0)),
+        parity=qn_defs.get("Parity", None),
+        c_parity=qn_defs.get("CParity", None),
+        g_parity=qn_defs.get("GParity", None),
     )
 
 

--- a/expertsystem/io/xml/_build.py
+++ b/expertsystem/io/xml/_build.py
@@ -48,9 +48,8 @@ def build_particle(definition: dict) -> Particle:
     return Particle(
         name=str(definition["Name"]),
         pid=int(definition["Pid"]),
-        energy=complex(
-            float(definition["Parameter"]["Value"]), _xml_to_width(definition)
-        ),
+        mass=float(definition["Parameter"]["Value"]),
+        width=_xml_to_width(definition),
         charge=int(qn_defs["Charge"]),
         spin=float(qn_defs["Spin"]),
         isospin=qn_defs.get("IsoSpin", None),

--- a/expertsystem/io/xml/_dump.py
+++ b/expertsystem/io/xml/_dump.py
@@ -16,7 +16,6 @@ from typing import (
 )
 
 from expertsystem.data import (
-    ComplexEnergyState,
     Parity,
     Particle,
     ParticleCollection,
@@ -31,11 +30,9 @@ def from_particle_collection(particles: ParticleCollection) -> dict:
     return output
 
 
-def from_particle_state(instance: Union[ComplexEnergyState, Particle]) -> dict:
+def from_particle_state(instance: Particle) -> dict:
     def create_parameter_dict(
-        value: float,
-        type_name: str,
-        state: Union[ComplexEnergyState, Particle],
+        value: float, type_name: str, state: Particle,
     ) -> dict:
         value_dict = {
             "Type": type_name,
@@ -59,26 +56,24 @@ def from_particle_state(instance: Union[ComplexEnergyState, Particle]) -> dict:
     return output_dict
 
 
-def _to_quantum_number_list(
-    state: Union[ComplexEnergyState, Particle]
-) -> List[Dict[str, Any]]:
+def _to_quantum_number_list(state: Particle) -> List[Dict[str, Any]]:
     conversion_map: Dict[
         str, Union[Optional[Parity], Optional[Spin], float, int]
     ] = {
-        "Spin": state.state.spin,
-        "Charge": state.state.charge,
-        "Parity": state.state.parity,
-        "CParity": state.state.c_parity,
-        "GParity": state.state.g_parity,
-        "Strangeness": state.state.strangeness,
-        "Charmness": state.state.charmness,
-        "Bottomness": state.state.bottomness,
-        "Topness": state.state.topness,
-        "BaryonNumber": state.state.baryon_number,
-        "ElectronLN": state.state.electron_lepton_number,
-        "MuonLN": state.state.muon_lepton_number,
-        "TauLN": state.state.tau_lepton_number,
-        "IsoSpin": state.state.isospin,
+        "Spin": state.spin,
+        "Charge": state.charge,
+        "Parity": state.parity,
+        "CParity": state.c_parity,
+        "GParity": state.g_parity,
+        "Strangeness": state.strangeness,
+        "Charmness": state.charmness,
+        "Bottomness": state.bottomness,
+        "Topness": state.topness,
+        "BaryonNumber": state.baryon_number,
+        "ElectronLN": state.electron_lepton_number,
+        "MuonLN": state.muon_lepton_number,
+        "TauLN": state.tau_lepton_number,
+        "IsoSpin": state.isospin,
     }
     output: List[Dict[str, Any]] = list()
     for type_name, instance in conversion_map.items():

--- a/expertsystem/io/yaml/_build.py
+++ b/expertsystem/io/yaml/_build.py
@@ -9,7 +9,6 @@ from expertsystem.data import (
     Parity,
     Particle,
     ParticleCollection,
-    QuantumState,
     Spin,
 )
 
@@ -30,24 +29,23 @@ def build_particle(name: str, definition: dict) -> Particle:
     return Particle(
         name=name,
         pid=int(definition["PID"]),
-        mass=float(definition["Mass"]),
-        width=float(definition.get("Width", 0.0)),
-        state=QuantumState[float](
-            charge=int(qn_def["Charge"]),
-            spin=float(qn_def["Spin"]),
-            strangeness=int(qn_def.get("Strangeness", 0)),
-            charmness=int(qn_def.get("Charmness", 0)),
-            bottomness=int(qn_def.get("Bottomness", 0)),
-            topness=int(qn_def.get("Topness", 0)),
-            baryon_number=int(qn_def.get("BaryonNumber", 0)),
-            electron_lepton_number=int(qn_def.get("ElectronLN", 0)),
-            muon_lepton_number=int(qn_def.get("MuonLN", 0)),
-            tau_lepton_number=int(qn_def.get("TauLN", 0)),
-            isospin=_yaml_to_isospin(qn_def.get("IsoSpin", None)),
-            parity=_yaml_to_parity(qn_def.get("Parity", None)),
-            c_parity=_yaml_to_parity(qn_def.get("CParity", None)),
-            g_parity=_yaml_to_parity(qn_def.get("GParity", None)),
+        energy=complex(
+            float(definition["Mass"]), float(definition.get("Width", 0.0))
         ),
+        charge=int(qn_def["Charge"]),
+        spin=float(qn_def["Spin"]),
+        strangeness=int(qn_def.get("Strangeness", 0)),
+        charmness=int(qn_def.get("Charmness", 0)),
+        bottomness=int(qn_def.get("Bottomness", 0)),
+        topness=int(qn_def.get("Topness", 0)),
+        baryon_number=int(qn_def.get("BaryonNumber", 0)),
+        electron_lepton_number=int(qn_def.get("ElectronLN", 0)),
+        muon_lepton_number=int(qn_def.get("MuonLN", 0)),
+        tau_lepton_number=int(qn_def.get("TauLN", 0)),
+        isospin=_yaml_to_isospin(qn_def.get("IsoSpin", None)),
+        parity=_yaml_to_parity(qn_def.get("Parity", None)),
+        c_parity=_yaml_to_parity(qn_def.get("CParity", None)),
+        g_parity=_yaml_to_parity(qn_def.get("GParity", None)),
     )
 
 

--- a/expertsystem/io/yaml/_build.py
+++ b/expertsystem/io/yaml/_build.py
@@ -29,9 +29,8 @@ def build_particle(name: str, definition: dict) -> Particle:
     return Particle(
         name=name,
         pid=int(definition["PID"]),
-        energy=complex(
-            float(definition["Mass"]), float(definition.get("Width", 0.0))
-        ),
+        mass=float(definition["Mass"]),
+        width=float(definition.get("Width", 0.0)),
         charge=int(qn_def["Charge"]),
         spin=float(qn_def["Spin"]),
         strangeness=int(qn_def.get("Strangeness", 0)),

--- a/expertsystem/io/yaml/_dump.py
+++ b/expertsystem/io/yaml/_dump.py
@@ -43,23 +43,23 @@ def _to_quantum_number_dict(
     particle: Particle,
 ) -> Dict[str, Union[float, int, Dict[str, float]]]:
     output_dict: Dict[str, Union[float, int, Dict[str, float]]] = {
-        "Spin": _attempt_to_int(particle.state.spin),
-        "Charge": int(particle.state.charge),
+        "Spin": _attempt_to_int(particle.spin),
+        "Charge": int(particle.charge),
     }
     optional_qn: List[
         Tuple[str, Union[Optional[Parity], Spin, int], Union[Callable, int]]
     ] = [
-        ("Parity", particle.state.parity, int),
-        ("CParity", particle.state.c_parity, int),
-        ("GParity", particle.state.g_parity, int),
-        ("Strangeness", particle.state.strangeness, int),
-        ("Charmness", particle.state.charmness, int),
-        ("Bottomness", particle.state.bottomness, int),
-        ("Topness", particle.state.topness, int),
-        ("BaryonNumber", particle.state.baryon_number, int),
-        ("ElectronLN", particle.state.electron_lepton_number, int),
-        ("MuonLN", particle.state.muon_lepton_number, int),
-        ("TauLN", particle.state.tau_lepton_number, int),
+        ("Parity", particle.parity, int),
+        ("CParity", particle.c_parity, int),
+        ("GParity", particle.g_parity, int),
+        ("Strangeness", particle.strangeness, int),
+        ("Charmness", particle.charmness, int),
+        ("Bottomness", particle.bottomness, int),
+        ("Topness", particle.topness, int),
+        ("BaryonNumber", particle.baryon_number, int),
+        ("ElectronLN", particle.electron_lepton_number, int),
+        ("MuonLN", particle.muon_lepton_number, int),
+        ("TauLN", particle.tau_lepton_number, int),
     ]
     for key, value, converter in optional_qn:
         if value in [0, None]:
@@ -67,8 +67,8 @@ def _to_quantum_number_dict(
         output_dict[key] = converter(  # type: ignore
             value
         )  # pylint: disable=not-callable
-    if particle.state.isospin is not None:
-        output_dict["IsoSpin"] = _from_spin(particle.state.isospin)
+    if particle.isospin is not None:
+        output_dict["IsoSpin"] = _from_spin(particle.isospin)
     return output_dict
 
 

--- a/expertsystem/state/particle.py
+++ b/expertsystem/state/particle.py
@@ -522,7 +522,7 @@ def __safe_set_spin_projections(
         particle_name = state
         particle = particle_db[state]
         spin_projections = arange(  # type: ignore
-            -particle.state.spin, particle.state.spin + 1, 1.0
+            -particle.spin, particle.spin + 1, 1.0
         ).tolist()
         if particle.mass == 0.0:
             if 0.0 in spin_projections:

--- a/tests/channels/test_d0_to_ks_kp_km.py
+++ b/tests/channels/test_d0_to_ks_kp_km.py
@@ -20,7 +20,7 @@ def test_script():
             "phi(1020)",
         ],
     )
-    stm.number_of_threads = 1
+    stm.number_of_threads = 2
 
     graph_interaction_settings_groups = stm.prepare_graphs()
     solutions, _ = stm.find_solutions(graph_interaction_settings_groups)

--- a/tests/channels/test_d0_to_ks_kp_km.py
+++ b/tests/channels/test_d0_to_ks_kp_km.py
@@ -20,7 +20,7 @@ def test_script():
             "phi(1020)",
         ],
     )
-    stm.number_of_threads = 2
+    stm.number_of_threads = 1
 
     graph_interaction_settings_groups = stm.prepare_graphs()
     solutions, _ = stm.find_solutions(graph_interaction_settings_groups)

--- a/tests/unit/data/test_particle.py
+++ b/tests/unit/data/test_particle.py
@@ -6,7 +6,6 @@ from expertsystem.data import (
     Parity,
     Particle,
     ParticleCollection,
-    QuantumState,
     Spin,
     create_antiparticle,
     create_particle,
@@ -16,16 +15,13 @@ from expertsystem.data import (
 J_PSI = Particle(
     name="J/psi(1S)",
     pid=443,
-    mass=3.0969,
-    width=9.29e-05,
-    state=QuantumState[float](
-        spin=1,
-        charge=0,
-        parity=Parity(-1),
-        c_parity=Parity(-1),
-        g_parity=Parity(-1),
-        isospin=Spin(0.0, 0.0),
-    ),
+    energy=complex(3.0969, 9.29e-05),
+    spin=1,
+    charge=0,
+    parity=Parity(-1),
+    c_parity=Parity(-1),
+    g_parity=Parity(-1),
+    isospin=Spin(0.0, 0.0),
 )
 
 
@@ -64,7 +60,7 @@ def test_spin():
 def test_particle():
     assert J_PSI.mass == 3.0969
     assert J_PSI.width == 9.29e-05
-    assert J_PSI.state.bottomness == 0
+    assert J_PSI.bottomness == 0
 
 
 @pytest.mark.parametrize(
@@ -80,17 +76,12 @@ def test_create_particle(
 
     assert new_particle.name == "testparticle"
     assert new_particle.pid == 89
-    assert new_particle.state.charge == template_particle.state.charge
-    assert new_particle.state.spin == template_particle.state.spin
+    assert new_particle.charge == template_particle.charge
+    assert new_particle.spin == template_particle.spin
     assert new_particle.mass == 1.5
     assert new_particle.width == 0.5
-    assert (
-        new_particle.state.baryon_number
-        == template_particle.state.baryon_number
-    )
-    assert (
-        new_particle.state.strangeness == template_particle.state.strangeness
-    )
+    assert new_particle.baryon_number == template_particle.baryon_number
+    assert new_particle.strangeness == template_particle.strangeness
 
 
 @pytest.mark.parametrize(
@@ -103,14 +94,12 @@ def test_create_antiparticle(
     anti_particle_name,
 ):
     template_particle = particle_database[particle_name]
-    anti_particle = create_antiparticle(template_particle)
+    anti_particle = create_antiparticle(
+        template_particle, new_name=anti_particle_name
+    )
     comparison_particle = particle_database[anti_particle_name]
 
-    assert anti_particle.pid == comparison_particle.pid
-    assert anti_particle.mass == comparison_particle.mass
-    assert anti_particle.width == comparison_particle.width
-    assert anti_particle.state == comparison_particle.state
-    assert anti_particle.name == "anti-" + particle_name
+    assert anti_particle == comparison_particle
 
 
 def test_create_antiparticle_tilde(particle_database):
@@ -124,10 +113,7 @@ def test_create_antiparticle_tilde(particle_database):
             particle_name = particle_name.replace("-", "+")
         created_particle = create_antiparticle(anti_particle, particle_name)
 
-        assert created_particle.state == particle_database[particle_name].state
-        assert created_particle.complex_energy == pytest.approx(
-            particle_database[particle_name].complex_energy
-        )
+        assert created_particle == particle_database[particle_name]
 
 
 class TestGellmannNishijima:
@@ -135,13 +121,28 @@ class TestGellmannNishijima:
     @pytest.mark.parametrize(
         "state",
         [
-            QuantumState(
-                spin=0.0, charge=1, isospin=Spin(1.0, 0.0), strangeness=2,
+            Particle(
+                "p1",
+                1,
+                complex(1, 0),
+                spin=0.0,
+                charge=1,
+                isospin=Spin(1.0, 0.0),
+                strangeness=2,
             ),
-            QuantumState(
-                spin=1.0, charge=1, isospin=Spin(1.5, 0.5), charmness=1,
+            Particle(
+                "p1",
+                1,
+                complex(1, 0),
+                spin=1.0,
+                charge=1,
+                isospin=Spin(1.5, 0.5),
+                charmness=1,
             ),
-            QuantumState(
+            Particle(
+                "p1",
+                1,
+                complex(1, 0),
                 spin=0.5,
                 charge=1.5,  # type: ignore
                 isospin=Spin(1.0, 1.0),
@@ -165,7 +166,9 @@ class TestGellmannNishijima:
 
     @staticmethod
     def test_isospin_none():
-        state = QuantumState(spin=0.0, charge=1, isospin=None)
+        state = Particle(
+            "p1", 1, complex(1, 0), spin=0.0, charge=1, isospin=None
+        )
         assert GellmannNishijima.compute_charge(state) is None
 
     @staticmethod
@@ -175,15 +178,13 @@ class TestGellmannNishijima:
                 Particle(
                     name="Fails Gell-Mann–Nishijima formula",
                     pid=666,
-                    mass=0.0,
-                    state=QuantumState[float](
-                        spin=1,
-                        charge=0,
-                        parity=Parity(-1),
-                        c_parity=Parity(-1),
-                        g_parity=Parity(-1),
-                        isospin=Spin(0.0, 0.0),
-                        charmness=1,
-                    ),
+                    energy=complex(0.0, 0.0),
+                    spin=1,
+                    charge=0,
+                    parity=Parity(-1),
+                    c_parity=Parity(-1),
+                    g_parity=Parity(-1),
+                    isospin=Spin(0.0, 0.0),
+                    charmness=1,
                 )
             )

--- a/tests/unit/data/test_particle.py
+++ b/tests/unit/data/test_particle.py
@@ -15,7 +15,8 @@ from expertsystem.data import (
 J_PSI = Particle(
     name="J/psi(1S)",
     pid=443,
-    energy=complex(3.0969, 9.29e-05),
+    mass=3.0969,
+    width=9.29e-05,
     spin=1,
     charge=0,
     parity=Parity(-1),
@@ -124,8 +125,8 @@ class TestGellmannNishijima:
             Particle(
                 "p1",
                 1,
-                complex(1, 0),
                 spin=0.0,
+                mass=1,
                 charge=1,
                 isospin=Spin(1.0, 0.0),
                 strangeness=2,
@@ -133,8 +134,8 @@ class TestGellmannNishijima:
             Particle(
                 "p1",
                 1,
-                complex(1, 0),
                 spin=1.0,
+                mass=1,
                 charge=1,
                 isospin=Spin(1.5, 0.5),
                 charmness=1,
@@ -142,8 +143,8 @@ class TestGellmannNishijima:
             Particle(
                 "p1",
                 1,
-                complex(1, 0),
                 spin=0.5,
+                mass=1,
                 charge=1.5,  # type: ignore
                 isospin=Spin(1.0, 1.0),
                 baryon_number=1,
@@ -166,9 +167,7 @@ class TestGellmannNishijima:
 
     @staticmethod
     def test_isospin_none():
-        state = Particle(
-            "p1", 1, complex(1, 0), spin=0.0, charge=1, isospin=None
-        )
+        state = Particle("p1", 1, mass=1, spin=0.0, charge=1, isospin=None)
         assert GellmannNishijima.compute_charge(state) is None
 
     @staticmethod
@@ -178,7 +177,7 @@ class TestGellmannNishijima:
                 Particle(
                     name="Fails Gell-Mann–Nishijima formula",
                     pid=666,
-                    energy=complex(0.0, 0.0),
+                    mass=0.0,
                     spin=1,
                     charge=0,
                     parity=Parity(-1),

--- a/tests/unit/data/test_particle_collection.py
+++ b/tests/unit/data/test_particle_collection.py
@@ -49,5 +49,5 @@ def test_exceptions(particle_database):
         particle_database.find(3.14)  # type: ignore
     with pytest.raises(NotImplementedError):
         particle_database += 3.14  # type: ignore
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(AssertionError):
         assert gamma_1 == "gamma"

--- a/tests/unit/data/test_states.py
+++ b/tests/unit/data/test_states.py
@@ -11,7 +11,8 @@ from expertsystem.data import Particle, Spin
         Particle(
             name="jpsi",
             pid=1234,
-            energy=complex(3.0969, 9.29e-05),
+            mass=3.0969,
+            width=9.29e-05,
             spin=1,
             charge=0,
         ),
@@ -27,7 +28,8 @@ def test_immutability():
         test_state = Particle(
             "MyParticle",
             123,
-            complex(1.2, 0.1),
+            mass=1.2,
+            width=0.1,
             spin=1,
             charge=0,
             isospin=Spin(1, 0),
@@ -38,20 +40,22 @@ def test_immutability():
 def test_complex_energy_equality():
     with pytest.raises(AssertionError):
         assert Particle(
-            "MyParticle", pid=123, energy=complex(1.5, 0.1), spin=1,
-        ) == Particle("MyParticle", pid=123, energy=complex(1.5, 0.2), spin=1)
+            "MyParticle", pid=123, mass=1.5, width=0.1, spin=1,
+        ) == Particle("MyParticle", pid=123, mass=1.5, width=0.2, spin=1)
 
     assert Particle(
         "MyParticle",
         123,
-        complex(1.2, 0.1),
+        mass=1.2,
+        width=0.1,
         spin=1,
         charge=0,
         isospin=Spin(1, 0),
     ) == Particle(
         "MyParticle",
         123,
-        complex(1.2, 0.1),
+        mass=1.2,
+        width=0.1,
         spin=1,
         charge=0,
         isospin=Spin(1, 0),

--- a/tests/unit/data/test_states.py
+++ b/tests/unit/data/test_states.py
@@ -2,22 +2,18 @@ from dataclasses import FrozenInstanceError
 
 import pytest
 
-from expertsystem.data import (
-    ComplexEnergy,
-    ComplexEnergyState,
-    QuantumState,
-    Spin,
-)
+from expertsystem.data import Particle, Spin
 
 
 @pytest.mark.parametrize(
     "instance",
     [
-        QuantumState(spin=Spin(1, 1), charge=0),
-        ComplexEnergy(complex(3.0969, 9.29e-05)),
-        ComplexEnergyState(
-            complex(3.0969, 9.29e-05),
-            state=QuantumState(spin=Spin(1, 1), charge=0),
+        Particle(
+            name="jpsi",
+            pid=1234,
+            energy=complex(3.0969, 9.29e-05),
+            spin=1,
+            charge=0,
         ),
     ],
 )
@@ -28,37 +24,42 @@ def test_repr(instance):
 
 def test_immutability():
     with pytest.raises(FrozenInstanceError):
-        test_state = QuantumState(
-            spin=Spin(1, 1), charge=0, isospin=Spin(1, 0)
+        test_state = Particle(
+            "MyParticle",
+            123,
+            complex(1.2, 0.1),
+            spin=1,
+            charge=0,
+            isospin=Spin(1, 0),
         )
         test_state.charge = 1  # type: ignore
-
-    with pytest.raises(FrozenInstanceError):
-        test_state2 = ComplexEnergyState(
-            complex(1.2, 0.1),
-            state=QuantumState(spin=Spin(1, 1), charge=0, isospin=Spin(1, 0)),
-        )
-        test_state2.state.charge = 1  # type: ignore
 
 
 def test_complex_energy_equality():
     with pytest.raises(AssertionError):
-        assert ComplexEnergy(complex(1.5, 0.1)) == ComplexEnergy(
-            complex(1.5, 0.2)
-        )
+        assert Particle(
+            "MyParticle", pid=123, energy=complex(1.5, 0.1), spin=1,
+        ) == Particle("MyParticle", pid=123, energy=complex(1.5, 0.2), spin=1)
 
-    assert ComplexEnergy(complex(1.5, 0.2)) == ComplexEnergy(complex(1.5, 0.2))
-    assert ComplexEnergyState(
+    assert Particle(
+        "MyParticle",
+        123,
         complex(1.2, 0.1),
-        state=QuantumState(spin=Spin(1, 1), charge=0, isospin=Spin(1, 0)),
-    ) == ComplexEnergyState(
+        spin=1,
+        charge=0,
+        isospin=Spin(1, 0),
+    ) == Particle(
+        "MyParticle",
+        123,
         complex(1.2, 0.1),
-        state=QuantumState(spin=Spin(1, 1), charge=0, isospin=Spin(1, 0)),
+        spin=1,
+        charge=0,
+        isospin=Spin(1, 0),
     )
 
 
 @pytest.mark.parametrize(
-    "magnitude, projection", [(0.3, 0.3), (1.0, 0.5), (0.5, 0.0)]
+    "magnitude, projection", [(0.3, 0.3), (1.0, 0.5), (0.5, 0.0), (-0.5, 0.5)],
 )
 def test_spin_exceptions(magnitude, projection):
     with pytest.raises(ValueError):

--- a/tests/unit/io/test_pdg.py
+++ b/tests/unit/io/test_pdg.py
@@ -53,8 +53,4 @@ def test_pdg_entries(pdg, particle_database):
             continue
         internal_particle = particle_database[name]
         pdg_particle = pdg[name]
-        assert pdg_particle.name == internal_particle.name
-        assert pdg_particle.pid == internal_particle.pid
-        assert pdg_particle.state == internal_particle.state
-        assert pdg_particle.mass == pytest.approx(internal_particle.mass)
-        assert pdg_particle.width == pytest.approx(internal_particle.width)
+        assert pdg_particle == internal_particle

--- a/tests/unit/io/test_pdg.py
+++ b/tests/unit/io/test_pdg.py
@@ -45,12 +45,3 @@ def test_missing_in_pdg(pdg, particle_database):
     assert missing_in_pdg == {
         "Y(4260)",
     }
-
-
-def test_pdg_entries(pdg, particle_database):
-    for name in particle_database:
-        if name not in pdg:
-            continue
-        internal_particle = particle_database[name]
-        pdg_particle = pdg[name]
-        assert pdg_particle == internal_particle

--- a/tests/unit/io/test_xml_adapters.py
+++ b/tests/unit/io/test_xml_adapters.py
@@ -2,21 +2,23 @@
 
 from expertsystem import io
 from expertsystem.data import (
-    ComplexEnergyState,
-    QuantumState,
+    Particle,
     Spin,
 )
 
 
-def test_complex_energy_state():
-    state = ComplexEnergyState(
+def test_particle():
+    state = Particle(
+        "MyParticle",
+        pid=123,
         energy=complex(2.5, 0.3),
-        state=QuantumState[Spin](spin=Spin(1.5, -0.5), charge=-1),
+        spin=1.5,
+        isospin=Spin(1.0, -1.0),
+        charge=-1,
     )
     converted_dict = io.xml.object_to_dict(state)
     quantum_numbers = converted_dict["QuantumNumber"]
     spin_dict = quantum_numbers[0]
     charge_dict = quantum_numbers[1]
     assert spin_dict["Value"] == 1.5
-    assert spin_dict["Projection"] == -0.5
     assert charge_dict["Value"] == -1

--- a/tests/unit/io/test_xml_adapters.py
+++ b/tests/unit/io/test_xml_adapters.py
@@ -11,7 +11,8 @@ def test_particle():
     state = Particle(
         "MyParticle",
         pid=123,
-        energy=complex(2.5, 0.3),
+        mass=2.5,
+        width=0.3,
         spin=1.5,
         isospin=Spin(1.0, -1.0),
         charge=-1,


### PR DESCRIPTION
This PR 
- removes the `QuantumState` and `ComplexEnergyState` classes which will not be used in this form internally
- merges  the `ComplexEnergy` functionality with `Particle` and flattens the quantum number structure in `Particle`

This influences issue #231 and should be easier to tackle