### PR TITLE
refactor: extract Topology class

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -14,6 +14,7 @@ disable=
     RST203, # unexpected indentation
     RST301, # related to google style docstring
     logging-fstring-interpolation,
+    not-callable,
 
 [MASTER]
 ignore=conf.py

--- a/expertsystem/state/particle.py
+++ b/expertsystem/state/particle.py
@@ -29,7 +29,7 @@ from expertsystem.data import (
     ParticleCollection,
     Spin,
 )
-from expertsystem.topology import StateTransitionGraph
+from expertsystem.topology import StateTransitionGraph, Topology
 
 
 StateWithSpins = Tuple[str, Sequence[float]]
@@ -460,7 +460,7 @@ class CompareGraphElementPropertiesFunctor:
 
 
 def initialize_graph(  # pylint: disable=too-many-locals
-    empty_topology: StateTransitionGraph,
+    topology: Topology,
     particles: ParticleCollection,
     initial_state: Sequence[StateDefinition],
     final_state: Sequence[StateDefinition],
@@ -475,8 +475,8 @@ def initialize_graph(  # pylint: disable=too-many-locals
                 f"(len({state_definitions}) != len({edge_ids})"
             )
 
-    is_edges = empty_topology.get_initial_state_edges()
-    fs_edges = empty_topology.get_final_state_edges()
+    is_edges = topology.get_initial_state_edges()
+    fs_edges = topology.get_final_state_edges()
     assert_number_of_states(initial_state, is_edges)
     assert_number_of_states(final_state, fs_edges)
 
@@ -488,16 +488,14 @@ def initialize_graph(  # pylint: disable=too-many-locals
     )
 
     attached_is_edges = [
-        empty_topology.get_originating_initial_state_edges(i)
-        for i in empty_topology.nodes
+        topology.get_originating_initial_state_edges(i) for i in topology.nodes
     ]
     is_edge_particle_pairs = __calculate_combinatorics(
         is_edges, initial_state_with_projections, attached_is_edges
     )
 
     attached_fs_edges = [
-        empty_topology.get_originating_final_state_edges(i)
-        for i in empty_topology.nodes
+        topology.get_originating_final_state_edges(i) for i in topology.nodes
     ]
     fs_edge_particle_pairs = __calculate_combinatorics(
         fs_edges,
@@ -512,7 +510,7 @@ def initialize_graph(  # pylint: disable=too-many-locals
             merged_dicts = initial_state_pair.copy()
             merged_dicts.update(fs_pair)
             new_graphs.extend(
-                __initialize_edges(empty_topology, merged_dicts, particles)
+                __initialize_edges(topology, merged_dicts, particles)
             )
 
     return new_graphs
@@ -621,10 +619,11 @@ def __initialize_external_edge_lists(
 
 
 def __initialize_edges(
-    graph: StateTransitionGraph,
+    topology: Topology,
     edge_particle_dict: Dict[int, StateWithSpins],
     particle_db: ParticleCollection,
 ) -> List[StateTransitionGraph]:
+    graph = StateTransitionGraph.from_topology(topology)
     for edge_id, state_particle in edge_particle_dict.items():
         particle_name = state_particle[0]
         particle = particle_db[particle_name]

--- a/expertsystem/state/particle.py
+++ b/expertsystem/state/particle.py
@@ -480,10 +480,10 @@ def initialize_graph(  # pylint: disable=too-many-locals
     assert_number_of_states(initial_state, is_edges)
     assert_number_of_states(final_state, fs_edges)
 
-    initial_state_with_projections = _safe_set_spin_projections(
+    initial_state_with_projections = __safe_set_spin_projections(
         initial_state, particles
     )
-    final_state_with_projections = _safe_set_spin_projections(
+    final_state_with_projections = __safe_set_spin_projections(
         final_state, particles
     )
 
@@ -516,7 +516,7 @@ def initialize_graph(  # pylint: disable=too-many-locals
     return new_graphs
 
 
-def _safe_set_spin_projections(
+def __safe_set_spin_projections(
     list_of_states: Sequence[StateDefinition], particle_db: ParticleCollection,
 ) -> Sequence[StateWithSpins]:
     def safe_set_spin_projections(

--- a/expertsystem/state/particle.py
+++ b/expertsystem/state/particle.py
@@ -465,7 +465,7 @@ def initialize_graph(  # pylint: disable=too-many-locals
     initial_state: Sequence[StateDefinition],
     final_state: Sequence[StateDefinition],
     final_state_groupings: Optional[List[List[List[str]]]] = None,
-) -> List[StateTransitionGraph]:
+) -> List[StateTransitionGraph[dict]]:
     def assert_number_of_states(
         state_definitions: Sequence, edge_ids: Sequence[int]
     ) -> None:
@@ -504,7 +504,7 @@ def initialize_graph(  # pylint: disable=too-many-locals
         final_state_groupings,
     )
 
-    new_graphs: List[StateTransitionGraph] = list()
+    new_graphs: List[StateTransitionGraph[dict]] = list()
     for initial_state_pair in is_edge_particle_pairs:
         for fs_pair in fs_edge_particle_pairs:
             merged_dicts = initial_state_pair.copy()
@@ -622,8 +622,10 @@ def __initialize_edges(
     topology: Topology,
     edge_particle_dict: Dict[int, StateWithSpins],
     particle_db: ParticleCollection,
-) -> List[StateTransitionGraph]:
-    graph = StateTransitionGraph.from_topology(topology)
+) -> List[StateTransitionGraph[dict]]:
+    graph: StateTransitionGraph[dict] = StateTransitionGraph.from_topology(
+        topology
+    )
     for edge_id, state_particle in edge_particle_dict.items():
         particle_name = state_particle[0]
         particle = particle_db[particle_name]
@@ -631,7 +633,7 @@ def __initialize_edges(
         graph.edge_props[edge_id] = particle_properties
 
     # now add more quantum numbers given by user (spin_projection)
-    new_graphs: List[StateTransitionGraph] = [graph]
+    new_graphs: List[StateTransitionGraph[dict]] = [graph]
     for edge_id, state_particle in edge_particle_dict.items():
         if isinstance(state_particle, str):
             continue
@@ -649,10 +651,10 @@ def __initialize_edges(
 
 
 def __populate_edge_with_spin_projections(
-    graph: StateTransitionGraph,
+    graph: StateTransitionGraph[dict],
     edge_id: int,
     spin_projections: Sequence[float],
-) -> List[StateTransitionGraph]:
+) -> List[StateTransitionGraph[dict]]:
     qns_label = Labels.QuantumNumber.name
     type_label = Labels.Type.name
     class_label = Labels.Class.name
@@ -683,9 +685,9 @@ def __populate_edge_with_spin_projections(
 
 
 def initialize_graphs_with_particles(
-    graphs: List[StateTransitionGraph],
+    graphs: List[StateTransitionGraph[dict]],
     allowed_particle_list: List[Dict[str, Any]],
-) -> List[StateTransitionGraph]:
+) -> List[StateTransitionGraph[dict]]:
     initialized_graphs = []
 
     for graph in graphs:

--- a/expertsystem/state/particle.py
+++ b/expertsystem/state/particle.py
@@ -466,20 +466,19 @@ def initialize_graph(  # pylint: disable=too-many-locals
     final_state: Sequence[StateDefinition],
     final_state_groupings: Optional[List[List[List[str]]]] = None,
 ) -> List[StateTransitionGraph]:
+    def assert_number_of_states(
+        state_definitions: Sequence, edge_ids: Sequence[int]
+    ) -> None:
+        if len(state_definitions) != len(edge_ids):
+            raise ValueError(
+                "Number of state definitions is not same as number of edge IDs:"
+                f"(len({state_definitions}) != len({edge_ids})"
+            )
+
     is_edges = empty_topology.get_initial_state_edges()
-    if len(initial_state) != len(is_edges):
-        raise ValueError(
-            "The graph initial state and the supplied initial"
-            "state are of different size! "
-            f"({len(is_edges)} !=  {len(initial_state)})"
-        )
     fs_edges = empty_topology.get_final_state_edges()
-    if len(final_state) != len(fs_edges):
-        raise ValueError(
-            "The graph initial state and the supplied initial"
-            "state are of different size! "
-            f"({len(fs_edges)} !=  {len(final_state)})"
-        )
+    assert_number_of_states(initial_state, is_edges)
+    assert_number_of_states(final_state, fs_edges)
 
     initial_state_with_projections = __safe_set_spin_projections(
         initial_state, particles

--- a/expertsystem/state/particle.py
+++ b/expertsystem/state/particle.py
@@ -480,10 +480,10 @@ def initialize_graph(  # pylint: disable=too-many-locals
     assert_number_of_states(initial_state, is_edges)
     assert_number_of_states(final_state, fs_edges)
 
-    initial_state_with_projections = __safe_set_spin_projections(
+    initial_state_with_projections = _safe_set_spin_projections(
         initial_state, particles
     )
-    final_state_with_projections = __safe_set_spin_projections(
+    final_state_with_projections = _safe_set_spin_projections(
         final_state, particles
     )
 
@@ -518,7 +518,7 @@ def initialize_graph(  # pylint: disable=too-many-locals
     return new_graphs
 
 
-def __safe_set_spin_projections(
+def _safe_set_spin_projections(
     list_of_states: Sequence[StateDefinition], particle_db: ParticleCollection,
 ) -> Sequence[StateWithSpins]:
     def safe_set_spin_projections(

--- a/expertsystem/topology.py
+++ b/expertsystem/topology.py
@@ -53,21 +53,25 @@ class Topology:
         edges: Optional[Dict[int, Edge]] = None,
     ) -> None:
         self.__nodes: Set[int] = set()
-        self.edges: Dict[int, Edge] = {}
+        self.__edges: Dict[int, Edge] = dict()
         if nodes is not None:
             self.__nodes = set(nodes)
         if edges is not None:
-            self.edges = edges
+            self.__edges = edges
 
     @property
     def nodes(self) -> Set[int]:
         return self.__nodes
 
+    @property
+    def edges(self) -> Dict[int, Edge]:
+        return self.__edges
+
     def __repr__(self) -> str:
         return (
             f"{self.__class__.__name__}()"
             f"\n    nodes: {self.nodes}"
-            f"\n    edges: {self.edges}"
+            f"\n    edges: {self.__edges}"
         )
 
     def __eq__(self, other: object) -> bool:
@@ -88,9 +92,9 @@ class Topology:
     def add_edges(self, edge_ids: List[int]) -> None:
         """Add edges with the ids in the edge_ids list."""
         for edge_id in edge_ids:
-            if edge_id in self.edges:
+            if edge_id in self.__edges:
                 raise ValueError(f"Edge with id {edge_id} already exists!")
-            self.edges[edge_id] = Edge()
+            self.__edges[edge_id] = Edge()
 
     def attach_edges_to_node_ingoing(
         self, ingoing_edge_ids: Iterable[int], node_id: int
@@ -109,34 +113,34 @@ class Topology:
         """
         # first check if the ingoing edges are all available
         for edge_id in ingoing_edge_ids:
-            if edge_id not in self.edges:
+            if edge_id not in self.__edges:
                 raise ValueError(f"Edge with id {edge_id} does not exist!")
-            if self.edges[edge_id].ending_node_id is not None:
+            if self.__edges[edge_id].ending_node_id is not None:
                 raise ValueError(
                     f"Edge with id {edge_id} is already ingoing to"
-                    f" node {self.edges[edge_id].ending_node_id}"
+                    f" node {self.__edges[edge_id].ending_node_id}"
                 )
 
         # update the newly connected edges
         for edge_id in ingoing_edge_ids:
-            self.edges[edge_id].ending_node_id = node_id
+            self.__edges[edge_id].ending_node_id = node_id
 
     def attach_edges_to_node_outgoing(
         self, outgoing_edge_ids: Iterable[int], node_id: int
     ) -> None:
         # first check if the ingoing edges are all available
         for edge_id in outgoing_edge_ids:
-            if edge_id not in self.edges:
+            if edge_id not in self.__edges:
                 raise ValueError(f"Edge with id {edge_id} does not exist!")
-            if self.edges[edge_id].originating_node_id is not None:
+            if self.__edges[edge_id].originating_node_id is not None:
                 raise ValueError(
                     f"Edge with id {edge_id} is already outgoing from"
-                    f" node {self.edges[edge_id].originating_node_id}"
+                    f" node {self.__edges[edge_id].originating_node_id}"
                 )
 
         # update the edges
         for edge_id in outgoing_edge_ids:
-            self.edges[edge_id].originating_node_id = node_id
+            self.__edges[edge_id].originating_node_id = node_id
 
     def get_originating_node_list(
         self, edge_ids: Iterable[int]
@@ -260,10 +264,10 @@ class Topology:
         return edge_list
 
     def swap_edges(self, edge_id1: int, edge_id2: int) -> None:
-        popped_edge_id1 = self.edges.pop(edge_id1)
-        popped_edge_id2 = self.edges.pop(edge_id2)
-        self.edges[edge_id2] = popped_edge_id1
-        self.edges[edge_id1] = popped_edge_id2
+        popped_edge_id1 = self.__edges.pop(edge_id1)
+        popped_edge_id2 = self.__edges.pop(edge_id2)
+        self.__edges[edge_id2] = popped_edge_id1
+        self.__edges[edge_id1] = popped_edge_id2
 
 
 class StateTransitionGraph(Topology):

--- a/expertsystem/topology.py
+++ b/expertsystem/topology.py
@@ -34,9 +34,11 @@ class Edge:
 
 
 class Topology:
-    """Directed graph for a state transition.
+    """Directed Feynman-like graph for a state transition.
 
-    Forms the underlying topology of `StateTransitionGraph`.
+    Forms the underlying topology of `StateTransitionGraph`. Note that a
+    `Topology` is not strictly speaking a graph from graph theory, because it
+    allows open edges, like a Feynman-diagram.
     """
 
     def __init__(

--- a/expertsystem/topology.py
+++ b/expertsystem/topology.py
@@ -14,12 +14,14 @@ from dataclasses import dataclass
 from typing import (
     Callable,
     Dict,
+    Generic,
     Iterable,
     List,
     Optional,
     Sequence,
     Set,
     Tuple,
+    TypeVar,
 )
 
 
@@ -260,7 +262,10 @@ class Topology:
         self.__edges[edge_id1] = popped_edge_id2
 
 
-class StateTransitionGraph(Topology):
+EdgeType = TypeVar("EdgeType")
+
+
+class StateTransitionGraph(Topology, Generic[EdgeType]):
     """Graph class that contains edges and nodes.
 
     Similar to feynman graphs. The graphs are directed, meaning the edges are
@@ -277,7 +282,7 @@ class StateTransitionGraph(Topology):
     ) -> None:
         super().__init__(nodes, edges)
         self.node_props: Dict[int, dict] = {}
-        self.edge_props: Dict[int, dict] = {}
+        self.edge_props: Dict[int, EdgeType] = {}
         self.graph_element_properties_comparator: Optional[Callable] = None
 
     def __repr__(self) -> str:
@@ -315,8 +320,8 @@ class StateTransitionGraph(Topology):
 
     def swap_edges(self, edge_id1: int, edge_id2: int) -> None:
         super().swap_edges(edge_id1, edge_id2)
-        value1: Optional[dict] = None
-        value2: Optional[dict] = None
+        value1: Optional[EdgeType] = None
+        value2: Optional[EdgeType] = None
         if edge_id1 in self.edge_props:
             value1 = self.edge_props.pop(edge_id1)
         if edge_id2 in self.edge_props:

--- a/expertsystem/topology.py
+++ b/expertsystem/topology.py
@@ -264,10 +264,10 @@ class Topology:
         self.__edges[edge_id1] = popped_edge_id2
 
 
-EdgeType = TypeVar("EdgeType")
+_EdgeType = TypeVar("_EdgeType")
 
 
-class StateTransitionGraph(Topology, Generic[EdgeType]):
+class StateTransitionGraph(Topology, Generic[_EdgeType]):
     """Graph class that contains edges and nodes.
 
     Similar to feynman graphs. The graphs are directed, meaning the edges are
@@ -284,7 +284,7 @@ class StateTransitionGraph(Topology, Generic[EdgeType]):
     ) -> None:
         super().__init__(nodes, edges)
         self.node_props: Dict[int, dict] = {}
-        self.edge_props: Dict[int, EdgeType] = {}
+        self.edge_props: Dict[int, _EdgeType] = {}
         self.graph_element_properties_comparator: Optional[Callable] = None
 
     def __repr__(self) -> str:
@@ -322,8 +322,8 @@ class StateTransitionGraph(Topology, Generic[EdgeType]):
 
     def swap_edges(self, edge_id1: int, edge_id2: int) -> None:
         super().swap_edges(edge_id1, edge_id2)
-        value1: Optional[EdgeType] = None
-        value2: Optional[EdgeType] = None
+        value1: Optional[_EdgeType] = None
+        value2: Optional[_EdgeType] = None
         if edge_id1 in self.edge_props:
             value1 = self.edge_props.pop(edge_id1)
         if edge_id2 in self.edge_props:

--- a/expertsystem/topology.py
+++ b/expertsystem/topology.py
@@ -52,11 +52,15 @@ class StateTransitionGraph:
     """
 
     def __init__(self) -> None:
-        self.nodes: Set[int] = set()
+        self.__nodes: Set[int] = set()
         self.edges: Dict[int, Edge] = {}
         self.node_props: Dict[int, dict] = {}
         self.edge_props: Dict[int, dict] = {}
         self.graph_element_properties_comparator: Optional[Callable] = None
+
+    @property
+    def nodes(self) -> Set[int]:
+        return self.__nodes
 
     def set_graph_element_properties_comparator(
         self, comparator: Optional[Callable]
@@ -74,7 +78,7 @@ class StateTransitionGraph:
 
     def __eq__(self, other: object) -> bool:
         if isinstance(other, StateTransitionGraph):
-            if set(self.nodes) != set(other.nodes):
+            if set(self.__nodes) != set(other.nodes):
                 return False
             if _dicts_unequal(self.edges, other.edges):
                 return False
@@ -97,9 +101,9 @@ class StateTransitionGraph:
         Raises:
             ValueError: if node_id already exists
         """
-        if node_id in self.nodes:
+        if node_id in self.__nodes:
             raise ValueError(f"Node with id {node_id} already exists!")
-        self.nodes.add(node_id)
+        self.__nodes.add(node_id)
 
     def add_edges(self, edge_ids: List[int]) -> None:
         """Add edges with the ids in the edge_ids list."""

--- a/expertsystem/topology.py
+++ b/expertsystem/topology.py
@@ -17,6 +17,7 @@ from typing import (
     List,
     Optional,
     Sequence,
+    Set,
     Tuple,
 )
 
@@ -51,7 +52,7 @@ class StateTransitionGraph:
     """
 
     def __init__(self) -> None:
-        self.nodes: List[int] = []
+        self.nodes: Set[int] = set()
         self.edges: Dict[int, Edge] = {}
         self.node_props: Dict[int, dict] = {}
         self.edge_props: Dict[int, dict] = {}
@@ -98,7 +99,7 @@ class StateTransitionGraph:
         """
         if node_id in self.nodes:
             raise ValueError(f"Node with id {node_id} already exists!")
-        self.nodes.append(node_id)
+        self.nodes.add(node_id)
 
     def add_edges(self, edge_ids: List[int]) -> None:
         """Add edges with the ids in the edge_ids list."""

--- a/expertsystem/topology.py
+++ b/expertsystem/topology.py
@@ -62,11 +62,6 @@ class StateTransitionGraph:
     def nodes(self) -> Set[int]:
         return self.__nodes
 
-    def set_graph_element_properties_comparator(
-        self, comparator: Optional[Callable]
-    ) -> None:
-        self.graph_element_properties_comparator = comparator
-
     def __repr__(self) -> str:
         return (
             f"{self.__class__.__name__}()"

--- a/expertsystem/topology.py
+++ b/expertsystem/topology.py
@@ -10,6 +10,7 @@ import copy
 import itertools
 import logging
 from collections import OrderedDict
+from dataclasses import dataclass
 from typing import (
     Callable,
     Dict,
@@ -22,23 +23,12 @@ from typing import (
 )
 
 
+@dataclass
 class Edge:
-    """Struct-like definition of an edge."""
+    """Struct-like definition of an edge, used in `Topology`."""
 
-    def __init__(self) -> None:
-        self.ending_node_id: Optional[int] = None
-        self.originating_node_id: Optional[int] = None
-
-    def __repr__(self) -> str:
-        return f"<class 'Edge': {self.ending_node_id} -> {self.originating_node_id}>"
-
-    def __eq__(self, other: object) -> bool:
-        if isinstance(other, Edge):
-            return (
-                self.ending_node_id == other.ending_node_id
-                and self.originating_node_id == other.originating_node_id
-            )
-        raise NotImplementedError
+    ending_node_id: Optional[int] = None
+    originating_node_id: Optional[int] = None
 
 
 class Topology:

--- a/expertsystem/ui/__init__.py
+++ b/expertsystem/ui/__init__.py
@@ -205,7 +205,7 @@ class StateTransitionManager:  # pylint: disable=too-many-instance-attributes
         # initialize the graph edges (initial and final state)
         init_graphs: List[StateTransitionGraph] = []
         for topology_graph in topology_graphs:
-            topology_graph.set_graph_element_properties_comparator(
+            topology_graph.graph_element_properties_comparator = (
                 CompareGraphElementPropertiesFunctor()
             )
             initialized_graphs = initialize_graph(

--- a/expertsystem/ui/__init__.py
+++ b/expertsystem/ui/__init__.py
@@ -202,9 +202,9 @@ class StateTransitionManager:  # pylint: disable=too-many-instance-attributes
 
     def _create_seed_graphs(
         self, topology_graphs: List[Topology]
-    ) -> List[StateTransitionGraph]:
+    ) -> List[StateTransitionGraph[dict]]:
         # initialize the graph edges (initial and final state)
-        init_graphs: List[StateTransitionGraph] = []
+        init_graphs: List[StateTransitionGraph[dict]] = []
         for topology_graph in topology_graphs:
             initialized_graphs = initialize_graph(
                 topology=topology_graph,

--- a/expertsystem/ui/__init__.py
+++ b/expertsystem/ui/__init__.py
@@ -37,6 +37,7 @@ from expertsystem.state.propagation import (
 from expertsystem.topology import (
     InteractionNode,
     StateTransitionGraph,
+    Topology,
 )
 from expertsystem.topology import SimpleStateTransitionTopologyBuilder
 
@@ -182,7 +183,7 @@ class StateTransitionManager:  # pylint: disable=too-many-instance-attributes
                 )
         self.allowed_interaction_types = allowed_interaction_types
 
-    def prepare_graphs(self,) -> GraphSettingsGroups:
+    def prepare_graphs(self) -> GraphSettingsGroups:
         topology_graphs = self._build_topologies()
         init_graphs = self._create_seed_graphs(topology_graphs)
         graph_node_setting_pairs = self._determine_node_settings(init_graphs)
@@ -192,7 +193,7 @@ class StateTransitionManager:  # pylint: disable=too-many-instance-attributes
         )
         return graph_settings_groups
 
-    def _build_topologies(self) -> List[StateTransitionGraph]:
+    def _build_topologies(self) -> List[Topology]:
         all_graphs = self.topology_builder.build_graphs(
             len(self.initial_state), len(self.final_state)
         )
@@ -200,22 +201,23 @@ class StateTransitionManager:  # pylint: disable=too-many-instance-attributes
         return all_graphs
 
     def _create_seed_graphs(
-        self, topology_graphs: List[StateTransitionGraph]
+        self, topology_graphs: List[Topology]
     ) -> List[StateTransitionGraph]:
         # initialize the graph edges (initial and final state)
         init_graphs: List[StateTransitionGraph] = []
         for topology_graph in topology_graphs:
-            topology_graph.graph_element_properties_comparator = (
-                CompareGraphElementPropertiesFunctor()
-            )
             initialized_graphs = initialize_graph(
-                empty_topology=topology_graph,
+                topology=topology_graph,
                 particles=self.__particles,
                 initial_state=self.initial_state,
                 final_state=self.final_state,
                 final_state_groupings=self.final_state_groupings,
             )
             init_graphs.extend(initialized_graphs)
+        for graph in init_graphs:
+            graph.graph_element_properties_comparator = (
+                CompareGraphElementPropertiesFunctor()
+            )
 
         logging.info(f"initialized {len(init_graphs)} graphs!")
         return init_graphs

--- a/expertsystem/ui/_system_control.py
+++ b/expertsystem/ui/_system_control.py
@@ -277,15 +277,15 @@ def _check_equal_ignoring_qns(
         )
     found_graph = None
     old_comparator = ref_graph.graph_element_properties_comparator
-    ref_graph.set_graph_element_properties_comparator(
-        CompareGraphElementPropertiesFunctor(ignored_qn_list)
+    ref_graph.graph_element_properties_comparator = CompareGraphElementPropertiesFunctor(
+        ignored_qn_list
     )
     for graph in solutions:
         if isinstance(graph, StateTransitionGraph):
             if ref_graph == graph:
                 found_graph = graph
                 break
-    ref_graph.set_graph_element_properties_comparator(old_comparator)
+    ref_graph.graph_element_properties_comparator = old_comparator
     return found_graph
 
 

--- a/tests/unit/topology/test_graph.py
+++ b/tests/unit/topology/test_graph.py
@@ -7,7 +7,7 @@ from expertsystem import ui
 from expertsystem.state.particle import initialize_graph
 from expertsystem.topology import (
     InteractionNode,
-    StateTransitionGraph,
+    Topology,
 )
 
 
@@ -41,8 +41,18 @@ class TestInteractionNode:
             )
 
 
-def create_dummy_topology() -> StateTransitionGraph:
-    topology = StateTransitionGraph()
+def create_dummy_topology() -> Topology:
+    r"""Create a dummy `Topology`.
+
+    Has the following shape:
+
+    .. code-block::
+
+        e0 -- (N0) -- e1 -- (N1) -- e3
+                \             \
+                 e2            e4
+    """
+    topology = Topology()
     topology.add_node(0)
     topology.add_node(1)
     topology.add_edges([0, 1, 2, 3, 4])

--- a/tests/unit/ui/test_system_control.py
+++ b/tests/unit/ui/test_system_control.py
@@ -111,7 +111,7 @@ def test_external_edge_initialization(
 
 def make_ls_test_graph(angular_momentum_magnitude, coupled_spin_magnitude):
     graph = StateTransitionGraph()
-    graph.set_graph_element_properties_comparator(
+    graph.graph_element_properties_comparator = (
         CompareGraphElementPropertiesFunctor()
     )
     graph.add_node(0)
@@ -138,7 +138,7 @@ def make_ls_test_graph_scrambled(
     angular_momentum_magnitude, coupled_spin_magnitude
 ):
     graph = StateTransitionGraph()
-    graph.set_graph_element_properties_comparator(
+    graph.graph_element_properties_comparator = (
         CompareGraphElementPropertiesFunctor()
     )
     graph.add_node(0)

--- a/tests/unit/ui/test_system_control.py
+++ b/tests/unit/ui/test_system_control.py
@@ -110,7 +110,7 @@ def test_external_edge_initialization(
 
 
 def make_ls_test_graph(angular_momentum_magnitude, coupled_spin_magnitude):
-    graph = StateTransitionGraph()
+    graph = StateTransitionGraph[dict]()
     graph.graph_element_properties_comparator = (
         CompareGraphElementPropertiesFunctor()
     )
@@ -137,7 +137,7 @@ def make_ls_test_graph(angular_momentum_magnitude, coupled_spin_magnitude):
 def make_ls_test_graph_scrambled(
     angular_momentum_magnitude, coupled_spin_magnitude
 ):
-    graph = StateTransitionGraph()
+    graph = StateTransitionGraph[dict]()
     graph.graph_element_properties_comparator = (
         CompareGraphElementPropertiesFunctor()
     )

--- a/tests/unit/ui/test_system_control.py
+++ b/tests/unit/ui/test_system_control.py
@@ -114,7 +114,7 @@ def make_ls_test_graph(angular_momentum_magnitude, coupled_spin_magnitude):
     graph.set_graph_element_properties_comparator(
         CompareGraphElementPropertiesFunctor()
     )
-    graph.nodes.append(0)
+    graph.add_node(0)
     graph.node_props[0] = {
         "QuantumNumber": [
             {
@@ -141,7 +141,7 @@ def make_ls_test_graph_scrambled(
     graph.set_graph_element_properties_comparator(
         CompareGraphElementPropertiesFunctor()
     )
-    graph.nodes.append(0)
+    graph.add_node(0)
     graph.node_props[0] = {
         "QuantumNumber": [
             {

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ whitelist_externals =
     pytest
 commands =
     pytest {posargs:tests/unit} \
-        --cov-fail-under=69 \
+        --cov-fail-under=70 \
         --cov-report=html \
         --cov-report=xml \
         --cov=expertsystem


### PR DESCRIPTION
Improvements to the `topology` module in order to distinguish the different initialize stages of `StateTransitionGraph`s:

* Extracted `Topology` base class (no node/edge properties) from `StateTransitionGraph`
* Nodes have become a `set`
* Protected nodes and edges of `Topology`
* Type-templated edge properties of `StateTransitionGraph`
* `Edge` has become a `dataclass`

_Rebased on #247_