### PR TITLE
feat: implement Result.get_particle_graphs

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,7 @@
 {
+  "[ipynb]": {
+    "editor.formatOnSave": false
+  },
   "[json]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
@@ -22,6 +25,7 @@
   "coverage-gutters.coverageReportFileName": "**/htmlcov/index.html",
   "coverage-gutters.showGutterCoverage": false,
   "coverage-gutters.showLineCoverage": true,
+  "editor.formatOnSave": true,
   "editor.rulers": [80],
   "files.associations": {
     "*.inc": "restructuredtext"

--- a/doc/usage/quickstart.ipynb
+++ b/doc/usage/quickstart.ipynb
@@ -252,7 +252,9 @@
     "\n",
     "    The \"number of `~.Result.solutions`\" is the total number of allowed `.StateTransitionGraph` instances that the `.StateTransitionManager` has found. This also includes all allowed **spin projection combinations**. In this channel, we for example consider a :math:`J/\\psi` with spin projection :math:`\\pm1` that decays into a :math:`\\gamma` with spin projection :math:`\\pm1`, which already gives us four possibilities.\n",
     "\n",
-    "    On the other hand, the intermediate state names that was extracted with `.Result.get_intermediate_particles`, is just a `set` of the state names on the intermediate edges of the list of `~.Result.solutions`, regardless of spin projection."
+    "    On the other hand, the intermediate state names that was extracted with `.Result.get_intermediate_particles`, is just a `set` of the state names on the intermediate edges of the list of `~.Result.solutions`, regardless of spin projection.\n",
+    "    \n",
+    "    .. tip:: Have a look at `.Result.get_particle_graphs`, if you want to extract a `list` of `.StateTransitionGraph` s of which the spin projections have been stripped. This is especially useful when :doc:`visualizing the decay topologies </usage/visualization>`."
    ]
   },
   {

--- a/doc/usage/visualization.ipynb
+++ b/doc/usage/visualization.ipynb
@@ -93,6 +93,17 @@
     "raw_mimetype": "text/restructuredtext"
    },
    "source": [
+    ".. margin::\n",
+    "\n",
+    "  .. warning:: `graphviz <graphviz.Source>` requires your system to have DOT installed, see :doc:`Installation <graphviz:index>`."
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {
+    "raw_mimetype": "text/restructuredtext"
+   },
+   "source": [
     "Finally, this `str` of `DOT language <https://graphviz.org/doc/info/lang.html>`_ for the list of `.StateTransitionGraph` instances can be visualized with a third-party library, for instance, with `graphviz.Source`:"
    ]
   },
@@ -105,16 +116,6 @@
     "import graphviz\n",
     "\n",
     "graphviz.Source(dot_source)"
