### PR TITLE
refactor!: improve Rule argument handling code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,7 +37,7 @@ htmlcov/
 prof/
 
 # Virtual environments
-*venv/
+*venv*/
 
 # Settings
 .idea/

--- a/.gitignore
+++ b/.gitignore
@@ -37,7 +37,8 @@ htmlcov/
 prof/
 
 # Virtual environments
-*venv*/
+*venv/
+pyvenv*/
 
 # Settings
 .idea/

--- a/cspell.json
+++ b/cspell.json
@@ -104,6 +104,7 @@
         "gitpod",
         "heli",
         "imag",
+        "isfunction",
         "jpsi",
         "jupyterlab",
         "kernelspec",

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -188,6 +188,7 @@ nitpick_ignore = [
     ("py:class", "a set-like object providing a view on D's keys"),
     ("py:class", "_T"),
     ("py:class", "an object providing a view on D's values"),
+    ("py:class", "typing_extensions.Protocol"),
 ]
 
 # Intersphinx settings

--- a/expertsystem/reaction/_default_settings.py
+++ b/expertsystem/reaction/_default_settings.py
@@ -9,23 +9,25 @@ from expertsystem.reaction.conservation_rules import (
     BottomnessConservation,
     ChargeConservation,
     CharmConservation,
-    ClebschGordanCheckHelicityToCanonical,
-    CParityConservation,
+    ConservationRule,
+    EdgeQNConservationRule,
     ElectronLNConservation,
-    GellMannNishijimaRule,
-    GParityConservation,
-    HelicityConservation,
-    IdenticalParticleSymmetrization,
-    IsoSpinConservation,
-    IsoSpinValidity,
     MassConservation,
     MuonLNConservation,
-    ParityConservation,
-    ParityConservationHelicity,
-    SpinConservation,
-    SpinConservationMagnitude,
     StrangenessConservation,
     TauLNConservation,
+    c_parity_conservation,
+    clebsch_gordan_helicity_to_canonical,
+    g_parity_conservation,
+    gellmann_nishijima,
+    helicity_conservation,
+    identical_particle_symmetrization,
+    isospin_conservation,
+    isospin_validity,
+    parity_conservation,
+    parity_conservation_helicity,
+    spin_conservation,
+    spin_magnitude_conservation,
 )
 from expertsystem.reaction.quantum_numbers import (
     EdgeQuantumNumbers,
@@ -45,26 +47,28 @@ DEFAULT_PARTICLE_LIST_PATH = join(
 
 # If a conservation law is not listed here, a default priority of 1 is assumed.
 # Higher number means higher priority
-__CONSERVATION_LAW_PRIORITIES = {
-    SpinConservation: 8,
-    SpinConservationMagnitude: 8,
-    HelicityConservation: 7,
+__CONSERVATION_LAW_PRIORITIES: Dict[
+    Union[EdgeQNConservationRule, ConservationRule], int
+] = {
+    spin_conservation: 8,
+    spin_magnitude_conservation: 8,
+    helicity_conservation: 7,
     MassConservation: 10,
-    GellMannNishijimaRule: 50,
+    gellmann_nishijima: 50,
     ChargeConservation: 100,
     ElectronLNConservation: 45,
     MuonLNConservation: 44,
     TauLNConservation: 43,
     BaryonNumberConservation: 90,
-    IdenticalParticleSymmetrization: 2,
+    identical_particle_symmetrization: 2,
     CharmConservation: 70,
     StrangenessConservation: 69,
-    ParityConservation: 6,
-    CParityConservation: 5,
-    ParityConservationHelicity: 4,
-    IsoSpinConservation: 60,
-    IsoSpinValidity: 61,
-    GParityConservation: 3,
+    parity_conservation: 6,
+    c_parity_conservation: 5,
+    parity_conservation_helicity: 4,
+    isospin_conservation: 60,
+    isospin_validity: 61,
+    g_parity_conservation: 3,
     BottomnessConservation: 68,
 }
 
@@ -108,8 +112,8 @@ def create_default_interaction_settings(
 
     if "helicity" in formalism_type:
         formalism_node_settings.conservation_rules = {
-            SpinConservationMagnitude(),
-            HelicityConservation(),
+            spin_magnitude_conservation,
+            helicity_conservation,
         }
         formalism_node_settings.qn_domains = {
             NodeQuantumNumbers.l_magnitude: _get_ang_mom_magnitudes(
@@ -121,9 +125,9 @@ def create_default_interaction_settings(
         }
     elif formalism_type == "canonical":
         formalism_node_settings.conservation_rules = {
-            SpinConservationMagnitude()
+            spin_magnitude_conservation
             if nbody_topology
-            else SpinConservation(),
+            else spin_conservation,
         }
         formalism_node_settings.qn_domains = {
             NodeQuantumNumbers.l_magnitude: _get_ang_mom_magnitudes(
@@ -141,7 +145,7 @@ def create_default_interaction_settings(
         }
     if formalism_type == "canonical-helicity":
         formalism_node_settings.conservation_rules.add(
-            ClebschGordanCheckHelicityToCanonical()
+            clebsch_gordan_helicity_to_canonical
         )
         formalism_node_settings.qn_domains.update(
             {
@@ -162,9 +166,9 @@ def create_default_interaction_settings(
             MuonLNConservation(),
             TauLNConservation(),
             BaryonNumberConservation(),
-            IsoSpinValidity(),  # should be changed to a pure edge rule
-            IdenticalParticleSymmetrization(),
-            GellMannNishijimaRule(),  # should be changed to a pure edge rule
+            isospin_validity,  # should be changed to a pure edge rule
+            identical_particle_symmetrization,
+            gellmann_nishijima,  # should be changed to a pure edge rule
         ]
     )
     weak_node_settings.interaction_strength = 10 ** (-4)
@@ -205,12 +209,12 @@ def create_default_interaction_settings(
             CharmConservation(),
             StrangenessConservation(),
             BottomnessConservation(),
-            ParityConservation(),
-            CParityConservation(),
+            parity_conservation,
+            c_parity_conservation,
         }
     )
     if "helicity" in formalism_type:
-        em_node_settings.conservation_rules.add(ParityConservationHelicity())
+        em_node_settings.conservation_rules.add(parity_conservation_helicity)
         em_node_settings.qn_domains.update(
             {NodeQuantumNumbers.parity_prefactor: [-1, 1]}
         )
@@ -225,7 +229,7 @@ def create_default_interaction_settings(
 
     strong_node_settings = deepcopy(em_node_settings)
     strong_node_settings.conservation_rules.update(
-        {IsoSpinConservation(), GParityConservation()}
+        {isospin_conservation, g_parity_conservation}
     )
     strong_node_settings.interaction_strength = 60
 

--- a/expertsystem/reaction/argument_handling.py
+++ b/expertsystem/reaction/argument_handling.py
@@ -1,0 +1,350 @@
+"""Handles argument handling for rules.
+
+Responsibilities are the check of requirements for rules and the creation of
+the arguments from general graph property maps. The information is extracted
+from the type annotations of the rules.
+"""
+
+import inspect
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Generic,
+    List,
+    Optional,
+    Sequence,
+    Set,
+    Tuple,
+    Type,
+    TypeVar,
+    Union,
+)
+
+import attr
+
+from expertsystem.particle import Parity
+
+from .conservation_rules import ConservationRule, EdgeQNConservationRule
+from .quantum_numbers import EdgeQuantumNumber, NodeQuantumNumber
+
+Scalar = Union[int, float]
+
+Rule = Union[EdgeQNConservationRule, ConservationRule]
+
+_ElementType = TypeVar("_ElementType", EdgeQuantumNumber, NodeQuantumNumber)
+
+GraphElementPropertyMap = Dict[Type[_ElementType], Union[int, float, None]]
+GraphEdgePropertyMap = GraphElementPropertyMap[EdgeQuantumNumber]
+GraphNodePropertyMap = GraphElementPropertyMap[NodeQuantumNumber]
+
+
+def _is_optional(field_type: Optional[type]) -> bool:
+    if (
+        hasattr(field_type, "__origin__")
+        and getattr(field_type, "__origin__") is Union
+        and type(None) in getattr(field_type, "__args__")
+    ):
+        return True
+    return False
+
+
+def _is_sequence_type(input_type: type) -> bool:
+    # pylint: disable=unidiomatic-typecheck
+    return hasattr(input_type, "__origin__") and (
+        input_type.__origin__ is list  # type: ignore
+        or input_type.__origin__ is tuple  # type: ignore
+        or input_type.__origin__ is List  # type: ignore
+        or input_type.__origin__ is Tuple  # type: ignore
+    )
+
+
+def _is_edge_quantum_number(qn_type: Any) -> bool:
+    return qn_type in getattr(EdgeQuantumNumber, "__args__")
+
+
+def _is_node_quantum_number(qn_type: Any) -> bool:
+    return qn_type in getattr(NodeQuantumNumber, "__args__")
+
+
+class _CompositeArgumentCheck:
+    def __init__(
+        self,
+        class_field_types: Union[
+            List[EdgeQuantumNumber], List[NodeQuantumNumber]
+        ],
+    ) -> None:
+        self.__class_field_types = class_field_types
+
+    def __call__(
+        self,
+        props: GraphElementPropertyMap,
+    ) -> bool:
+        return all(
+            [
+                bool(class_field_type in props)
+                for class_field_type in self.__class_field_types
+            ]
+        )
+
+
+def _direct_qn_check(
+    qn_type: Union[Type[EdgeQuantumNumber], Type[NodeQuantumNumber]]
+) -> Callable[[GraphElementPropertyMap], bool]:
+    def wrapper(props: GraphElementPropertyMap) -> bool:
+        return qn_type in props
+
+    return wrapper
+
+
+def _sequence_input_check(func: Callable) -> Callable[[Sequence], bool]:
+    def wrapper(edge_props_list: Sequence[Any]) -> bool:
+        if not isinstance(edge_props_list, (list, tuple)):
+            raise TypeError("Rule evaluated with invalid argument type...")
+
+        return all([func(x) for x in edge_props_list])
+
+    return wrapper
+
+
+def _check_all_arguments(checks: List[Callable]) -> Callable[..., bool]:
+    def wrapper(*args: Any) -> bool:
+        return all([check(arg) for check, arg in zip(checks, args)])
+
+    return wrapper
+
+
+class _ValueExtractor(Generic[_ElementType]):
+    def __init__(self, obj_type: Optional[Type[_ElementType]]) -> None:
+        self.__obj_type: Type[_ElementType] = obj_type  # type: ignore
+        self.__function = self.__extract  # type: ignore
+
+        if _is_optional(obj_type):
+            self.__obj_type = getattr(obj_type, "__args__")[0]
+            self.__function = self.__optional_extract  # type: ignore
+
+    def __call__(
+        self, props: GraphElementPropertyMap[_ElementType]
+    ) -> Optional[_ElementType]:
+        return self.__function(props)
+
+    def __optional_extract(
+        self, props: GraphElementPropertyMap[_ElementType]
+    ) -> Optional[_ElementType]:
+        if self.__obj_type in props:
+            return self.__extract(props)
+
+        return None
+
+    def __extract(
+        self, props: GraphElementPropertyMap[_ElementType]
+    ) -> _ElementType:
+        # print(props, self.__obj_type)
+        value = props[self.__obj_type]
+
+        if (
+            "__supertype__" in self.__obj_type.__dict__
+            and self.__obj_type.__supertype__ == Parity  # type: ignore
+        ):
+            return self.__obj_type.__supertype__(value)  # type: ignore
+        return self.__obj_type(value)  # type: ignore
+
+
+class _CompositeArgumentCreator:
+    def __init__(self, class_type: type) -> None:
+        self.__class_type = class_type
+        self.__extractors = dict(
+            {
+                class_field.name: _ValueExtractor[EdgeQuantumNumber](
+                    class_field.type
+                )
+                if _is_edge_quantum_number(class_field.type)
+                else _ValueExtractor[NodeQuantumNumber](class_field.type)
+                for class_field in attr.fields(class_type)
+            }
+        )
+
+    def __call__(
+        self,
+        props: GraphElementPropertyMap,
+    ) -> Any:
+        return self.__class_type(
+            **{
+                arg_name: extractor(props)  # type: ignore
+                for arg_name, extractor in self.__extractors.items()
+            }
+        )
+
+
+def _sequence_arg_builder(func: Callable) -> Callable[[Sequence], List[Any]]:
+    def wrapper(edge_props_list: Sequence[Any]) -> List[Any]:
+        if not isinstance(edge_props_list, (list, tuple)):
+            raise TypeError("Rule evaluated with invalid argument type...")
+
+        return [func(x) for x in edge_props_list if x]
+
+    return wrapper
+
+
+def _build_all_arguments(checks: List[Callable]) -> Callable:
+    def wrapper(*args: Any) -> List[Any]:
+        return [check(arg) for check, arg in zip(checks, args) if arg]
+
+    return wrapper
+
+
+class RuleArgumentHandler:
+    def __init__(self) -> None:
+        self.__rule_to_requirements_check: Dict[Rule, Callable] = {}
+        self.__rule_to_argument_builder: Dict[Rule, Callable] = {}
+
+    def __verify(self, rule_annotations: list) -> None:
+        pass
+
+    @staticmethod
+    def __create_requirements_check(
+        argument_types: List[type],
+    ) -> Callable:
+        individual_argument_checkers = []
+        for input_type in argument_types:
+            is_list = False
+            qn_type = input_type
+            if _is_sequence_type(input_type):
+                qn_type = input_type.__args__[0]  # type: ignore
+                is_list = True
+
+            if attr.has(qn_type):
+                class_field_types = [
+                    class_field.type
+                    for class_field in attr.fields(qn_type)
+                    if not _is_optional(class_field.type)
+                ]
+                qn_check_function: Callable[
+                    ..., bool
+                ] = _CompositeArgumentCheck(
+                    class_field_types  # type: ignore
+                )
+            else:
+                qn_check_function = _direct_qn_check(qn_type)
+
+            if is_list:
+                qn_check_function = _sequence_input_check(qn_check_function)
+
+            individual_argument_checkers.append(qn_check_function)
+
+        return _check_all_arguments(individual_argument_checkers)
+
+    @staticmethod
+    def __create_argument_builder(
+        argument_types: List[type],
+    ) -> Callable:
+        individual_argument_builders = []
+        for input_type in argument_types:
+            is_list = False
+            qn_type = input_type
+            if _is_sequence_type(input_type):
+                qn_type = input_type.__args__[0]  # type: ignore
+                is_list = True
+
+            if attr.has(qn_type):
+                arg_builder: Callable[..., Any] = _CompositeArgumentCreator(
+                    qn_type
+                )
+            else:
+                if _is_edge_quantum_number(qn_type):
+                    arg_builder = _ValueExtractor[EdgeQuantumNumber](qn_type)
+                elif _is_node_quantum_number(qn_type):
+                    arg_builder = _ValueExtractor[NodeQuantumNumber](qn_type)
+                else:
+                    raise TypeError(
+                        f"Quantum number type {qn_type} is not supported."
+                        " Has to be of type Edge/NodeQuantumNumber."
+                    )
+
+            if is_list:
+                arg_builder = _sequence_arg_builder(arg_builder)
+
+            individual_argument_builders.append(arg_builder)
+
+        return _build_all_arguments(individual_argument_builders)
+
+    def register_rule(self, rule: Rule) -> Tuple[Callable, Callable]:
+        if (
+            rule not in self.__rule_to_requirements_check
+            or rule not in self.__rule_to_argument_builder
+        ):
+            rule_annotations = list()
+            rule_func_signature = inspect.signature(rule)
+            if not rule_func_signature.return_annotation:
+                raise TypeError(
+                    f"missing return type annotation for rule {str(rule)}"
+                )
+            for par in rule_func_signature.parameters.values():
+                if not par.annotation:
+                    raise TypeError(
+                        f"missing type annotations for argument {par.name}"
+                        f" of rule {str(rule)}"
+                    )
+                rule_annotations.append(par.annotation)
+
+            # check type annotations are legal
+            try:
+                self.__verify(rule_annotations)
+            except TypeError as exception:
+                raise TypeError(
+                    f"rule {str(rule)}: {str(exception)}"
+                ) from exception
+
+            # then create requirements check function and add to dict
+            self.__rule_to_requirements_check[
+                rule
+            ] = self.__create_requirements_check(rule_annotations)
+
+            # then create arguments builder function and add to dict
+            self.__rule_to_argument_builder[
+                rule
+            ] = self.__create_argument_builder(rule_annotations)
+
+        return (
+            self.__rule_to_requirements_check[rule],
+            self.__rule_to_argument_builder[rule],
+        )
+
+
+def get_required_qns(
+    rule: Rule,
+) -> Tuple[Set[Type[EdgeQuantumNumber]], Set[Type[NodeQuantumNumber]]]:
+    rule_annotations = list()
+    for par in inspect.signature(rule).parameters.values():
+        if not par.annotation:
+            raise TypeError(f"missing type annotations for rule {str(rule)}")
+        rule_annotations.append(par.annotation)
+
+    required_edge_qns: Set[Type[EdgeQuantumNumber]] = set()
+    required_node_qns: Set[Type[NodeQuantumNumber]] = set()
+
+    arg_counter = 0
+    for input_type in rule_annotations:
+        class_type = input_type
+        if _is_sequence_type(input_type):
+            class_type = input_type.__args__[0]
+
+        if attr.has(class_type):
+            for class_field in attr.fields(class_type):
+                field_type = (
+                    getattr(class_field.type, "__args__")[0]
+                    if _is_optional(class_field.type)
+                    else class_field.type
+                )
+                if _is_edge_quantum_number(field_type):
+                    required_edge_qns.add(field_type)
+                else:
+                    required_node_qns.add(field_type)
+        else:
+            if _is_edge_quantum_number(class_type):
+                required_edge_qns.add(class_type)
+            else:
+                required_node_qns.add(class_type)
+        arg_counter += 1
+
+    return (required_edge_qns, required_node_qns)

--- a/expertsystem/reaction/argument_handling.py
+++ b/expertsystem/reaction/argument_handling.py
@@ -42,8 +42,8 @@ GraphNodePropertyMap = GraphElementPropertyMap[NodeQuantumNumber]
 def _is_optional(field_type: Optional[type]) -> bool:
     if (
         hasattr(field_type, "__origin__")
-        and getattr(field_type, "__origin__") is Union
-        and type(None) in getattr(field_type, "__args__")
+        and field_type.__origin__ is Union  # type: ignore
+        and type(None) in field_type.__args__  # type: ignore
     ):
         return True
     return False
@@ -60,11 +60,11 @@ def _is_sequence_type(input_type: type) -> bool:
 
 
 def _is_edge_quantum_number(qn_type: Any) -> bool:
-    return qn_type in getattr(EdgeQuantumNumber, "__args__")
+    return qn_type in EdgeQuantumNumber.__args__  # type: ignore
 
 
 def _is_node_quantum_number(qn_type: Any) -> bool:
-    return qn_type in getattr(NodeQuantumNumber, "__args__")
+    return qn_type in NodeQuantumNumber.__args__  # type: ignore
 
 
 class _CompositeArgumentCheck:
@@ -120,7 +120,7 @@ class _ValueExtractor(Generic[_ElementType]):
         self.__function = self.__extract  # type: ignore
 
         if _is_optional(obj_type):
-            self.__obj_type = getattr(obj_type, "__args__")[0]
+            self.__obj_type = obj_type.__args__[0]  # type: ignore
             self.__function = self.__optional_extract  # type: ignore
 
     def __call__(
@@ -332,7 +332,7 @@ def get_required_qns(
         if attr.has(class_type):
             for class_field in attr.fields(class_type):
                 field_type = (
-                    getattr(class_field.type, "__args__")[0]
+                    class_field.type.__args__[0]  # type: ignore
                     if _is_optional(class_field.type)
                     else class_field.type
                 )

--- a/expertsystem/reaction/conservation_rules.py
+++ b/expertsystem/reaction/conservation_rules.py
@@ -8,10 +8,10 @@ There are four different types of rules:
 
 1. Rules that work on individual graph edges (WIP).
 2. Rules that work on individual graph nodes (WIP).
-3. Rules that work on the interaction level, which use ingoing edges, outgoing
-   edges as arguments. For example `.ChargeConservation`.
-4. Rules that work on the interaction level, which use ingoing edges, outgoing
-   edges and a interaction node as arguments. For example
+3. `EdgeQNConservationRule` that work on the interaction level, which use
+   ingoing edges, outgoing edges as arguments.  E.g.: `.ChargeConservation`.
+4. `ConservationRule` that work on the interaction level, which use ingoing
+   edges, outgoing edges and a interaction node as arguments. E.g:
    `.parity_conservation`.
 
 The arguments can be any type of quantum number. However a rule argument

--- a/expertsystem/reaction/conservation_rules.py
+++ b/expertsystem/reaction/conservation_rules.py
@@ -1,20 +1,55 @@
 """Collection of quantum number conservation rules for particle reactions.
 
 This module is the place where the 'expert' defines the rules that verify
-quantum numbers of the reaction. The module is therefore strongly typed (both
+quantum numbers of the reaction.
+
+A rule is a function that takes quantum numbers as input and outputs a boolean.
+There are four different types of rules:
+
+1. Rules that work on individual graph edges (WIP).
+2. Rules that work on individual graph nodes (WIP).
+3. Rules that work on the interaction level, which use ingoing edges, outgoing
+   edges as arguments. For example `.ChargeConservation`.
+4. Rules that work on the interaction level, which use ingoing edges, outgoing
+   edges and a interaction node as arguments. For example
+   `.parity_conservation`.
+
+The arguments can be any type of quantum number. However a rule argument
+resembling edges only accepts `~.quantum_numbers.EdgeQuantumNumbers`. Similarly
+arguments that resemble a node only accept
+`~.quantum_numbers.NodeQuantumNumbers`. The argument types do not have to be
+limited to a single quantum number, but can be a composite (see
+`.CParityEdgeInput`).
+
+.. warning::
+    Besides the rule logic itself, a rule also has the responsibility of
+    stating its run conditions. These run conditions **must** be stated by
+    the type annotations of its **__call__** method. The type annotations
+    therefore are not just there for *static* type checking: they also
+    carry more information about the rule that is extracted *dynamically*
+    by the `.reaction` module.
+
+Generally, the conditions can be separated into two categories:
+
+* variable conditions
+* toplogical conditions
+
+Currently, only variable conditions are being used. Topological conditions
+could be created in the form of `~typing.Tuple` instead of `~typing.List`.
+
+For additive quantum numbers, the decorator `additive_quantum_number_rule`
+can be used to automatically generate the appropriate behavior.
+
+
+The module is therefore strongly typed (both
 for the reader of the code and for type checking with :doc:`mypy
 <mypy:index>`). An example is `.HelicityParityEdgeInput`, which has been
-defined to provide type checks on `.ParityConservationHelicity`.
-
-See more information under `Rule`.
+defined to provide type checks on `.parity_conservation_helicity`.
 """
-
-# pylint: disable=abstract-method
-
 
 from copy import deepcopy
 from functools import reduce
-from typing import Any, Callable, List, Optional, Set, Tuple, Type, Union
+from typing import Any, Callable, List, Optional, Set, Tuple, Union
 
 import attr
 
@@ -22,6 +57,11 @@ from expertsystem.particle import Spin
 
 from .combinatorics import arange
 from .quantum_numbers import EdgeQuantumNumbers, NodeQuantumNumbers
+
+try:
+    from typing import Protocol
+except ImportError:
+    from typing_extensions import Protocol  # type: ignore
 
 
 def _is_boson(spin_magnitude: float) -> bool:
@@ -34,59 +74,32 @@ def _is_particle_antiparticle_pair(pid1: int, pid2: int) -> bool:
     return pid1 == -pid2
 
 
-class Rule:
-    """Interface for conservation rules.
+class EdgeQNConservationRule(Protocol):
+    def __call__(
+        self, __ingoing_edge_qns: List[Any], __outgoing_edge_qns: List[Any]
+    ) -> bool:
+        ...
 
-    A `Rule` performs checks on an `.InteractionNode` and its attached `.Edge`
-    instances. The `__call__` method contains actual rule logic and has to be
-    overwritten.
 
-    .. warning::
-        Besides the rule logic itself, a `Rule` also has the responsibility of
-        stating its run conditions. These run conditions **must** be stated by
-        the type annotations of its `.__call__` method. The type annotations
-        therefore are not just there for *static* type checking: they also
-        carry more information about the rule that is extracted *dynamically*
-        by the `.reaction` module.
-
-    Generally, the conditions can be separated into two categories:
-
-    * variable conditions
-    * toplogical conditions
-
-    Currently, only variable conditions are being used. Topological conditions
-    could be created in the form of `~typing.Tuple` instead of `~typing.List`.
-
-    For additive quantum numbers, the decorator `additive_quantum_number_rule`
-    can simplify the constrution of the appropriate `Rule`.
-    """
-
-    def __repr__(self) -> str:
-        return f"{self.__class__.__name__}"
-
-    def __hash__(self) -> int:
-        return hash(self.__class__.__name__)
-
-    def __eq__(self, o: object) -> bool:
-        if isinstance(o, Rule):
-            return self.__class__.__name__ == str(o)
-        return False
-
+class ConservationRule(Protocol):
     def __call__(
         self,
-        ingoing_edge_qns: List[Any],
-        outgoing_edge_qns: List[Any],
-        interaction_node_qns: Any,
+        __ingoing_edge_qns: List[Any],
+        __outgoing_edge_qns: List[Any],
+        __node_qns: Any,
     ) -> bool:
-        raise NotImplementedError
+        ...
 
 
+# Note a generic would be more fitting here. However the type annotations of
+# __call__ method in a concrete version of the generic are still containing the
+# TypeVar types. See https://github.com/python/typing/issues/762
 def additive_quantum_number_rule(
     quantum_number: type,
-) -> Callable[[Type[Rule]], Type[Rule]]:
-    r"""Class decorator for creating an additive conservation `Rule`.
+) -> Callable[[Any], EdgeQNConservationRule]:
+    r"""Class decorator for creating an additive conservation rule.
 
-    Use this decorator to create a conservation `Rule` for a quantum number
+    Use this decorator to create a `EdgeQNConservationRule` for a quantum number
     to which an additive conservation rule applies:
 
     .. math:: \sum q_{in} = \sum q_{out}
@@ -97,16 +110,15 @@ def additive_quantum_number_rule(
             `.EdgeQuantumNumbers.charge`.
     """
 
-    def decorator(rule_class: Type[Rule]) -> Type[Rule]:
+    def decorator(rule_class: Any) -> EdgeQNConservationRule:
         def new_call(  # type: ignore
             self,  # pylint: disable=unused-argument
             ingoing_edge_qns: List[quantum_number],  # type: ignore
             outgoing_edge_qns: List[quantum_number],  # type: ignore
-            _=None,
         ) -> bool:
             return sum(ingoing_edge_qns) == sum(outgoing_edge_qns)
 
-        setattr(rule_class, "__call__", new_call)  # noqa: B010
+        rule_class.__call__ = new_call
         rule_class.__doc__ = (
             f"""Decorated via `{additive_quantum_number_rule.__name__}`.\n\n"""
             f"""Check for `~.EdgeQuantumNumbers.{quantum_number.__name__}` conservation."""
@@ -117,58 +129,56 @@ def additive_quantum_number_rule(
 
 
 @additive_quantum_number_rule(EdgeQuantumNumbers.charge)
-class ChargeConservation(Rule):
+class ChargeConservation(EdgeQNConservationRule):
     pass
 
 
 @additive_quantum_number_rule(EdgeQuantumNumbers.baryon_number)
-class BaryonNumberConservation(Rule):
+class BaryonNumberConservation(EdgeQNConservationRule):
     pass
 
 
 @additive_quantum_number_rule(EdgeQuantumNumbers.electron_lepton_number)
-class ElectronLNConservation(Rule):
+class ElectronLNConservation(EdgeQNConservationRule):
     pass
 
 
 @additive_quantum_number_rule(EdgeQuantumNumbers.muon_lepton_number)
-class MuonLNConservation(Rule):
+class MuonLNConservation(EdgeQNConservationRule):
     pass
 
 
 @additive_quantum_number_rule(EdgeQuantumNumbers.tau_lepton_number)
-class TauLNConservation(Rule):
+class TauLNConservation(EdgeQNConservationRule):
     pass
 
 
 @additive_quantum_number_rule(EdgeQuantumNumbers.strangeness)
-class StrangenessConservation(Rule):
+class StrangenessConservation(EdgeQNConservationRule):
     pass
 
 
 @additive_quantum_number_rule(EdgeQuantumNumbers.charmness)
-class CharmConservation(Rule):
+class CharmConservation(EdgeQNConservationRule):
     pass
 
 
 @additive_quantum_number_rule(EdgeQuantumNumbers.bottomness)
-class BottomnessConservation(Rule):
+class BottomnessConservation(EdgeQNConservationRule):
     pass
 
 
-class ParityConservation(Rule):
-    def __call__(
-        self,
-        ingoing_edge_qns: List[EdgeQuantumNumbers.parity],
-        outgoing_edge_qns: List[EdgeQuantumNumbers.parity],
-        l_mag: NodeQuantumNumbers.l_magnitude,
-    ) -> bool:
-        r"""Implement :math:`P_{in} = P_{out} \cdot (-1)^L`."""
-        if len(ingoing_edge_qns) == 1 and len(outgoing_edge_qns) == 2:
-            parity_in = reduce(lambda x, y: x * y.value, ingoing_edge_qns, 1)
-            parity_out = reduce(lambda x, y: x * y.value, outgoing_edge_qns, 1)
-            return parity_in == (parity_out * (-1) ** l_mag)
-        return True
+def parity_conservation(
+    ingoing_edge_qns: List[EdgeQuantumNumbers.parity],
+    outgoing_edge_qns: List[EdgeQuantumNumbers.parity],
+    l_mag: NodeQuantumNumbers.l_magnitude,
+) -> bool:
+    r"""Implement :math:`P_{in} = P_{out} \cdot (-1)^L`."""
+    if len(ingoing_edge_qns) == 1 and len(outgoing_edge_qns) == 2:
+        parity_in = reduce(lambda x, y: x * y.value, ingoing_edge_qns, 1)
+        parity_out = reduce(lambda x, y: x * y.value, outgoing_edge_qns, 1)
+        return parity_in == (parity_out * (-1) ** l_mag)
+    return True
 
 
 @attr.s(frozen=True)
@@ -178,42 +188,40 @@ class HelicityParityEdgeInput:
     spin_proj: EdgeQuantumNumbers.spin_projection = attr.ib()
 
 
-class ParityConservationHelicity(Rule):
-    def __call__(
-        self,
-        ingoing_edge_qns: List[HelicityParityEdgeInput],
-        outgoing_edge_qns: List[HelicityParityEdgeInput],
-        parity_prefactor: NodeQuantumNumbers.parity_prefactor,
-    ) -> bool:
-        r"""Implements parity conservation for helicity formalism.
+def parity_conservation_helicity(
+    ingoing_edge_qns: List[HelicityParityEdgeInput],
+    outgoing_edge_qns: List[HelicityParityEdgeInput],
+    parity_prefactor: NodeQuantumNumbers.parity_prefactor,
+) -> bool:
+    r"""Implements parity conservation for helicity formalism.
 
-        Check the following:
+    Check the following:
 
-        .. math:: A_{-\lambda_1-\lambda_2} = P_1 P_2 P_3 (-1)^{S_2+S_3-S_1}
-            A_{\lambda_1\lambda_2}
+    .. math:: A_{-\lambda_1-\lambda_2} = P_1 P_2 P_3 (-1)^{S_2+S_3-S_1}
+        A_{\lambda_1\lambda_2}
 
-        Notice that only the special case :math:`\lambda_1=\lambda_2=0` may
-        return False.
-        """
-        if len(ingoing_edge_qns) == 1 and len(outgoing_edge_qns) == 2:
-            out_spins = [x.spin_mag for x in outgoing_edge_qns]
-            parity_product = reduce(
-                lambda x, y: x * y.parity.value if y.parity else x,
-                ingoing_edge_qns + outgoing_edge_qns,
-                1,
-            )
+    Notice that only the special case :math:`\lambda_1=\lambda_2=0` may
+    return False.
+    """
+    if len(ingoing_edge_qns) == 1 and len(outgoing_edge_qns) == 2:
+        out_spins = [x.spin_mag for x in outgoing_edge_qns]
+        parity_product = reduce(
+            lambda x, y: x * y.parity.value if y.parity else x,
+            ingoing_edge_qns + outgoing_edge_qns,
+            1,
+        )
 
-            prefactor = parity_product * (-1.0) ** (
-                sum(out_spins) - ingoing_edge_qns[0].spin_mag
-            )
+        prefactor = parity_product * (-1.0) ** (
+            sum(out_spins) - ingoing_edge_qns[0].spin_mag
+        )
 
-            daughter_hel = [0 for x in outgoing_edge_qns if x.spin_proj == 0.0]
-            if len(daughter_hel) == 2:
-                if prefactor == -1:
-                    return False
+        daughter_hel = [0 for x in outgoing_edge_qns if x.spin_proj == 0.0]
+        if len(daughter_hel) == 2:
+            if prefactor == -1:
+                return False
 
-            return prefactor == parity_prefactor
-        return True
+        return prefactor == parity_prefactor
+    return True
 
 
 @attr.s(frozen=True)
@@ -229,58 +237,51 @@ class CParityNodeInput:
     s_mag: NodeQuantumNumbers.s_magnitude = attr.ib()
 
 
-class CParityConservation(Rule):
-    def __call__(
-        self,
-        ingoing_edge_qns: List[CParityEdgeInput],
-        outgoing_edge_qns: List[CParityEdgeInput],
-        interaction_node_qns: CParityNodeInput,
-    ) -> bool:
-        """Check for :math:`C`-parity conservation.
+def c_parity_conservation(
+    ingoing_edge_qns: List[CParityEdgeInput],
+    outgoing_edge_qns: List[CParityEdgeInput],
+    interaction_node_qns: CParityNodeInput,
+) -> bool:
+    """Check for :math:`C`-parity conservation.
 
-        Implements :math:`C_{in} = C_{out}`.
-        """
+    Implements :math:`C_{in} = C_{out}`.
+    """
 
-        def _get_c_parity_multiparticle(
-            part_qns: List[CParityEdgeInput], interaction_qns: CParityNodeInput
-        ) -> Optional[int]:
-            c_parities_part = [
-                x.c_parity.value for x in part_qns if x.c_parity
-            ]
-            # if all states have C parity defined, then just multiply them
-            if len(c_parities_part) == len(part_qns):
-                return reduce(lambda x, y: x * y, c_parities_part, 1)
+    def _get_c_parity_multiparticle(
+        part_qns: List[CParityEdgeInput], interaction_qns: CParityNodeInput
+    ) -> Optional[int]:
+        c_parities_part = [x.c_parity.value for x in part_qns if x.c_parity]
+        # if all states have C parity defined, then just multiply them
+        if len(c_parities_part) == len(part_qns):
+            return reduce(lambda x, y: x * y, c_parities_part, 1)
 
-            # two particle case
-            if len(part_qns) == 2:
-                if _is_particle_antiparticle_pair(
-                    part_qns[0].pid, part_qns[1].pid
-                ):
-                    ang_mom = interaction_qns.l_mag
-                    # if boson
-                    if _is_boson(part_qns[0].spin_mag):
-                        return (-1) ** int(ang_mom)
-                    coupled_spin = interaction_qns.s_mag
-                    if (
-                        isinstance(coupled_spin, int)
-                        or coupled_spin.is_integer()
-                    ):
-                        return (-1) ** int(ang_mom + coupled_spin)
-            return None
+        # two particle case
+        if len(part_qns) == 2:
+            if _is_particle_antiparticle_pair(
+                part_qns[0].pid, part_qns[1].pid
+            ):
+                ang_mom = interaction_qns.l_mag
+                # if boson
+                if _is_boson(part_qns[0].spin_mag):
+                    return (-1) ** int(ang_mom)
+                coupled_spin = interaction_qns.s_mag
+                if isinstance(coupled_spin, int) or coupled_spin.is_integer():
+                    return (-1) ** int(ang_mom + coupled_spin)
+        return None
 
-        c_parity_in = _get_c_parity_multiparticle(
-            ingoing_edge_qns, interaction_node_qns
-        )
-        if c_parity_in is None:
-            return True
+    c_parity_in = _get_c_parity_multiparticle(
+        ingoing_edge_qns, interaction_node_qns
+    )
+    if c_parity_in is None:
+        return True
 
-        c_parity_out = _get_c_parity_multiparticle(
-            outgoing_edge_qns, interaction_node_qns
-        )
-        if c_parity_out is None:
-            return True
+    c_parity_out = _get_c_parity_multiparticle(
+        outgoing_edge_qns, interaction_node_qns
+    )
+    if c_parity_out is None:
+        return True
 
-        return c_parity_in == c_parity_out
+    return c_parity_in == c_parity_out
 
 
 @attr.s(frozen=True)
@@ -297,89 +298,85 @@ class GParityNodeInput:
     s_mag: NodeQuantumNumbers.s_magnitude = attr.ib()
 
 
-class GParityConservation(Rule):
-    def __call__(
-        self,
-        ingoing_edge_qns: List[GParityEdgeInput],
-        outgoing_edge_qns: List[GParityEdgeInput],
-        interaction_qns: GParityNodeInput,
+def g_parity_conservation(
+    ingoing_edge_qns: List[GParityEdgeInput],
+    outgoing_edge_qns: List[GParityEdgeInput],
+    interaction_qns: GParityNodeInput,
+) -> bool:
+    """Check for :math:`G`-parity conservation.
+
+    Implements for :math:`G_{in} = G_{out}`.
+    """
+
+    def check_multistate_g_parity(
+        isospin: EdgeQuantumNumbers.isospin_magnitude,
+        double_state_qns: Tuple[GParityEdgeInput, GParityEdgeInput],
+    ) -> Optional[int]:
+        if _is_particle_antiparticle_pair(
+            double_state_qns[0].pid, double_state_qns[1].pid
+        ):
+            ang_mom = interaction_qns.l_mag
+            if isinstance(isospin, int) or isospin.is_integer():
+                # if boson
+                if _is_boson(double_state_qns[0].spin_mag):
+                    return (-1) ** int(ang_mom + isospin)
+                coupled_spin = interaction_qns.s_mag
+                if isinstance(coupled_spin, int) or coupled_spin.is_integer():
+                    return (-1) ** int(ang_mom + coupled_spin + isospin)
+        return None
+
+    def check_g_parity_isobar(
+        single_state: GParityEdgeInput,
+        couple_state: Tuple[GParityEdgeInput, GParityEdgeInput],
     ) -> bool:
-        """Check for :math:`G`-parity conservation.
+        couple_state_g_parity = check_multistate_g_parity(
+            single_state.isospin,
+            (couple_state[0], couple_state[1]),
+        )
+        single_state_g_parity = (
+            ingoing_edge_qns[0].g_parity.value
+            if ingoing_edge_qns[0].g_parity
+            else None
+        )
 
-        Implements for :math:`G_{in} = G_{out}`.
-        """
-        no_g_parity_in_part = [
-            True for x in ingoing_edge_qns if x.g_parity is None
-        ]
-        no_g_parity_out_part = [
-            True for x in outgoing_edge_qns if x.g_parity is None
-        ]
-        # if all states have G parity defined, then just multiply them
-        if not any(no_g_parity_in_part + no_g_parity_out_part):
-            in_g_parity = reduce(
-                lambda x, y: x * y.g_parity.value if y.g_parity else x,
-                ingoing_edge_qns,
-                1,
-            )
-            out_g_parity = reduce(
-                lambda x, y: x * y.g_parity.value if y.g_parity else x,
-                outgoing_edge_qns,
-                1,
-            )
-            return in_g_parity == out_g_parity
+        if not couple_state_g_parity or not single_state_g_parity:
+            return True
+        return couple_state_g_parity == single_state_g_parity
 
-        # two particle case
-        def check_multistate_g_parity(
-            isospin: EdgeQuantumNumbers.isospin_magnitude,
-            double_state_qns: Tuple[GParityEdgeInput, GParityEdgeInput],
-        ) -> Optional[int]:
-            if _is_particle_antiparticle_pair(
-                double_state_qns[0].pid, double_state_qns[1].pid
-            ):
-                ang_mom = interaction_qns.l_mag
-                if isinstance(isospin, int) or isospin.is_integer():
-                    # if boson
-                    if _is_boson(double_state_qns[0].spin_mag):
-                        return (-1) ** int(ang_mom + isospin)
-                    coupled_spin = interaction_qns.s_mag
-                    if (
-                        isinstance(coupled_spin, int)
-                        or coupled_spin.is_integer()
-                    ):
-                        return (-1) ** int(ang_mom + coupled_spin + isospin)
-            return None
+    no_g_parity_in_part = [
+        True for x in ingoing_edge_qns if x.g_parity is None
+    ]
+    no_g_parity_out_part = [
+        True for x in outgoing_edge_qns if x.g_parity is None
+    ]
+    # if all states have G parity defined, then just multiply them
+    if not any(no_g_parity_in_part + no_g_parity_out_part):
+        in_g_parity = reduce(
+            lambda x, y: x * y.g_parity.value if y.g_parity else x,
+            ingoing_edge_qns,
+            1,
+        )
+        out_g_parity = reduce(
+            lambda x, y: x * y.g_parity.value if y.g_parity else x,
+            outgoing_edge_qns,
+            1,
+        )
+        return in_g_parity == out_g_parity
 
-        def check_g_parity_isobar(
-            single_state: GParityEdgeInput,
-            couple_state: Tuple[GParityEdgeInput, GParityEdgeInput],
-        ) -> bool:
-            couple_state_g_parity = check_multistate_g_parity(
-                single_state.isospin,
-                (couple_state[0], couple_state[1]),
-            )
-            single_state_g_parity = (
-                ingoing_edge_qns[0].g_parity.value
-                if ingoing_edge_qns[0].g_parity
-                else None
-            )
+    # two particle case
+    particle_counts = (len(ingoing_edge_qns), len(outgoing_edge_qns))
+    if particle_counts == (1, 2):
+        return check_g_parity_isobar(
+            ingoing_edge_qns[0],
+            (outgoing_edge_qns[0], outgoing_edge_qns[1]),
+        )
 
-            if not couple_state_g_parity or not single_state_g_parity:
-                return True
-            return couple_state_g_parity == single_state_g_parity
-
-        particle_counts = (len(ingoing_edge_qns), len(outgoing_edge_qns))
-        if particle_counts == (1, 2):
-            return check_g_parity_isobar(
-                ingoing_edge_qns[0],
-                (outgoing_edge_qns[0], outgoing_edge_qns[1]),
-            )
-
-        if particle_counts == (2, 1):
-            return check_g_parity_isobar(
-                outgoing_edge_qns[0],
-                (ingoing_edge_qns[0], ingoing_edge_qns[1]),
-            )
-        return True
+    if particle_counts == (2, 1):
+        return check_g_parity_isobar(
+            outgoing_edge_qns[0],
+            (ingoing_edge_qns[0], ingoing_edge_qns[1]),
+        )
+    return True
 
 
 @attr.s(frozen=True)
@@ -390,42 +387,39 @@ class IdenticalParticleSymmetryEdgeInput:
     pid: EdgeQuantumNumbers.pid = attr.ib()
 
 
-class IdenticalParticleSymmetrization(Rule):
-    def __call__(  # type: ignore
-        self,
-        ingoing_edge_qns: List[IdenticalParticleSymmetryEdgeInput],
-        outgoing_edge_qns: List[IdenticalParticleSymmetryEdgeInput],
-        _=None,
+def identical_particle_symmetrization(
+    ingoing_edge_qns: List[IdenticalParticleSymmetryEdgeInput],
+    outgoing_edge_qns: List[IdenticalParticleSymmetryEdgeInput],
+) -> bool:
+    """Implementation of particle symmetrization."""
+
+    def _check_particles_identical(
+        particles: List[IdenticalParticleSymmetryEdgeInput],
     ) -> bool:
-        """Implementation of particle symmetrization."""
-
-        def _check_particles_identical(
-            particles: List[IdenticalParticleSymmetryEdgeInput],
-        ) -> bool:
-            """Check if pids and spins match."""
-            reference_pid = particles[0].pid
-            reference_spin_proj = particles[0].spin_projection
-            for particle in particles[1:]:
-                if particle.pid != reference_pid:
-                    return False
-                if particle.spin_projection != reference_spin_proj:
-                    return False
-            return True
-
-        if _check_particles_identical(outgoing_edge_qns):
-            if _is_boson(outgoing_edge_qns[0].spin_magnitude):
-                # we have a boson, check if parity of mother is even
-                parity = ingoing_edge_qns[0].parity
-                if parity == -1:
-                    # if its odd then return False
-                    return False
-            else:
-                # its fermion
-                parity = ingoing_edge_qns[0].parity
-                if parity == 1:
-                    return False
-
+        """Check if pids and spins match."""
+        reference_pid = particles[0].pid
+        reference_spin_proj = particles[0].spin_projection
+        for particle in particles[1:]:
+            if particle.pid != reference_pid:
+                return False
+            if particle.spin_projection != reference_spin_proj:
+                return False
         return True
+
+    if _check_particles_identical(outgoing_edge_qns):
+        if _is_boson(outgoing_edge_qns[0].spin_magnitude):
+            # we have a boson, check if parity of mother is even
+            parity = ingoing_edge_qns[0].parity
+            if parity == -1:
+                # if its odd then return False
+                return False
+        else:
+            # its fermion
+            parity = ingoing_edge_qns[0].parity
+            if parity == 1:
+                return False
+
+    return True
 
 
 def _is_clebsch_gordan_coefficient_zero(
@@ -598,28 +592,28 @@ def _check_spin_valid(magnitude: float, projection: float) -> bool:
     return (magnitude - abs(projection)).is_integer()
 
 
-def _check_isospins_valid(isospins: List[IsoSpinEdgeInput]) -> bool:
-    for edge in isospins:
-        if not _check_spin_valid(
-            float(edge.isospin_mag), float(edge.isospin_proj)
-        ):
-            return False
+def _check_isospin_valid(isospin: IsoSpinEdgeInput) -> bool:
+    return _check_spin_valid(
+        float(isospin.isospin_mag), float(isospin.isospin_proj)
+    )
+
+
+def isospin_validity(
+    ingoing_edge_qns: List[IsoSpinEdgeInput],
+    outgoing_edge_qns: List[IsoSpinEdgeInput],
+) -> bool:
+    r"""Check for valid isospin magnitude and projection."""
+    if not all(
+        [_check_isospin_valid(x) for x in ingoing_edge_qns + outgoing_edge_qns]
+    ):
+        return False
     return True
 
 
-class IsoSpinValidity(Rule):
-    r"""Check for valid isospin magnitude and projection."""
-
-    def __call__(  # type: ignore
-        self,
-        ingoing_isospins: List[IsoSpinEdgeInput],
-        outgoing_isospins: List[IsoSpinEdgeInput],
-        _=None,
-    ) -> bool:
-        return _check_isospins_valid(ingoing_isospins + outgoing_isospins)
-
-
-class IsoSpinConservation(Rule):
+def isospin_conservation(
+    ingoing_isospins: List[IsoSpinEdgeInput],
+    outgoing_isospins: List[IsoSpinEdgeInput],
+) -> bool:
     r"""Check for isospin conservation.
 
     Implements
@@ -630,24 +624,19 @@ class IsoSpinConservation(Rule):
     Also checks :math:`I_{1,z} + I_{2,z} = I_z` and if Clebsch-Gordan
     coefficients are all 0.
     """
-
-    def __call__(  # type: ignore
-        self,
-        ingoing_isospins: List[IsoSpinEdgeInput],
-        outgoing_isospins: List[IsoSpinEdgeInput],
-        _=None,
-    ) -> bool:
-        if not sum([x.isospin_proj for x in ingoing_isospins]) == sum(
-            [x.isospin_proj for x in outgoing_isospins]
-        ):
-            return False
-        if not _check_isospins_valid(ingoing_isospins + outgoing_isospins):
-            return False
-        return _check_spin_couplings(
-            [Spin(x.isospin_mag, x.isospin_proj) for x in ingoing_isospins],
-            [Spin(x.isospin_mag, x.isospin_proj) for x in outgoing_isospins],
-            None,
-        )
+    if not sum([x.isospin_proj for x in ingoing_isospins]) == sum(
+        [x.isospin_proj for x in outgoing_isospins]
+    ):
+        return False
+    if not all(
+        [_check_isospin_valid(x) for x in ingoing_isospins + outgoing_isospins]
+    ):
+        return False
+    return _check_spin_couplings(
+        [Spin(x.isospin_mag, x.isospin_proj) for x in ingoing_isospins],
+        [Spin(x.isospin_mag, x.isospin_proj) for x in outgoing_isospins],
+        None,
+    )
 
 
 @attr.s
@@ -678,7 +667,11 @@ def _check_spins_valid(
     return True
 
 
-class SpinConservation(Rule):
+def spin_conservation(
+    ingoing_spins: List[SpinEdgeInput],
+    outgoing_spins: List[SpinEdgeInput],
+    interaction_qns: SpinNodeInput,
+) -> bool:
     r"""Check for spin conservation.
 
     Implements
@@ -694,48 +687,38 @@ class SpinConservation(Rule):
     Also checks :math:`M_1 + M_2 = M` and if Clebsch-Gordan coefficients
     are all 0.
     """
+    if not _check_spins_valid(ingoing_spins + outgoing_spins, interaction_qns):
+        return False
 
-    def __call__(
-        self,
-        ingoing_spins: List[SpinEdgeInput],
-        outgoing_spins: List[SpinEdgeInput],
-        interaction_qns: SpinNodeInput,
-    ) -> bool:
-        if not _check_spins_valid(
-            ingoing_spins + outgoing_spins, interaction_qns
-        ):
-            return False
+    # L and S can only be used if one side is a single state
+    # and the other side contains of two states (isobar)
+    # So do a full check if this is the case
+    if (len(ingoing_spins) == 1 and len(outgoing_spins) == 2) or (
+        len(ingoing_spins) == 2 and len(outgoing_spins) == 1
+    ):
 
-        # L and S can only be used if one side is a single state
-        # and the other side contains of two states (isobar)
-        # So do a full check if this is the case
-        if (len(ingoing_spins) == 1 and len(outgoing_spins) == 2) or (
-            len(ingoing_spins) == 2 and len(outgoing_spins) == 1
-        ):
-
-            return _check_spin_couplings(
-                [
-                    Spin(x.spin_magnitude, x.spin_projection)
-                    for x in ingoing_spins
-                ],
-                [
-                    Spin(x.spin_magnitude, x.spin_projection)
-                    for x in outgoing_spins
-                ],
-                interaction_qns,
-            )
-
-        # otherwise don't use S and L and just check magnitude
-        # are integral or non integral on both sides
-        return (
-            sum([float(x.spin_magnitude) for x in ingoing_spins]).is_integer()
-            == sum(
-                [float(x.spin_magnitude) for x in outgoing_spins]
-            ).is_integer()
+        return _check_spin_couplings(
+            [Spin(x.spin_magnitude, x.spin_projection) for x in ingoing_spins],
+            [
+                Spin(x.spin_magnitude, x.spin_projection)
+                for x in outgoing_spins
+            ],
+            interaction_qns,
         )
 
+    # otherwise don't use S and L and just check magnitude
+    # are integral or non integral on both sides
+    return (
+        sum([float(x.spin_magnitude) for x in ingoing_spins]).is_integer()
+        == sum([float(x.spin_magnitude) for x in outgoing_spins]).is_integer()
+    )
 
-class SpinConservationMagnitude(Rule):
+
+def spin_magnitude_conservation(
+    ingoing_spins: List[SpinEdgeInput],
+    outgoing_spins: List[SpinEdgeInput],
+    interaction_qns: SpinMagnitudeNodeInput,
+) -> bool:
     r"""Check for spin conservation.
 
     Implements
@@ -748,107 +731,91 @@ class SpinConservationMagnitude(Rule):
     .. math::
         |L - S| \leq J \leq |L + S|
     """
+    if not _check_spins_valid(ingoing_spins + outgoing_spins, None):
+        return False
 
-    def __call__(
-        self,
-        ingoing_spins: List[SpinEdgeInput],
-        outgoing_spins: List[SpinEdgeInput],
-        interaction_qns: SpinMagnitudeNodeInput,
-    ) -> bool:
-        if not _check_spins_valid(ingoing_spins + outgoing_spins, None):
-            return False
-
-        # L and S can only be used if one side is a single state
-        # and the other side contains of two states (isobar)
-        # So do a full check if this is the case
-        if (len(ingoing_spins) == 1 and len(outgoing_spins) == 2) or (
-            len(ingoing_spins) == 2 and len(outgoing_spins) == 1
-        ):
-            return _check_magnitude(
-                [x.spin_magnitude for x in ingoing_spins],
-                [x.spin_magnitude for x in outgoing_spins],
-                interaction_qns,
-            )
-
-        # otherwise don't use S and L and just check magnitude
-        # are integral or non integral on both sides
-        return (
-            sum([float(x.spin_magnitude) for x in ingoing_spins]).is_integer()
-            == sum(
-                [float(x.spin_magnitude) for x in outgoing_spins]
-            ).is_integer()
+    # L and S can only be used if one side is a single state
+    # and the other side contains of two states (isobar)
+    # So do a full check if this is the case
+    if (len(ingoing_spins) == 1 and len(outgoing_spins) == 2) or (
+        len(ingoing_spins) == 2 and len(outgoing_spins) == 1
+    ):
+        return _check_magnitude(
+            [x.spin_magnitude for x in ingoing_spins],
+            [x.spin_magnitude for x in outgoing_spins],
+            interaction_qns,
         )
 
-
-class ClebschGordanCheckHelicityToCanonical(Rule):
-    def __call__(
-        self,
-        ingoing_spins: List[SpinEdgeInput],
-        outgoing_spins: List[SpinEdgeInput],
-        interaction_qns: SpinNodeInput,
-    ) -> bool:
-        """Implement Clebsch-Gordan checks.
-
-        For :math:`S_1, S_2` to :math:`S` and the :math:`L,S` to :math:`J` coupling
-        based on the conversion of helicity to canonical amplitude sums.
-        """
-        if len(ingoing_spins) == 1 and len(outgoing_spins) == 2:
-            if not _check_spins_valid(
-                ingoing_spins + outgoing_spins, interaction_qns
-            ):
-                return False
-
-            out_spin1 = Spin(
-                outgoing_spins[0].spin_magnitude,
-                outgoing_spins[0].spin_projection,
-            )
-            out_spin2 = Spin(
-                outgoing_spins[1].spin_magnitude,
-                -outgoing_spins[1].spin_projection,
-            )
-
-            helicity_diff = out_spin1.projection + out_spin2.projection
-            ang_mom = Spin(
-                interaction_qns.l_magnitude, interaction_qns.l_projection
-            )
-            coupled_spin = Spin(
-                interaction_qns.s_magnitude, interaction_qns.s_projection
-            )
-            parent_spin = ingoing_spins[0].spin_magnitude
-            try:
-                coupled_spin = Spin(coupled_spin.magnitude, helicity_diff)
-                in_spin = Spin(parent_spin, helicity_diff)
-            except ValueError:
-                return False
-            if _is_clebsch_gordan_coefficient_zero(
-                out_spin1, out_spin2, coupled_spin
-            ):
-                return False
-
-            return not _is_clebsch_gordan_coefficient_zero(
-                ang_mom, coupled_spin, in_spin
-            )
-        return False
+    # otherwise don't use S and L and just check magnitude
+    # are integral or non integral on both sides
+    return (
+        sum([float(x.spin_magnitude) for x in ingoing_spins]).is_integer()
+        == sum([float(x.spin_magnitude) for x in outgoing_spins]).is_integer()
+    )
 
 
-class HelicityConservation(Rule):
-    def __call__(  # type: ignore
-        self,
-        ingoing_spin_mags: List[EdgeQuantumNumbers.spin_magnitude],
-        outgoing_helicities: List[EdgeQuantumNumbers.spin_projection],
-        _=None,
-    ) -> bool:
-        r"""Implementation of helicity conservation.
+def clebsch_gordan_helicity_to_canonical(
+    ingoing_spins: List[SpinEdgeInput],
+    outgoing_spins: List[SpinEdgeInput],
+    interaction_qns: SpinNodeInput,
+) -> bool:
+    """Implement Clebsch-Gordan checks.
 
-        Check for :math:`|\lambda_2-\lambda_3| \leq S_1`.
-        """
-        if len(ingoing_spin_mags) == 1 and len(outgoing_helicities) == 2:
-            mother_spin = ingoing_spin_mags[0]
-            if mother_spin >= abs(
-                outgoing_helicities[0] - outgoing_helicities[1]
-            ):
-                return True
-        return False
+    For :math:`S_1, S_2` to :math:`S` and the :math:`L,S` to :math:`J`
+    coupling based on the conversion of helicity to canonical amplitude sums.
+    """
+    if len(ingoing_spins) == 1 and len(outgoing_spins) == 2:
+        if not _check_spins_valid(
+            ingoing_spins + outgoing_spins, interaction_qns
+        ):
+            return False
+
+        out_spin1 = Spin(
+            outgoing_spins[0].spin_magnitude,
+            outgoing_spins[0].spin_projection,
+        )
+        out_spin2 = Spin(
+            outgoing_spins[1].spin_magnitude,
+            -outgoing_spins[1].spin_projection,
+        )
+
+        helicity_diff = out_spin1.projection + out_spin2.projection
+        ang_mom = Spin(
+            interaction_qns.l_magnitude, interaction_qns.l_projection
+        )
+        coupled_spin = Spin(
+            interaction_qns.s_magnitude, interaction_qns.s_projection
+        )
+        parent_spin = ingoing_spins[0].spin_magnitude
+        try:
+            coupled_spin = Spin(coupled_spin.magnitude, helicity_diff)
+            in_spin = Spin(parent_spin, helicity_diff)
+        except ValueError:
+            return False
+        if _is_clebsch_gordan_coefficient_zero(
+            out_spin1, out_spin2, coupled_spin
+        ):
+            return False
+
+        return not _is_clebsch_gordan_coefficient_zero(
+            ang_mom, coupled_spin, in_spin
+        )
+    return False
+
+
+def helicity_conservation(
+    ingoing_spin_mags: List[EdgeQuantumNumbers.spin_magnitude],
+    outgoing_helicities: List[EdgeQuantumNumbers.spin_projection],
+) -> bool:
+    r"""Implementation of helicity conservation.
+
+    Check for :math:`|\lambda_2-\lambda_3| \leq S_1`.
+    """
+    if len(ingoing_spin_mags) == 1 and len(outgoing_helicities) == 2:
+        mother_spin = ingoing_spin_mags[0]
+        if mother_spin >= abs(outgoing_helicities[0] - outgoing_helicities[1]):
+            return True
+    return False
 
 
 @attr.s(frozen=True)
@@ -870,47 +837,44 @@ class GellMannNishijimaEdgeInput:
     tau_ln: Optional[EdgeQuantumNumbers.tau_lepton_number] = attr.ib(None)
 
 
-class GellMannNishijimaRule(Rule):
-    def __call__(  # type: ignore
-        self,
-        ingoing_edge_qns: List[GellMannNishijimaEdgeInput],
-        outgoing_edge_qns: List[GellMannNishijimaEdgeInput],
-        _=None,
-    ) -> bool:
-        r"""Check the Gell-Mann–Nishijima formula.
+def gellmann_nishijima(
+    ingoing_edge_qns: List[GellMannNishijimaEdgeInput],
+    outgoing_edge_qns: List[GellMannNishijimaEdgeInput],
+) -> bool:
+    r"""Check the Gell-Mann–Nishijima formula.
 
-        :math:`Q=I_3+\frac{Y}{2}` for each particle.
-        """
+    :math:`Q=I_3+\frac{Y}{2}` for each particle.
+    """
 
-        def calculate_hypercharge(
-            particle: GellMannNishijimaEdgeInput,
-        ) -> float:
-            """Calculate the hypercharge :math:`Y=S+C+B+T+B`."""
-            return sum(
-                [
-                    0.0 if x is None else x
-                    for x in [
-                        particle.strangeness,
-                        particle.charmness,
-                        particle.bottomness,
-                        particle.topness,
-                        particle.baryon_number,
-                    ]
+    def calculate_hypercharge(
+        particle: GellMannNishijimaEdgeInput,
+    ) -> float:
+        """Calculate the hypercharge :math:`Y=S+C+B+T+B`."""
+        return sum(
+            [
+                0.0 if x is None else x
+                for x in [
+                    particle.strangeness,
+                    particle.charmness,
+                    particle.bottomness,
+                    particle.topness,
+                    particle.baryon_number,
                 ]
-            )
+            ]
+        )
 
-        for particle in ingoing_edge_qns + outgoing_edge_qns:
-            if particle.electron_ln or particle.muon_ln or particle.tau_ln:
-                # if particle is a lepton then skip the check
-                continue
-            isospin_3 = 0.0
-            if particle.isospin_proj:
-                isospin_3 = particle.isospin_proj
-            if float(particle.charge) != (
-                isospin_3 + 0.5 * calculate_hypercharge(particle)
-            ):
-                return False
-        return True
+    for particle in ingoing_edge_qns + outgoing_edge_qns:
+        if particle.electron_ln or particle.muon_ln or particle.tau_ln:
+            # if particle is a lepton then skip the check
+            continue
+        isospin_3 = 0.0
+        if particle.isospin_proj:
+            isospin_3 = particle.isospin_proj
+        if float(particle.charge) != (
+            isospin_3 + 0.5 * calculate_hypercharge(particle)
+        ):
+            return False
+    return True
 
 
 @attr.s(frozen=True)
@@ -919,18 +883,16 @@ class MassEdgeInput:
     width: Optional[EdgeQuantumNumbers.width] = attr.ib(default=None)
 
 
-class MassConservation(Rule):
+class MassConservation:
     """Mass conservation rule."""
 
     def __init__(self, width_factor: float):
         self.__width_factor = width_factor
-        super().__init__()
 
-    def __call__(  # type: ignore
+    def __call__(
         self,
         ingoing_edge_qns: List[MassEdgeInput],
         outgoing_edge_qns: List[MassEdgeInput],
-        _=None,
     ) -> bool:
         r"""Implements mass conservation.
 

--- a/expertsystem/reaction/quantum_numbers.py
+++ b/expertsystem/reaction/quantum_numbers.py
@@ -25,7 +25,8 @@ class EdgeQuantumNumbers:  # pylint: disable=too-many-instance-attributes
     `.additive_quantum_number_rule`. You can also create data classes (see
     `attr.s`) with data members that are typed as the data members of
     `.EdgeQuantumNumbers` (see for example `.HelicityParityEdgeInput`) and use
-    them in conservation rules that derive from `.Rule`.
+    them in conservation rules that satisfy the appropriate rule protocol (see
+    `.ConservationRule`, `.EdgeQNConservationRule`).
     """
 
     pid = NewType("pid", int)

--- a/expertsystem/reaction/solving.py
+++ b/expertsystem/reaction/solving.py
@@ -117,9 +117,8 @@ def convert_to_names(
 class Result:
     """Defines a result to a problem set processed by the solving code.
 
-    Args:
-        `violated_rules`: A tuple of rules defines a group, which together
-          violate all quantum number combinations that were processed.
+    The tuple of rules in `violated_rules` defines a group, which together
+    violate all quantum number combinations that were processed.
     """
 
     def __init__(

--- a/expertsystem/reaction/solving.py
+++ b/expertsystem/reaction/solving.py
@@ -91,8 +91,6 @@ class GraphSettings:
     node_settings: Dict[int, NodeSettings] = attr.ib(factory=dict)
 
 
-# a tuple of rules defines a group which together violates all possible
-# combinations that were processed
 def convert_to_names(
     rules: Union[
         Dict[int, Set[Tuple[Rule, ...]]], Dict[int, Set[Tuple[str, ...]]]
@@ -117,6 +115,13 @@ def convert_to_names(
 
 
 class Result:
+    """Defines a result to a problem set processed by the solving code.
+
+    Args:
+        `violated_rules`: A tuple of rules defines a group, which together
+          violate all quantum number combinations that were processed.
+    """
+
     def __init__(
         self,
         solutions: Optional[

--- a/expertsystem/reaction/solving.py
+++ b/expertsystem/reaction/solving.py
@@ -9,6 +9,8 @@ belonging to an intermediate state) and validate the decay processes with the
 rules formulated by the :mod:`.conservation_rules` module.
 """
 
+
+import inspect
 import logging
 from abc import ABC, abstractmethod
 from collections import defaultdict
@@ -27,7 +29,15 @@ from constraint import (
 
 from expertsystem.particle import Parity, Particle, ParticleCollection, Spin
 
-from .conservation_rules import IsoSpinValidity, Rule
+from .argument_handling import (
+    GraphEdgePropertyMap,
+    GraphNodePropertyMap,
+    Rule,
+    RuleArgumentHandler,
+    Scalar,
+    get_required_qns,
+)
+from .conservation_rules import isospin_validity
 from .quantum_numbers import (
     EdgeQuantumNumber,
     EdgeQuantumNumbers,
@@ -36,8 +46,6 @@ from .quantum_numbers import (
     ParticleWithSpin,
 )
 from .topology import StateTransitionGraph
-
-Scalar = Union[int, float]
 
 
 class InteractionTypes(Enum):
@@ -53,7 +61,7 @@ class EdgeSettings:
     """Solver settings for a specific edge of a graph."""
 
     conservation_rules: Set[Rule] = attr.ib(factory=set)
-    rule_priorities: Dict[Type[Rule], int] = attr.ib(factory=dict)
+    rule_priorities: Dict[Rule, int] = attr.ib(factory=dict)
     qn_domains: Dict[Any, Any] = attr.ib(factory=dict)
 
 
@@ -72,7 +80,7 @@ class NodeSettings:
     """
 
     conservation_rules: Set[Rule] = attr.ib(factory=set)
-    rule_priorities: Dict[Type[Rule], int] = attr.ib(factory=dict)
+    rule_priorities: Dict[Rule, int] = attr.ib(factory=dict)
     qn_domains: Dict[Any, Any] = attr.ib(factory=dict)
     interaction_strength: float = 1.0
 
@@ -83,6 +91,31 @@ class GraphSettings:
     node_settings: Dict[int, NodeSettings] = attr.ib(factory=dict)
 
 
+# a tuple of rules defines a group which together violates all possible
+# combinations that were processed
+def convert_to_names(
+    rules: Union[
+        Dict[int, Set[Tuple[Rule, ...]]], Dict[int, Set[Tuple[str, ...]]]
+    ]
+) -> Dict[int, Set[Tuple[str, ...]]]:
+    def get_name(rule: Any) -> str:
+        if inspect.isfunction(rule):
+            return rule.__name__
+        if isinstance(rule, str):
+            return rule
+        return rule.__class__.__name__
+
+    converted_dict = {}
+    for node_id, rule_set in rules.items():
+        rule_name_set = set()
+        for rule_tuple in rule_set:
+            rule_name_set.add(tuple(get_name(rule) for rule in rule_tuple))
+
+        converted_dict[node_id] = rule_name_set
+
+    return converted_dict
+
+
 class Result:
     def __init__(
         self,
@@ -90,7 +123,12 @@ class Result:
             List[StateTransitionGraph[ParticleWithSpin]]
         ] = None,
         not_executed_rules: Optional[Dict[int, Set[Rule]]] = None,
-        violated_rules: Optional[Dict[int, Set[Tuple[Rule]]]] = None,
+        violated_rules: Optional[
+            Union[
+                Dict[int, Set[Tuple[Rule, ...]]],
+                Dict[int, Set[Tuple[str, ...]]],
+            ]
+        ] = None,
         formalism_type: Optional[str] = None,
     ) -> None:
         if solutions and violated_rules:
@@ -107,11 +145,11 @@ class Result:
         if not_executed_rules is not None:
             self.__not_executed_rules = not_executed_rules
 
-        # a tuple of rules defines a group which together violates all possible
-        # combinations that were processed
-        self.__violated_rules: Dict[int, Set[Tuple[Rule]]] = defaultdict(set)
+        self.__violated_rules: Dict[int, Set[Tuple[str, ...]]] = defaultdict(
+            set
+        )
         if violated_rules is not None:
-            self.__violated_rules = violated_rules
+            self.__violated_rules = convert_to_names(violated_rules)
 
     @property
     def formalism_type(self) -> Optional[str]:
@@ -126,7 +164,7 @@ class Result:
         return self.__not_executed_rules
 
     @property
-    def violated_rules(self) -> Dict[int, Set[Tuple[Rule]]]:
+    def violated_rules(self) -> Dict[int, Set[Tuple[str, ...]]]:
         return self.__violated_rules
 
     def extend(
@@ -212,228 +250,6 @@ class Solver(ABC):
           Result: contains possible solutions, violated rules and not executed
           rules due to requirement issues.
         """
-
-
-def _is_optional(
-    field_type: Union[EdgeQuantumNumber, NodeQuantumNumber]
-) -> bool:
-    if (
-        hasattr(field_type, "__origin__")
-        and getattr(field_type, "__origin__") is Union  # noqa: B009
-        and type(None) in getattr(field_type, "__args__")  # noqa: B009
-    ):
-        return True
-    return False
-
-
-_GraphEdgePropertyMap = Dict[Type[EdgeQuantumNumber], Any]
-_GraphNodePropertyMap = Dict[Type[NodeQuantumNumber], Any]
-_GraphElementPropertyMap = Union[_GraphEdgePropertyMap, _GraphNodePropertyMap]
-
-
-def _init_class(
-    class_type: Type,
-    props: _GraphElementPropertyMap,
-) -> object:
-    return class_type(
-        **{
-            class_field.name: _extract_value(props, class_field.type)
-            for class_field in attr.fields(class_type)
-        }
-    )
-
-
-def _extract_value(
-    props: _GraphElementPropertyMap,
-    obj_type: Any,
-) -> Any:
-    if _is_optional(obj_type):
-        obj_type = obj_type.__args__[0]
-        if obj_type in props:
-            value = props[obj_type]
-        else:
-            return None
-    else:
-        value = props[obj_type]
-
-    if (
-        "__supertype__" in obj_type.__dict__
-        and obj_type.__supertype__ == Parity
-    ):
-        return obj_type.__supertype__(value)
-    return obj_type(value)
-
-
-def _check_arg_requirements(
-    class_type: type,
-    props: _GraphElementPropertyMap,
-) -> bool:
-    if attr.has(class_type):
-        return all(
-            [
-                bool(class_field.type in props)
-                for class_field in attr.fields(class_type)
-                if not _is_optional(class_field.type)  # type: ignore
-            ]
-        )
-
-    return class_type in props
-
-
-def _check_requirements(
-    rule: Rule,
-    in_edge_props: Sequence[_GraphEdgePropertyMap],
-    out_edge_props: Sequence[_GraphEdgePropertyMap],
-    node_props: _GraphNodePropertyMap,
-) -> bool:
-    if not hasattr(rule.__class__.__call__, "__annotations__"):
-        raise TypeError(
-            f"missing type annotations for __call__ of rule {rule.__class__.__name__}"
-        )
-    arg_counter = 1
-    rule_annotations = _remove_return_annotation(
-        list(rule.__class__.__call__.__annotations__.values())
-    )
-    for arg_type, props in zip(
-        rule_annotations,
-        (in_edge_props, out_edge_props, node_props),
-    ):
-        if arg_counter == 3:
-            if not _check_arg_requirements(arg_type, props):  # type: ignore
-                return False
-        else:
-            if not all(
-                [
-                    _check_arg_requirements(arg_type.__args__[0], x)
-                    for x in props  # type: ignore
-                ]
-            ):
-                return False
-        arg_counter += 1
-
-    return True
-
-
-def _create_rule_edge_arg(
-    input_type: Type[Any],
-    edge_props: Sequence[_GraphEdgePropertyMap],
-) -> List[Any]:
-    # pylint: disable=unidiomatic-typecheck
-    if not isinstance(edge_props, (list, tuple)):
-        raise TypeError("edge_props are incompatible...")
-    if not (type(input_type) is list or type(input_type) is tuple):
-        raise TypeError("input type is incompatible...")
-    in_list_type = input_type[0]
-
-    if attr.has(in_list_type):
-        # its a composite type -> create new class type here
-        return [_init_class(in_list_type, x) for x in edge_props if x]
-    return [_extract_value(x, in_list_type) for x in edge_props if x]
-
-
-def _create_rule_node_arg(
-    input_type: Type[Any],
-    node_props: _GraphNodePropertyMap,
-) -> Any:
-    # pylint: disable=unidiomatic-typecheck
-    if isinstance(node_props, (list, tuple)):
-        raise TypeError("node_props is incompatible...")
-    if type(input_type) is list or type(input_type) is tuple:
-        raise TypeError("input type is incompatible...")
-
-    if attr.has(input_type):
-        # its a composite type -> create new class type here
-        return _init_class(input_type, node_props)
-    return _extract_value(node_props, input_type)
-
-
-def _create_rule_args(
-    rule: Rule,
-    in_edge_props: Sequence[_GraphEdgePropertyMap],
-    out_edge_props: Sequence[_GraphEdgePropertyMap],
-    node_props: _GraphNodePropertyMap,
-) -> list:
-    if not hasattr(rule.__class__.__call__, "__annotations__"):
-        raise TypeError(
-            f"missing type annotations for __call__ of rule {str(rule)}"
-        )
-    args = []
-    arg_counter = 0
-    rule_annotations = list(rule.__class__.__call__.__annotations__.values())
-    rule_annotations = _remove_return_annotation(rule_annotations)
-
-    ordered_props = (in_edge_props, out_edge_props, node_props)
-    for arg_type in rule_annotations:
-        if arg_counter == 2:
-            args.append(
-                _create_rule_node_arg(
-                    arg_type,
-                    ordered_props[arg_counter],  # type: ignore
-                )
-            )
-        else:
-            args.append(
-                _create_rule_edge_arg(
-                    arg_type.__args__,
-                    ordered_props[arg_counter],  # type: ignore
-                )
-            )
-        arg_counter += 1
-    if arg_counter == 2:
-        # the rule does not use the third argument, just add None
-        args.append(None)
-
-    return args
-
-
-def _remove_return_annotation(
-    rule_annotations: List[Type[Any]],
-) -> List[Type[Any]]:
-    # this assumes that all rules have also the return type defined
-    return rule_annotations[:-1]
-
-
-def _get_required_qns(
-    rule: Rule,
-) -> Tuple[Set[Type[EdgeQuantumNumber]], Set[Type[NodeQuantumNumber]]]:
-    if not hasattr(rule.__class__.__call__, "__annotations__"):
-        raise TypeError(
-            f"missing type annotations for __call__ of rule {rule.__class__.__name__}"
-        )
-
-    required_edge_qns: Set[Type[EdgeQuantumNumber]] = set()
-    required_node_qns: Set[Type[NodeQuantumNumber]] = set()
-
-    rule_annotations = list(rule.__class__.__call__.__annotations__.values())
-    rule_annotations = _remove_return_annotation(rule_annotations)
-
-    arg_counter = 0
-    for input_type in rule_annotations:
-        qn_set = required_edge_qns
-        if arg_counter == 2:
-            qn_set = required_node_qns  # type: ignore
-
-        class_type = input_type
-        if "__origin__" in input_type.__dict__ and (
-            input_type.__origin__ is list
-            or input_type.__origin__ is tuple
-            or input_type.__origin__ is List
-            or input_type.__origin__ is Tuple
-        ):
-            class_type = input_type.__args__[0]
-
-        if attr.has(class_type):
-            for class_field in attr.fields(class_type):
-                qn_set.add(
-                    class_field.type.__args__[0]  # type: ignore
-                    if _is_optional(class_field.type)  # type: ignore
-                    else class_field.type
-                )
-        else:
-            qn_set.add(class_type)
-        arg_counter += 1
-
-    return (required_edge_qns, required_node_qns)
 
 
 def _merge_solutions_with_graph(
@@ -522,6 +338,8 @@ def validate_fully_initialized_graph(
 ) -> Result:
     logging.debug("validating graph...")
 
+    rule_argument_handler = RuleArgumentHandler()
+
     def _create_node_variables(
         node_id: int, qn_list: Set[Type[NodeQuantumNumber]]
     ) -> Dict[Type[NodeQuantumNumber], Scalar]:
@@ -564,7 +382,7 @@ def validate_fully_initialized_graph(
         in_edges = graph.get_edges_ingoing_to_node(node_id)
         out_edges = graph.get_edges_outgoing_from_node(node_id)
 
-        edge_qns, node_qns = _get_required_qns(cons_law)
+        edge_qns, node_qns = get_required_qns(cons_law)
         in_edges_vars = _create_edge_variables(in_edges, edge_qns)  # type: ignore
         out_edges_vars = _create_edge_variables(out_edges, edge_qns)  # type: ignore
 
@@ -572,24 +390,27 @@ def validate_fully_initialized_graph(
 
         return (in_edges_vars, out_edges_vars, node_vars)
 
-    node_violated_rules: Dict[int, Set[Tuple[Rule]]] = defaultdict(set)
+    node_violated_rules: Dict[int, Set[Tuple[Rule, ...]]] = defaultdict(set)
     node_not_executed_rules: Dict[int, Set[Rule]] = defaultdict(set)
     for node_id, rules in rules_per_node.items():
         for rule in rules:
             # get the needed qns for this conservation law
             # for all edges and the node
+            (
+                check_requirements,
+                create_rule_args,
+            ) = rule_argument_handler.register_rule(rule)
+
             var_containers = _create_variable_containers(node_id, rule)
             # check the requirements
-            if isinstance(rule, IsoSpinValidity) or _check_requirements(
-                rule,
+            if rule is isospin_validity or check_requirements(
                 var_containers[0],
                 var_containers[1],
                 var_containers[2],
             ):
                 # and run the rule check
                 if not rule(
-                    *_create_rule_args(
-                        rule,
+                    *create_rule_args(
                         var_containers[0],
                         var_containers[1],
                         var_containers[2],
@@ -671,7 +492,9 @@ class CSPSolver(Solver):
             node_id: set(x.rule for x in constraints)
             for node_id, constraints in self.__non_executable_constraints.items()
         }
-        not_satisfied_rules: Dict[int, Set[Tuple[Rule]]] = defaultdict(set)
+        not_satisfied_rules: Dict[int, Set[Tuple[Rule, ...]]] = defaultdict(
+            set
+        )
         for node_id, constraints in self.__constraints.items():
             for constraint in constraints:
                 if (
@@ -746,16 +569,15 @@ class CSPSolver(Solver):
             # and strip away the priorities again
             return [x[0] for x in sorted_list]
 
+        arg_handler = RuleArgumentHandler()
+
         for node_id in self.__graph.nodes:
-            # currently we only have rules related to graph nodes
-            # later on rules that are directly connected to edge can also be
-            # defined (GellmannNishijimaRule can be changed to that)
-            for cons_law in get_rules_by_priority(
+            for rule in get_rules_by_priority(
                 graph_settings.node_settings[node_id]
             ):
                 variable_mapping = _VariableContainer()
                 # from cons law and graph determine needed var lists
-                edge_qns, node_qns = _get_required_qns(cons_law)
+                edge_qns, node_qns = get_required_qns(rule)
 
                 in_edges = self.__graph.get_edges_ingoing_to_node(node_id)
                 in_edge_vars = self.__create_edge_variables(
@@ -788,8 +610,9 @@ class CSPSolver(Solver):
                 var_list.extend(list(variable_mapping.node_variables))
 
                 constraint = _ConservationRuleConstraintWrapper(
-                    cons_law,
+                    rule,
                     variable_mapping,
+                    arg_handler,
                 )
                 if var_list:
                     var_strings = [
@@ -926,17 +749,27 @@ class _ConservationRuleConstraintWrapper(Constraint):
     cleaner user interface.
     """
 
-    def __init__(self, rule: Rule, variables: _VariableContainer) -> None:
-        if not isinstance(rule, Rule):
-            raise TypeError("rule has to be of type Rule!")
+    # pylint: disable=too-many-instance-attributes
+    def __init__(
+        self,
+        rule: Rule,
+        variables: _VariableContainer,
+        argument_handler: RuleArgumentHandler,
+    ) -> None:
+        if not callable(rule):
+            raise TypeError("rule has to be a callable!")
         self.__rule = rule
+        (
+            self.__check_rule_requirements,
+            self.__create_rule_args,
+        ) = argument_handler.register_rule(rule)
         self.__var_string_to_data: Dict[
             str,
             Union[_EdgeVariableInfo, _NodeVariableInfo],
         ] = {}
-        self.__in_edges_qns: Dict[int, _GraphEdgePropertyMap] = {}
-        self.__out_edges_qns: Dict[int, _GraphEdgePropertyMap] = {}
-        self.__node_qns: _GraphNodePropertyMap = {}
+        self.__in_edges_qns: Dict[int, GraphEdgePropertyMap] = {}
+        self.__out_edges_qns: Dict[int, GraphEdgePropertyMap] = {}
+        self.__node_qns: GraphNodePropertyMap = {}
 
         self.conditions_never_met = False
         self.scenario_results = [0, 0]
@@ -961,9 +794,9 @@ class _ConservationRuleConstraintWrapper(Constraint):
         def _initialize_edge_container(
             variable_set: Set[_EdgeVariableInfo],
             fixed_variables: Dict[int, Dict[Type[EdgeQuantumNumber], Scalar]],
-            container: Dict[int, _GraphEdgePropertyMap],
+            container: Dict[int, GraphEdgePropertyMap],
         ) -> None:
-            container.update(fixed_variables)
+            container.update(fixed_variables)  # type: ignore
             for element_id, qn_type in variable_set:
                 self.__var_string_to_data[
                     _create_variable_string(element_id, qn_type)
@@ -1032,19 +865,20 @@ class _ConservationRuleConstraintWrapper(Constraint):
             return True
 
         self.__update_variable_lists(params)
-        if not isinstance(self.rule, IsoSpinValidity):
-            if not _check_requirements(
-                self.__rule,
+
+        if (
+            self.rule is not isospin_validity
+            and not self.__check_rule_requirements(
                 list(self.__in_edges_qns.values()),
                 list(self.__out_edges_qns.values()),
                 self.__node_qns,
-            ):
-                self.conditions_never_met = True
-                return True
+            )
+        ):
+            self.conditions_never_met = True
+            return True
 
         passed = self.__rule(
-            *_create_rule_args(
-                self.__rule,
+            *self.__create_rule_args(
                 list(self.__in_edges_qns.values()),
                 list(self.__out_edges_qns.values()),
                 self.__node_qns,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "setuptools>=36.0.0", #
+    "setuptools>=36.2.1", # environment markers
     "setuptools_scm",
     "wheel",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "setuptools>=30.3.0",
+    "setuptools>=36.0.0", #
     "setuptools_scm",
     "wheel",
 ]

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,6 +44,7 @@ install_requires =
     python-constraint==1.4.0
     PyYAML==5.3
     xmltodict==0.12.0
+    typing_extensions==3.7.4.3; python_version < 3.8.0
 packages = find:
 
 [options.packages.find]

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,7 @@ install_requires =
     python-constraint==1.4.0
     PyYAML==5.3
     xmltodict==0.12.0
-    typing_extensions==3.7.4.3; python_version < 3.8.0
+    typing_extensions==3.7.4.3; python_version < "3.8.0"
 packages = find:
 
 [options.packages.find]

--- a/tests/channels/test_nbody_reactions.py
+++ b/tests/channels/test_nbody_reactions.py
@@ -8,16 +8,15 @@ from expertsystem.reaction import (
     SolvingMode,
     StateTransitionManager,
 )
-from expertsystem.reaction.solving import Rule
 
 
 def reduce_violated_rules(
-    violated_rules: Dict[int, Set[Tuple[Rule]]]
+    violated_rules: Dict[int, Set[Tuple[str, ...]]]
 ) -> Set[str]:
     reduced_violations = set()
     for rule_set in violated_rules.values():
         for rule_group in rule_set:
-            reduced_violations.update(set(str(x) for x in rule_group))
+            reduced_violations.update(set(x for x in rule_group))
 
     return reduced_violations
 
@@ -28,7 +27,7 @@ def reduce_violated_rules(
     [
         (
             (["p", "p~"], ["pi+", "pi0"]),
-            ["ChargeConservation", "IsoSpinConservation"],
+            ["ChargeConservation", "isospin_conservation"],
         ),
         ((["eta"], ["gamma", "gamma"]), []),
         ((["Sigma0"], ["Lambda", "pi0"]), ["MassConservation"]),
@@ -61,19 +60,19 @@ def reduce_violated_rules(
         ((["n", "n~"], ["pi+", "pi-", "pi0"]), []),
         (
             (["pi+", "n"], ["pi-", "p"]),
-            ["ChargeConservation", "IsoSpinConservation"],
+            ["ChargeConservation", "isospin_conservation"],
         ),
         ((["K-"], ["pi-", "pi0"]), []),
         (
             (["Sigma+", "n"], ["Sigma-", "p"]),
-            ["ChargeConservation", "IsoSpinConservation"],
+            ["ChargeConservation", "isospin_conservation"],
         ),
         ((["Sigma0"], ["Lambda", "gamma"]), []),
         ((["Xi-"], ["Lambda", "pi-"]), []),
         ((["Xi0"], ["p", "pi-"]), []),
         ((["pi-", "p"], ["Lambda", "K~0"]), []),
         ((["pi0"], ["gamma", "gamma"]), []),
-        ((["pi0"], ["gamma", "gamma", "gamma"]), ["CParityConservation"]),
+        ((["pi0"], ["gamma", "gamma", "gamma"]), ["c_parity_conservation"]),
         ((["Sigma-"], ["n", "e-", "nu(e)~"]), []),
         # (  # https://github.com/ComPWA/expertsystem/issues/281
         #     (["rho(770)0"], ["pi0", "pi0"]),
@@ -83,7 +82,7 @@ def reduce_violated_rules(
         #         "IdenticalParticleSymmetrization",
         #     ],
         # ),
-        ((["rho(770)0"], ["gamma", "gamma"]), ["CParityConservation"]),
+        ((["rho(770)0"], ["gamma", "gamma"]), ["c_parity_conservation"]),
         ((["rho(770)0"], ["gamma", "gamma", "gamma"]), []),
         ((["J/psi(1S)"], ["pi0", "eta"]), []),
         ((["J/psi(1S)"], ["rho(770)0", "rho(770)0"]), []),
@@ -128,7 +127,7 @@ def test_general_reaction(test_input, expected):
         ((["pi0"], ["gamma", "gamma"]), []),
         (
             (["pi0"], ["gamma", "gamma", "gamma"]),
-            ["CParityConservation"],
+            ["c_parity_conservation"],
         ),
         ((["pi0"], ["e+", "e-", "gamma"]), []),
         ((["pi0"], ["e+", "e-"]), []),

--- a/tests/unit/reaction/conservation_rules/test_additive_qn.py
+++ b/tests/unit/reaction/conservation_rules/test_additive_qn.py
@@ -8,6 +8,4 @@ from expertsystem.reaction.conservation_rules import ChargeConservation
     [(([0], [-1, 1]), True), (([0], [1, 1]), False)],
 )
 def test_charge_conservation(graph_input, expected_value):
-    rule = ChargeConservation()
-
-    assert rule(*graph_input) == expected_value
+    assert ChargeConservation()(*graph_input) == expected_value

--- a/tests/unit/reaction/conservation_rules/test_c_parity.py
+++ b/tests/unit/reaction/conservation_rules/test_c_parity.py
@@ -4,9 +4,9 @@ import pytest
 
 from expertsystem.particle import Parity
 from expertsystem.reaction.conservation_rules import (
-    CParityConservation,
     CParityEdgeInput,
     CParityNodeInput,
+    c_parity_conservation,
 )
 from expertsystem.reaction.quantum_numbers import (
     EdgeQuantumNumbers,
@@ -73,9 +73,7 @@ from expertsystem.reaction.quantum_numbers import (
     ],
 )
 def test_c_parity_all_defined(rule_input, expected):
-    rule = CParityConservation()
-
-    assert rule(*rule_input) is expected
+    assert c_parity_conservation(*rule_input) is expected
 
 
 @pytest.mark.parametrize(
@@ -111,9 +109,7 @@ def test_c_parity_all_defined(rule_input, expected):
     ],
 )
 def test_c_parity_multiparticle_boson(rule_input, expected):
-    rule = CParityConservation()
-
-    assert rule(*rule_input) is expected
+    assert c_parity_conservation(*rule_input) is expected
 
 
 @pytest.mark.parametrize(
@@ -151,6 +147,4 @@ def test_c_parity_multiparticle_boson(rule_input, expected):
     ],
 )
 def test_c_parity_multiparticle_fermion(rule_input, expected):
-    rule = CParityConservation()
-
-    assert rule(*rule_input) is expected
+    assert c_parity_conservation(*rule_input) is expected

--- a/tests/unit/reaction/conservation_rules/test_g_parity.py
+++ b/tests/unit/reaction/conservation_rules/test_g_parity.py
@@ -4,9 +4,9 @@ import pytest
 
 from expertsystem.particle import Parity
 from expertsystem.reaction.conservation_rules import (
-    GParityConservation,
     GParityEdgeInput,
     GParityNodeInput,
+    g_parity_conservation,
 )
 from expertsystem.reaction.quantum_numbers import (
     EdgeQuantumNumbers,
@@ -72,9 +72,7 @@ from expertsystem.reaction.quantum_numbers import (
     ],
 )
 def test_g_parity_all_defined(rule_input, expected):
-    g_parity_rule = GParityConservation()
-
-    assert g_parity_rule(*rule_input) is expected
+    assert g_parity_conservation(*rule_input) is expected
 
 
 @pytest.mark.parametrize(
@@ -113,6 +111,4 @@ def test_g_parity_all_defined(rule_input, expected):
     ],
 )
 def test_g_parity_multiparticle_boson(rule_input, expected):
-    g_parity_rule = GParityConservation()
-
-    assert g_parity_rule(*rule_input) is expected
+    assert g_parity_conservation(*rule_input) is expected

--- a/tests/unit/reaction/conservation_rules/test_spin.py
+++ b/tests/unit/reaction/conservation_rules/test_spin.py
@@ -4,12 +4,12 @@ import pytest
 
 from expertsystem.particle import Spin
 from expertsystem.reaction.conservation_rules import (
-    IsoSpinConservation,
     IsoSpinEdgeInput,
-    SpinConservation,
-    SpinConservationMagnitude,
     SpinEdgeInput,
     SpinNodeInput,
+    isospin_conservation,
+    spin_conservation,
+    spin_magnitude_conservation,
 )
 from expertsystem.reaction.quantum_numbers import (
     EdgeQuantumNumbers,
@@ -132,9 +132,7 @@ def __create_two_body_decay_spin_data(
 def test_spin_all_defined(
     rule_input: _SpinRuleInputType, expected: bool
 ) -> None:
-    spin_rule = SpinConservation()
-
-    assert spin_rule(*rule_input) is expected
+    assert spin_conservation(*rule_input) is expected
 
 
 @pytest.mark.parametrize(
@@ -226,9 +224,7 @@ def test_clebsch_gordan_ls_coupling(
     rule_input: _SpinRuleInputType,
     expected: bool,
 ):
-    spin_rule = SpinConservation()
-
-    assert spin_rule(*rule_input) is expected
+    assert spin_conservation(*rule_input) is expected
 
 
 @pytest.mark.parametrize(
@@ -267,9 +263,7 @@ def test_clebsch_gordan_ls_coupling(
 def test_spin_ignore_z_component(
     rule_input: _SpinRuleInputType, expected: bool
 ) -> None:
-    spin_rule = SpinConservationMagnitude()
-
-    assert spin_rule(*rule_input) is expected  # type: ignore
+    assert spin_magnitude_conservation(*rule_input) is expected  # type: ignore
 
 
 @pytest.mark.parametrize(
@@ -291,10 +285,8 @@ def test_isospin_clebsch_gordan_zeros(
     isospin_mag2: int,
     expected: bool,
 ) -> None:
-    isospin_rule = IsoSpinConservation()
-
     assert (
-        isospin_rule(
+        isospin_conservation(
             [IsoSpinEdgeInput(coupled_isospin_mag, 0)],  # type: ignore
             [
                 IsoSpinEdgeInput(isospin_mag1, 0),  # type: ignore


### PR DESCRIPTION
Extract the Rule argument handling code into a separate module. Also allow more flexible arguments and improve type annotation handling via inspect. Exchange the Rule interface with a `Protocol` (`ConservationRule`) and define a second type of Rule (`EdgeQNConservationRule`), which does not require any node quantum numbers.

This prepares things for issue #303 