### PR TITLE
fix: make expertsystem PEP-561 compatible

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -50,6 +50,7 @@ exclude =
 [options.package_data]
 expertsystem =
     additional_particle_definitions.yml
+    py.typed
     schemas/xml/particle.json
     schemas/xml/particle-list.json
     schemas/yaml/amplitude-model.json

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,8 +51,8 @@ exclude =
 expertsystem =
     additional_particle_definitions.yml
     py.typed
-    schemas/xml/particle.json
     schemas/xml/particle-list.json
+    schemas/xml/particle.json
     schemas/yaml/amplitude-model.json
     schemas/yaml/particle-list.json
 


### PR DESCRIPTION
Even though #43 has been closed, the `expertsystem` as a package is not yet [PEP-561](https://www.python.org/dev/peps/pep-0561/) compatible due to [this](https://mypy.readthedocs.io/en/latest/installed_packages.html#making-pep-561-compatible-packages).