-   ]
-  },
-  {
-   "cell_type": "raw",
-   "metadata": {
-    "raw_mimetype": "text/restructuredtext"
-   },
-   "source": [
-    ".. warning::\n",
-    "  `graphviz <graphviz.Source>` requires your system to have DOT installed, see :doc:`Installation <graphviz:index>`."
    ]
   },
   {

--- a/doc/usage/visualization.ipynb
+++ b/doc/usage/visualization.ipynb
@@ -41,7 +41,7 @@
     "stm = StateTransitionManager(\n",
     "    initial_state=[(\"J/psi(1S)\", [-1, 1])],\n",
     "    final_state=[\"gamma\", \"pi0\", \"pi0\"],\n",
-    "    allowed_intermediate_particles=[\"f(0)(980)\", \"f(0)(1500)\",],\n",
+    "    allowed_intermediate_particles=[\"f(0)\"],\n",
     ")\n",
     "stm.set_allowed_interaction_types([InteractionTypes.EM])\n",
     "graph_interaction_settings_groups = stm.prepare_graphs()\n",
@@ -54,7 +54,7 @@
     "raw_mimetype": "text/restructuredtext"
    },
    "source": [
-    "Now, we use the `~.io.convert_to_dot` function to create a `str` of DOT language for the list of `~.Result.solutions` (`.StateTransitionGraph` instances):"
+    ":ref:`As noted in the Quickstart <usage/quickstart:1.3. Find solutions>`, the `~.Result.solutions` contain all spin projection combinations (which is necessary for the `~expertsystem.amplitude` module). It is possible to convert all these solutions to DOT language with `.io.convert_to_dot`:"
    ]
   },
   {
@@ -65,7 +65,7 @@
    "source": [
     "from expertsystem import io\n",
     "\n",
-    "dot_source = io.convert_to_dot(result.solutions)"
+    "dot_source = io.convert_to_dot(result.solutions)  # with spin projections!"
    ]
   },
   {
@@ -74,7 +74,26 @@
     "raw_mimetype": "text/restructuredtext"
    },
    "source": [
-    "This `str` can then be visualized with a third-party library, for instance, with `graphviz.Source`:"
+    "However, since this list of all possible spin projections is rather long, it is often useful to make use of the `~.Result.get_particle_graphs` method first:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "graphs = result.get_particle_graphs()\n",
+    "dot_source = io.convert_to_dot(graphs)"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {
+    "raw_mimetype": "text/restructuredtext"
+   },
+   "source": [
+    "Finally, this `str` of `DOT language <https://graphviz.org/doc/info/lang.html>`_ for the list of `.StateTransitionGraph` instances can be visualized with a third-party library, for instance, with `graphviz.Source`:"
    ]
   },
   {
@@ -113,7 +132,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "io.write(instance=result.solutions, filename=\"decay_topologies.gv\")"
+    "io.write(result.solutions, \"decay_topologies_with_spin.gv\")\n",
+    "io.write(graphs, \"decay_topologies.gv\")"
    ]
   }
  ],

--- a/expertsystem/io/__init__.py
+++ b/expertsystem/io/__init__.py
@@ -67,6 +67,8 @@ def convert_to_dot(instance: object) -> str:
 
     Only works for objects that can be represented as a graph, particularly a
     `.StateTransitionGraph` or a `list` of `.StateTransitionGraph` instances.
+
+    .. seealso:: :doc:`/usage/visualization`
     """
     if isinstance(instance, (StateTransitionGraph, Topology)):
         return _dot.graph_to_dot(instance)

--- a/expertsystem/reaction/solving.py
+++ b/expertsystem/reaction/solving.py
@@ -220,6 +220,8 @@ class Result:
 
         Extract a `list` of `.StateTransitionGraph` instances with only
         particles on the edges.
+
+        .. seealso:: :doc:`/usage/visualization`
         """
         inventory: List[StateTransitionGraph[Particle]] = list()
         for graph in self.solutions:

--- a/expertsystem/reaction/solving.py
+++ b/expertsystem/reaction/solving.py
@@ -215,6 +215,32 @@ class Result:
                     intermediate_states.add(particle)
         return intermediate_states
 
+    def get_particle_graphs(self) -> List[StateTransitionGraph[Particle]]:
+        """Strip `list` of `.StateTransitionGraph` s of the spin projections.
+
+        Extract a `list` of `.StateTransitionGraph` instances with only
+        particles on the edges.
+        """
+        inventory: List[StateTransitionGraph[Particle]] = list()
+        for graph in self.solutions:
+            if any(
+                [
+                    graph.compare(
+                        other, edge_comparator=lambda e1, e2: e1[0] == e2
+                    )
+                    for other in inventory
+                ]
+            ):
+                continue
+            new_graph: StateTransitionGraph[
+                Particle
+            ] = StateTransitionGraph.from_topology(graph)
+            for i, edge_prop in graph.edge_props.items():
+                particle, _ = edge_prop
+                new_graph.edge_props[i] = particle
+            inventory.append(new_graph)
+        return inventory
+
 
 @attr.s(frozen=True)
 class _QuantumNumberSolution:

--- a/expertsystem/reaction/solving.py
+++ b/expertsystem/reaction/solving.py
@@ -239,6 +239,12 @@ class Result:
                 particle, _ = edge_prop
                 new_graph.edge_props[i] = particle
             inventory.append(new_graph)
