### PR TITLE
fix: validate list-only in recoil systems

### DIFF
--- a/expertsystem/schemas/yaml/amplitude-model.json
+++ b/expertsystem/schemas/yaml/amplitude-model.json
@@ -313,22 +313,12 @@
             "additionalProperties": false,
             "properties": {
               "RecoilFinalState": {
-                "anyOf": [
-                  { "$ref": "#/definitions/StateID" },
-                  {
-                    "type": "array",
-                    "items": { "$ref": "#/definitions/StateID" }
-                  }
-                ]
+                "type": "array",
+                "items": { "$ref": "#/definitions/StateID" }
               },
               "ParentRecoilFinalState": {
-                "anyOf": [
-                  { "$ref": "#/definitions/StateID" },
-                  {
-                    "type": "array",
-                    "items": { "$ref": "#/definitions/StateID" }
-                  }
-                ]
+                "type": "array",
+                "items": { "$ref": "#/definitions/StateID" }
               }
             }
           },


### PR DESCRIPTION
There's a mistake in the JSON validation schema for the YAML recipe file: it does not reflect the structure of a `RecoilSystem`, which has a `list` of `int`s only:
https://github.com/ComPWA/expertsystem/blob/c4f1769c7c49915ca363b8402e82826b3b30c922/expertsystem/amplitude/model.py#L329-L332