### PR TITLE
fix: sort ParticleColl. getitem candidates by mass

### DIFF
--- a/expertsystem/particle.py
+++ b/expertsystem/particle.py
@@ -298,14 +298,15 @@ class ParticleCollection(abc.MutableSet):
         error_message = (
             f'No particle with name "{particle_name} in the database"'
         )
-        candidate_names = {
-            name for name in self.__particles if particle_name in name
-        }
-        if candidate_names:
+        candidates = self.filter(lambda p: particle_name in p.name)
+        if candidates:
+            sorted_by_mass = sorted(
+                (p for p in candidates), key=lambda p: p.mass
+            )
             raise KeyError(
                 error_message,
                 "Did you mean one of these?",
-                candidate_names,
+                [p.name for p in sorted_by_mass],
             )
         raise KeyError(error_message)
 

--- a/tests/unit/test_particles.py
+++ b/tests/unit/test_particles.py
@@ -340,15 +340,14 @@ class TestParticleCollection:
     @staticmethod
     def test_key_error(particle_database: ParticleCollection):
         try:
-            search_term = "omega"
-            assert particle_database[search_term]
+            assert particle_database["omega"]
         except LookupError as error:
-            candidates = {
-                particle.name
-                for particle in particle_database
-                if search_term in particle.name
-            }
-            assert error.args[-1] == candidates
+            assert error.args[-1] == [
+                "omega(782)",
+                "omega(1420)",
+                "omega(3)(1670)",
+                "omega(1650)",
+            ]
 
 
 class TestSpin:


### PR DESCRIPTION
Small enhancement I found to be useful when defining the initial and final states and making a typo. Results in the following https://github.com/ComPWA/expertsystem/blob/64d4ec18028063ccc1f2226925e545a5e65afd22/tests/unit/test_particles.py#L342-L350