+        inventory = sorted(
+            inventory,
+            key=lambda g: [
+                g.edge_props[i].mass for i in g.get_intermediate_state_edges()
+            ],
+        )
         return inventory
 
 

--- a/expertsystem/reaction/topology.py
+++ b/expertsystem/reaction/topology.py
@@ -12,6 +12,7 @@ import copy
 import itertools
 import logging
 from typing import (
+    Any,
     Callable,
     Dict,
     Generic,
@@ -365,6 +366,30 @@ class StateTransitionGraph(Topology, Generic[_EdgeType]):
     def from_topology(topology: Topology) -> "StateTransitionGraph":
         """Create a `StateTransitionGraph` from a `Topology`."""
         return StateTransitionGraph(topology.nodes, topology.edges)
+
+    def compare(
+        self,
+        other: "StateTransitionGraph",
+        edge_comparator: Optional[Callable[[Any, Any], bool]] = None,
+        node_comparator: Optional[Callable[[Any, Any], bool]] = None,
+    ) -> bool:
+        if self.nodes != other.nodes:
+            return False
+        if self.edges != other.edges:
+            return False
+        if edge_comparator is not None:
+            for i in self.edges:
+                if not edge_comparator(
+                    self.edge_props[i], other.edge_props[i]
+                ):
+                    return False
+        if node_comparator is not None:
+            for i in self.nodes:
+                if not node_comparator(
+                    self.node_props[i], other.node_props[i]
+                ):
+                    return False
+        return True
 
     def swap_edges(self, edge_id1: int, edge_id2: int) -> None:
         super().swap_edges(edge_id1, edge_id2)

--- a/tests/unit/io/test_dot.py
+++ b/tests/unit/io/test_dot.py
@@ -61,3 +61,18 @@ class TestWrite:
         with open(output_file, "r") as stream:
             dot_data = stream.read()
         assert pydot.graph_from_dot_data(dot_data) is not None
+
+    @staticmethod
+    def test_write_particle_graphs(
+        jpsi_to_gamma_pi_pi_helicity_solutions: Result,
+    ):
+        result = jpsi_to_gamma_pi_pi_helicity_solutions
+        particle_graphs = result.get_particle_graphs()
+        output_file = "test_particle_graphs.gv"
+        io.write(
+            instance=particle_graphs,
+            filename=output_file,
+        )
+        with open(output_file, "r") as stream:
+            dot_data = stream.read()
+        assert pydot.graph_from_dot_data(dot_data) is not None

--- a/tests/unit/reaction/test_solving.py
+++ b/tests/unit/reaction/test_solving.py
@@ -1,5 +1,6 @@
 # pylint: disable=no-self-use
 
+from expertsystem.particle import ParticleCollection
 from expertsystem.reaction.solving import Result
 
 
@@ -10,3 +11,21 @@ class TestResult:
         result = jpsi_to_gamma_pi_pi_helicity_solutions
         intermediate_particles = result.get_intermediate_particles()
         assert intermediate_particles.names == {"f(0)(1500)", "f(0)(980)"}
+
+    def test_get_particle_graphs(
+        self,
+        particle_database: ParticleCollection,
+        jpsi_to_gamma_pi_pi_helicity_solutions: Result,
+    ):
+        pdg = particle_database
+        result = jpsi_to_gamma_pi_pi_helicity_solutions
+        particle_graphs = result.get_particle_graphs()
+        assert len(particle_graphs) == 2
+        assert particle_graphs[0].edge_props[1] == pdg["f(0)(980)"]
+        assert particle_graphs[1].edge_props[1] == pdg["f(0)(1500)"]
+        assert len(particle_graphs[0].edges) == 5
+        for edge_id in (0, 2, 3, 4):
+            assert (
+                particle_graphs[0].edge_props[edge_id]
+                is particle_graphs[1].edge_props[edge_id]
+            )


### PR DESCRIPTION
Extract a `List[StateTransitionGraph[Particle]]` (without spin projections) from the `Result` class. This is useful when visualising solutions, e.g.:
![image](https://user-images.githubusercontent.com/29308176/97093381-b6ca4680-164b-11eb-998c-b262ff9e40a5.png)
