### PR TITLE
docs: visualize module dependencies

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -70,6 +70,7 @@
         "mypy",
         "nishijima",
         "pycompwa",
+        "pydeps",
         "pydocstyle",
         "pydot",
         "pylint",

--- a/doc/.gitignore
+++ b/doc/.gitignore
@@ -2,4 +2,5 @@
 *.inv
 *build/
 api/
+expertsystem.svg
 usage/*.ipynb

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -35,11 +35,12 @@ subprocess.call(
     " ".join(
         [
             "sphinx-apidoc",
+            "../expertsystem/",
+            "-o api/",
             "--force",
             "--no-toc",
             "--templatedir _templates",
             "--separate",
-            "-o api/ ../expertsystem/",
         ]
     )
     + ";",

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -51,11 +51,11 @@ subprocess.call(
 subprocess.call(
     " ".join(
         [
-            "HOME=.",  # when running from tox
+            "HOME=.",  # in case of calling through tox
             "pydeps",
             "../expertsystem",
-            "--exclude *._*",
-            "--max-bacon=1",
+            "--exclude *._*",  # hide private modules
+            "--max-bacon=1",  # hide external dependencies
             "--noshow",
         ]
     )

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -133,7 +133,7 @@ extensions = [
 exclude_patterns = [
     "**.ipynb_checkpoints",
     "*build",
-    "adr/template.md",
+    "adr*",
     "tests",
 ]
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -41,6 +41,25 @@ subprocess.call(
     shell=True,
 )
 
+# -- Visualize dependencies ---------------------------------------------------
+subprocess.call(
+    " ".join(
+        [
+            "HOME=.",  # when running from tox
+            "pydeps",
+            "../expertsystem",
+            "--exclude *._*",
+            "--max-bacon=1",
+            "--noshow",
+        ]
+    )
+    + ";",
+    shell=True,
+)
+if os.path.exists("expertsystem.svg"):
+    with open("api/expertsystem.rst", "a") as stream:
+        stream.write("\n.. image:: /expertsystem.svg")
+
 # -- Convert sphinx object inventory -----------------------------------------
 inv = soi.Inventory()
 inv.project = "constraint"

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -32,12 +32,17 @@ for file_to_copy in FILES_TO_COPY:
 # -- Generate API skeleton ----------------------------------------------------
 shutil.rmtree("api", ignore_errors=True)
 subprocess.call(
-    "sphinx-apidoc "
-    "--force "
-    "--no-toc "
-    "--templatedir _templates "
-    "--separate "
-    "-o api/ ../expertsystem/; ",
+    " ".join(
+        [
+            "sphinx-apidoc",
+            "--force",
+            "--no-toc",
+            "--templatedir _templates",
+            "--separate",
+            "-o api/ ../expertsystem/",
+        ]
+    )
+    + ";",
     shell=True,
 )
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -156,3 +156,10 @@ Table of Contents
 
   api
   adr
+
+.. toctree::
+  :caption: Related projects
+  :hidden:
+
+  TensorWaves <http://pwa.readthedocs.io>
+  PWA Pages <http://pwa.readthedocs.io>

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -147,6 +147,8 @@ Table of Contents
   interactive
   contribute
 
+* :ref:`Python API <modindex>`
+
 
 .. toctree::
   :maxdepth: 1
@@ -154,5 +156,3 @@ Table of Contents
 
   api
   adr
-
-* :ref:`Python API <modindex>`

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -151,11 +151,9 @@ Table of Contents
 
 
 .. toctree::
-  :maxdepth: 1
   :hidden:
 
   api
-  adr
 
 .. toctree::
   :caption: Related projects

--- a/setup.cfg
+++ b/setup.cfg
@@ -74,6 +74,7 @@ doc =
     jupyter==1.0.0
     nbsphinx==0.7.1
     myst-parser==0.12.6
+    pydeps==1.9.9
     Sphinx==3.2.1
     sphinx-book-theme==0.0.36
     sphinx-copybutton==0.3.0


### PR DESCRIPTION
Also adds links to related projects in the sidebar and hides the ADR pages.

Note: `pydeps` requires Graphviz at runtime. However, the `subprocess.call` won't signal a fatal error once `pydeps` fails and then the image simply won't be added. On RTD, Graphviz is available (see the graph vizualisation module), and the image will be rendered if it is available.