### PR TITLE
ci: activate flake8 bugbear

### DIFF
--- a/expertsystem/reaction/conservation_rules.py
+++ b/expertsystem/reaction/conservation_rules.py
@@ -106,7 +106,7 @@ def additive_quantum_number_rule(
         ) -> bool:
             return sum(ingoing_edge_qns) == sum(outgoing_edge_qns)
 
-        setattr(rule_class, "__call__", new_call)
+        setattr(rule_class, "__call__", new_call)  # noqa: B010
         rule_class.__doc__ = (
             f"""Decorated via `{additive_quantum_number_rule.__name__}`.\n\n"""
             f"""Check for `~.EdgeQuantumNumbers.{quantum_number.__name__}` conservation."""

--- a/expertsystem/reaction/solving.py
+++ b/expertsystem/reaction/solving.py
@@ -186,8 +186,8 @@ def _is_optional(
 ) -> bool:
     if (
         hasattr(field_type, "__origin__")
-        and getattr(field_type, "__origin__") is Union
-        and type(None) in getattr(field_type, "__args__")
+        and getattr(field_type, "__origin__") is Union  # noqa: B009
+        and type(None) in getattr(field_type, "__args__")  # noqa: B009
     ):
         return True
     return False
@@ -868,7 +868,9 @@ class CSPSolver(Solver):
             for var_string, value in solution.items():
                 ele_id, qn_type = self.__var_string_to_data[var_string]
 
-                if qn_type in getattr(EdgeQuantumNumber, "__args__"):
+                if qn_type in getattr(  # noqa: B009
+                    EdgeQuantumNumber, "__args__"
+                ):
                     if ele_id in initial_edges or ele_id in final_edges:
                         # skip if its an initial or final state edge
                         continue

--- a/expertsystem/ui/__init__.py
+++ b/expertsystem/ui/__init__.py
@@ -75,7 +75,7 @@ class StateTransitionManager:  # pylint: disable=too-many-instance-attributes
         self,
         initial_state: Sequence[StateDefinition],
         final_state: Sequence[StateDefinition],
-        particles: ParticleCollection = ParticleCollection(),
+        particles: Optional[ParticleCollection] = None,
         allowed_intermediate_particles: Optional[List[str]] = None,
         interaction_type_settings: Dict[
             InteractionTypes, Tuple[EdgeSettings, NodeSettings]
@@ -99,7 +99,9 @@ class StateTransitionManager:  # pylint: disable=too-many-instance-attributes
                 f" Use {allowed_formalism_types} instead."
             )
         self.__formalism_type = str(formalism_type)
-        self.__particles = particles
+        self.__particles = ParticleCollection()
+        if particles is not None:
+            self.__particles = particles
         self.number_of_threads = int(number_of_threads)
         self.reaction_mode = str(solving_mode)
         self.initial_state = initial_state

--- a/setup.cfg
+++ b/setup.cfg
@@ -86,6 +86,7 @@ dev =
     black==20.8b1
     flake8==3.8.3 # >=3 for per-file-ignores
     flake8-blind-except==0.1.1
+    flake8-bugbear==20.1.4
     flake8-builtins==1.5.3
     flake8-rst-docstrings==0.0.13
     isort==5.6.1

--- a/tests/unit/reaction/conservation_rules/test_spin.py
+++ b/tests/unit/reaction/conservation_rules/test_spin.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 
 import pytest
 
@@ -22,12 +22,23 @@ _SpinRuleInputType = Tuple[
 
 
 def __create_two_body_decay_spin_data(
-    in_spin: Spin = Spin(0, 0),
-    out_spin1: Spin = Spin(0, 0),
-    out_spin2: Spin = Spin(0, 0),
-    angular_momentum: Spin = Spin(0, 0),
-    coupled_spin: Spin = Spin(0, 0),
+    in_spin: Optional[Spin] = None,
+    out_spin1: Optional[Spin] = None,
+    out_spin2: Optional[Spin] = None,
+    angular_momentum: Optional[Spin] = None,
+    coupled_spin: Optional[Spin] = None,
 ) -> _SpinRuleInputType:
+    spin_zero = Spin(0, 0)
+    if in_spin is None:
+        in_spin = spin_zero
+    if out_spin1 is None:
+        out_spin1 = spin_zero
+    if out_spin2 is None:
+        out_spin2 = spin_zero
+    if angular_momentum is None:
+        angular_momentum = spin_zero
+    if coupled_spin is None:
+        coupled_spin = spin_zero
     return (
         [
             SpinEdgeInput(

--- a/tox.ini
+++ b/tox.ini
@@ -98,6 +98,7 @@ exclude =
     __pycache__
     doc/conf.py
 ignore = # more info: https://www.flake8rules.com/
+    B305 # progress.Bar.next()
     E203 # https://github.com/psf/black#slices
     E231 # allowed by black
     E501 # https://github.com/psf/black#line-length


### PR DESCRIPTION
Adds the [`flake8-bugbear` ](https://github.com/PyCQA/flake8-bugbear) extension, which seems to be stable and used a lot. Also points some potential design flaws (marked `# noqa: B009/B010`) that might be fixed later on with #309.