### PR TITLE
fix: repair PreFactor key in YAML validation

### DIFF
--- a/expertsystem/schemas/yaml/amplitude-model.json
+++ b/expertsystem/schemas/yaml/amplitude-model.json
@@ -251,14 +251,7 @@
         "properties": {
           "Class": { "$ref": "#/definitions/Amplitude/_types" },
           "Component": { "type": "string" },
-          "PreFactor": {
-            "type": "object",
-            "properties": {
-              "Real": { "type": "number" },
-              "Imaginary": { "type": "number" }
-            },
-            "anyOf": [{ "required": ["Real"] }, { "required": ["Imaginary"] }]
-          },
+          "PreFactor": { "type": "number" },
           "Magnitude": { "type": "string" },
           "Phase": { "type": "string" },
           "Amplitude": { "$ref": "#/definitions/Amplitude/_recursion" }


### PR DESCRIPTION
The JSON validation schema for YAML had a bug with regard to `PreFactor`.

Fix is simple, but it took some time, because I tried to write a test for this. Eventually I gave up with that, because I keep running in some `pytest` loops, see #.