### PR TITLE
feat: implement Particle.__neg__ operator

### DIFF
--- a/doc/interactive.rst
+++ b/doc/interactive.rst
@@ -27,11 +27,12 @@ set of quantum numbers.
 .. code-block:: python
   :class: thebe, thebe-init
 
-  results = pdg.filter(lambda p:
+  subset = pdg.filter(
+    lambda p:
     p.spin in [2.5, 3.5, 4.5]
     and p.name.startswith("N")
   )
-  sorted(list(results))
+  {p.name for p in subset}
 
 .. thebe-button::
 

--- a/expertsystem/data.py
+++ b/expertsystem/data.py
@@ -262,6 +262,9 @@ class Particle:  # pylint: disable=too-many-instance-attributes
                 ")"
             )
 
+    def __neg__(self) -> "Particle":
+        return create_antiparticle(self)
+
     def __repr__(self) -> str:
         output_string = f"{self.__class__.__name__}("
         for member in fields(self):

--- a/tests/unit/test_data.py
+++ b/tests/unit/test_data.py
@@ -422,6 +422,22 @@ def test_create_antiparticle_tilde(particle_database: ParticleCollection):
         assert created_particle == particle_database[particle_name]
 
 
+def test_create_antiparticle_by_pid(particle_database: ParticleCollection):
+    n_particles_with_neg_pid = 0
+    for particle in particle_database:
+        anti_particles_by_pid = particle_database.filter(
+            lambda p: p.pid
+            == -particle.pid  # pylint: disable=cell-var-from-loop
+        )
+        if len(anti_particles_by_pid) != 1:
+            continue
+        n_particles_with_neg_pid += 1
+        anti_particle = next(iter(anti_particles_by_pid))
+        particle_from_anti = -anti_particle
+        assert particle == particle_from_anti
+    assert n_particles_with_neg_pid == 428
+
+
 @pytest.mark.parametrize(
     "particle_name",
     ["p", "phi(1020)", "W-", "gamma"],

--- a/tests/unit/test_data.py
+++ b/tests/unit/test_data.py
@@ -198,6 +198,11 @@ class TestParticle:
         assert particle.name != different_labels.name
         assert particle.pid != different_labels.pid
 
+    def test_neg(self, particle_database: ParticleCollection):
+        pip = particle_database.find(211)
+        pim = particle_database.find(-211)
+        assert pip == -pim
+
 
 class TestParticleCollection:
     @staticmethod


### PR DESCRIPTION
Closes #294 

The `create_antiparticle` is now also tested for all particles in the PDG that have a counterpart with -PID.