### PR TITLE
ci: implement doc8 check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,6 +29,12 @@ repos:
     hooks:
       - id: black
 
+  - repo: https://github.com/PyCQA/doc8
+    rev: 0.8.1
+    hooks:
+      - id: doc8
+        args: ["-q"]
+
   - repo: https://github.com/kynan/nbstripout
     rev: 0.3.8
     hooks:

--- a/doc/contribute.rst
+++ b/doc/contribute.rst
@@ -1,4 +1,5 @@
-.. cSpell:ignore aquirdturtle, docnb, htmlcov, ijmbarr, labextension, pylintrc, ryantam, serverextension, testenv
+.. cSpell:ignore aquirdturtle docnb htmlcov ijmbarr labextension pylintrc
+.. cSpell:ignore ryantam serverextension testenv
 
 How to contribute?
 ==================

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -47,10 +47,10 @@ Welcome to the PWA Expert System!
 
 The two purposes of the Partial Wave Analysis Expert System are to:
 
-1. validate a particle reaction, based on given information. E.g.: Can a :math:`\pi^0`
-   decay into 1, 2, 3 :math:`\gamma` particles?
+1. validate a particle reaction, based on given information. E.g.: Can a
+   :math:`\pi^0` decay into 1, 2, 3 :math:`\gamma` particles?
 2. create partial wave analysis amplitude models, based on basic information of
-   a reaction, for instance, an amplitude model for :math:`J/\psi →
+   a reaction, for instance, an amplitude model for :math:`J/\psi \rightarrow
    \gamma\pi^0\pi^0` in the helicity or canonical formalism.
 
 The user only has to provide a basic information of the particle reaction, such
@@ -84,7 +84,7 @@ transition from one state to another.
   transition of this specific step. Most importantly, a node contains a
   collection of conservation rules that have to be satisfied. An interaction
   node has :math:`M` ingoing lines and :math:`N` outgoing lines, where
-  :math:`M,N \in \mathbb{Z}`, :math:`M > 0, 𝑁 > 0`.
+  :math:`M,N \in \mathbb{Z}`, :math:`M > 0, N > 0`.
 
 2. Conservation Rules
 ~~~~~~~~~~~~~~~~~~~~~

--- a/setup.cfg
+++ b/setup.cfg
@@ -96,6 +96,13 @@ dev =
     rstcheck==3.3.1
     tox==3.20.0
 
+[doc8]
+extension=.inc
+file-encoding=UTF-8
+ignore-path=*build
+max-line-length=79
+quiet=1
+
 [mypy]
 disallow_incomplete_defs = True
 disallow_untyped_defs = True


### PR DESCRIPTION
This correctly enforces a line width of 79 in `.rst` files.