### PR TITLE
docs: add PyPI project URLs

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -6,6 +6,10 @@ maintainer_email = compwa-admin@ep1.rub.de
 long_description = file: README.md
 long_description_content_type = text/markdown
 url = https://github.com/ComPWA/expertsystem
+project_urls =
+    Documentation = http://expertsystem.rtfd.io
+    Source = https://github.com/ComPWA/expertsystem
+    Tracker = https://github.com/ComPWA/expertsystem/issues
 license = GPLv3 or later
 keywords =
     HEP


### PR DESCRIPTION
https://packaging.python.org/guides/distributing-packages-using-setuptools/#project-urls

Result would be something like this on https://pypi.org/project/expertsystem
![image](https://user-images.githubusercontent.com/29308176/95478340-b2363a80-0989-11eb-80ac-c3c67eb54507.png)
