### PR TITLE
feat: implement ParticleCollection.names

### DIFF
--- a/doc/interactive.rst
+++ b/doc/interactive.rst
@@ -32,7 +32,7 @@ set of quantum numbers.
     p.spin in [2.5, 3.5, 4.5]
     and p.name.startswith("N")
   )
-  {p.name for p in subset}
+  subset.names
 
 .. thebe-button::
 

--- a/examples/particles.ipynb
+++ b/examples/particles.ipynb
@@ -96,7 +96,7 @@
    "outputs": [],
    "source": [
     "subset = particle_db.filter(lambda p: p.name.startswith(\"f(2)\"))\n",
-    "set(subset)"
+    "subset.names"
    ]
   },
   {
@@ -108,7 +108,7 @@
     "subset = particle_db.filter(\n",
     "    lambda p: p.strangeness == 1 and p.spin >= 1 and p.mass > 1.8 and p.mass < 1.9\n",
     ")\n",
-    "set(subset)"
+    "subset.names"
    ]
   },
   {
@@ -118,7 +118,7 @@
    "outputs": [],
    "source": [
     "subset = particle_db.filter(lambda p: p.is_lepton())\n",
-    "set(subset)"
+    "subset.names"
    ]
   },
   {
@@ -127,7 +127,7 @@
     "raw_mimetype": "text/restructuredtext"
    },
    "source": [
-    "In each of these examples, we cast to a `set`. This is just to only display the names, sorted alphabetically. The full representation of a `.ParticleCollection` looks like this:"
+    "In each of these examples, we call the `~.ParticleCollection.names` property. This is just to only display the names, sorted alphabetically. The full representation of a `.ParticleCollection` looks like this:"
    ]
   },
   {
@@ -245,7 +245,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "set(particle_db.filter(lambda p: \"EpEm\" in p.name))"
+    "particle_db.filter(lambda p: \"EpEm\" in p.name).names"
    ]
   },
   {
@@ -340,7 +340,7 @@
     "output += particle_db[\"pi+\"]\n",
     "output += particle_db[\"pi-\"]\n",
     "io.write(output, \"particle_list_selection.yml\")\n",
-    "set(output)"
+    "output.names"
    ]
   },
   {

--- a/examples/quickstart.ipynb
+++ b/examples/quickstart.ipynb
@@ -410,7 +410,7 @@
    "outputs": [],
    "source": [
     "amplitude_model = stm.generate_amplitude_model(result)\n",
-    "set(amplitude_model.particles)"
+    "amplitude_model.particles.names"
    ]
   },
   {

--- a/expertsystem/particle.py
+++ b/expertsystem/particle.py
@@ -14,7 +14,16 @@ and final state.
 import logging
 from collections import abc
 from functools import total_ordering
-from typing import Any, Callable, Dict, Iterable, Iterator, Optional, Union
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Iterable,
+    Iterator,
+    Optional,
+    Set,
+    Union,
+)
 
 import attr
 
@@ -396,6 +405,10 @@ class ParticleCollection(abc.MutableSet):
             )
         for particle in other:
             self.add(particle)
+
+    @property
+    def names(self) -> Set[str]:
+        return set(self.__particles)
 
 
 def create_particle(  # pylint: disable=too-many-arguments,too-many-locals

--- a/expertsystem/particle.py
+++ b/expertsystem/particle.py
@@ -384,13 +384,13 @@ class ParticleCollection(abc.MutableSet):
 
         >>> from expertsystem import io
         >>> pdg = io.load_pdg()
-        >>> results = pdg.filter(
+        >>> subset = pdg.filter(
         ...     lambda p: p.mass > 1.8
         ...     and p.mass < 2.0
         ...     and p.spin == 2
         ...     and p.strangeness == 1
         ... )
-        >>> sorted([p.name for p in results])
+        >>> sorted(list(subset.names))
         ['K(2)(1820)+', 'K(2)(1820)0']
         """
         return ParticleCollection(

--- a/tests/unit/test_particles.py
+++ b/tests/unit/test_particles.py
@@ -255,7 +255,7 @@ class TestParticleCollection:
             and p.spin == 2
             and p.strangeness == 1
         )
-        assert {p.name for p in filtered_result} == {
+        assert filtered_result.names == {
             "K(2)(1820)0",
             "K(2)(1820)+",
         }


### PR DESCRIPTION
Now that `ParticleCollection` mimicks a `set`, it has become a bit bothersome to get a list of particle names. This has some rather ugly effects here, for instance:
https://pwa.readthedocs.io/projects/expertsystem/en/0.5.0/usage/particles.html#Finding-particles