### PR TITLE
ci: ignore draft pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,8 +82,6 @@ jobs:
         run: make html
       - name: Test doctests in docstrings
         working-directory: doc
-        env:
-          NBSPHINX_EXECUTE: YES
         run: make doctest
 
   style:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
+    types: [review_requested, ready_for_review]
 
 jobs:
   codecov:

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -5,6 +5,7 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
+    types: [review_requested, ready_for_review]
 
 jobs:
   style:


### PR DESCRIPTION
Only run GitHub Actions if PR is ready for review (not draft status).