### PR TITLE
feat: visualize collapsed graphs

### DIFF
--- a/doc/usage/visualization.ipynb
+++ b/doc/usage/visualization.ipynb
@@ -13,8 +13,22 @@
     "raw_mimetype": "text/restructuredtext"
    },
    "source": [
-    "The `.io` module allows you to convert a `.StateTransitionGraph` to `DOT language <https://graphviz.org/doc/info/lang.html>`_, which you can then visualize with third-party libraries such as `Graphviz <https://graphviz.org/>`_. This is particularly useful after running `~.StateTransitionManager.find_solutions`, which produces a `.Result` object with a `list` of `.StateTransitionGraph` instances (see the :doc:`/usage/quickstart`).\n",
-    "\n",
+    "The `.io` module allows you to convert a `.StateTransitionGraph` to `DOT language <https://graphviz.org/doc/info/lang.html>`_, which you can then visualize with third-party libraries such as `Graphviz <https://graphviz.org/>`_. This is particularly useful after running `~.StateTransitionManager.find_solutions`, which produces a `.Result` object with a `list` of `.StateTransitionGraph` instances (see the :doc:`/usage/quickstart`)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Generate solutions"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {
+    "raw_mimetype": "text/restructuredtext"
+   },
+   "source": [
     "First, we quickly create some dummy solutions. We're not interested in the propagate process, so we decrease the `logging` level as well"
    ]
   },
@@ -35,17 +49,23 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from expertsystem.amplitude.helicity_decay import HelicityAmplitudeGenerator\n",
     "from expertsystem.reaction import InteractionTypes, StateTransitionManager\n",
     "\n",
     "stm = StateTransitionManager(\n",
-    "    initial_state=[(\"J/psi(1S)\", [-1, 1])],\n",
-    "    final_state=[\"gamma\", \"pi0\", \"pi0\"],\n",
-    "    allowed_intermediate_particles=[\"f(0)\"],\n",
+    "    initial_state=[\"psi(2S)\"],\n",
+    "    final_state=[\"gamma\", \"eta\", \"eta\"],\n",
+    "    formalism_type=\"helicity\",\n",
     ")\n",
-    "stm.set_allowed_interaction_types([InteractionTypes.EM])\n",
+    "stm.set_allowed_interaction_types([InteractionTypes.EM, InteractionTypes.Strong])\n",
     "graph_interaction_settings_groups = stm.prepare_graphs()\n",
     "result = stm.find_solutions(graph_interaction_settings_groups)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Convert to DOT and visualize"
    ]
   },
   {
@@ -54,7 +74,7 @@
     "raw_mimetype": "text/restructuredtext"
    },
    "source": [
-    ":ref:`As noted in the Quickstart <usage/quickstart:1.3. Find solutions>`, the `~.Result.solutions` contain all spin projection combinations (which is necessary for the `~expertsystem.amplitude` module). It is possible to convert all these solutions to DOT language with `.io.convert_to_dot`:"
+    ":ref:`As noted in the Quickstart <usage/quickstart:1.3. Find solutions>`, the `~.Result.solutions` contain all spin projection combinations (which is necessary for the `~expertsystem.amplitude` module). It is possible to convert all these solutions to DOT language with `.io.convert_to_dot`. To avoid visualizing all solutions, we just take a subset of the `~.Result.solutions`:"
    ]
   },
   {
@@ -65,7 +85,7 @@
    "source": [
     "from expertsystem import io\n",
     "\n",
-    "dot_source = io.convert_to_dot(result.solutions)  # with spin projections!"
+    "dot_source = io.convert_to_dot(result.solutions[::50][:3])  # just some selection"
    ]
   },
   {
@@ -74,17 +94,7 @@
     "raw_mimetype": "text/restructuredtext"
    },
    "source": [
-    "However, since this list of all possible spin projections is rather long, it is often useful to make use of the `~.Result.get_particle_graphs` method first:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "graphs = result.get_particle_graphs()\n",
-    "dot_source = io.convert_to_dot(graphs)"
+    "This `str` of `DOT language <https://graphviz.org/doc/info/lang.html>`_ for the list of `.StateTransitionGraph` instances can then be visualized with a third-party library, for instance, with `graphviz.Source`:"
    ]
   },
   {
@@ -96,15 +106,6 @@
     ".. margin::\n",
     "\n",
     "  .. warning:: `graphviz <graphviz.Source>` requires your system to have DOT installed, see :doc:`Installation <graphviz:index>`."
-   ]
-  },
-  {
-   "cell_type": "raw",
-   "metadata": {
-    "raw_mimetype": "text/restructuredtext"
-   },
-   "source": [
-    "Finally, this `str` of `DOT language <https://graphviz.org/doc/info/lang.html>`_ for the list of `.StateTransitionGraph` instances can be visualized with a third-party library, for instance, with `graphviz.Source`:"
    ]
   },
   {
@@ -133,8 +134,54 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "io.write(result.solutions, \"decay_topologies_with_spin.gv\")\n",
-    "io.write(graphs, \"decay_topologies.gv\")"
+    "io.write(result.solutions, \"decay_topologies_with_spin.gv\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Collapse graphs"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {
+    "raw_mimetype": "text/restructuredtext"
+   },
+   "source": [
+    "Since this list of all possible spin projections (`~.Result.solutions`) is rather long, it is often useful to make use of the `~.Result.get_particle_graphs` or `~.Result.collapse_graphs` methods to bundle comparable graphs. First, `~.Result.get_particle_graphs` allows one collapse (ignore) the spin projections (we again show a selection only):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "graphs = result.get_particle_graphs()\n",
+    "dot_source = io.convert_to_dot(graphs[:3])\n",
+    "graphviz.Source(dot_source)"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {
+    "raw_mimetype": "text/restructuredtext"
+   },
+   "source": [
+    "If that list is still too much, there is `~.Result.collapse_graphs`, which bundles all graphs with the same final state groupings:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "graphs = result.collapse_graphs()\n",
+    "dot_source = io.convert_to_dot(graphs)\n",
+    "graphviz.Source(dot_source)"
    ]
   }
  ],

--- a/expertsystem/io/_dot.py
+++ b/expertsystem/io/_dot.py
@@ -5,8 +5,8 @@ See :doc:`/usage/visualization` for more info.
 
 from typing import Any, Callable, List, Optional
 
-from expertsystem.particle import Particle
-from expertsystem.reaction.topology import StateTransitionGraph
+from expertsystem.particle import Particle, ParticleCollection
+from expertsystem.reaction.topology import StateTransitionGraph, Topology
 
 _DOT_HEAD = """digraph {
     rankdir=LR;
@@ -85,21 +85,24 @@ def __rank_string(node_edge_ids: List[int], prefix: str = "") -> str:
 
 
 def __edge_label(graph: StateTransitionGraph, edge_id: int) -> str:
-    if isinstance(graph, StateTransitionGraph) and edge_id in graph.edge_props:
+    if isinstance(graph, StateTransitionGraph):
+        if edge_id not in graph.edge_props:
+            return str(edge_id)
         edge_prop = graph.edge_props[edge_id]
         if isinstance(edge_prop, Particle):
-            particle = edge_prop
-            spin_projection = None
-        elif isinstance(edge_prop, tuple):
+            return edge_prop.name
+        if isinstance(edge_prop, tuple):
             particle, projection = edge_prop
             spin_projection = float(projection)
             if spin_projection.is_integer():
                 spin_projection = int(spin_projection)
-        else:
-            raise NotImplementedError
-        label = particle.name
-        if spin_projection is not None:
-            label += f"[{projection}]"
-    else:
-        label = str(edge_id)
-    return label
+            label = particle.name
+            if spin_projection is not None:
+                label += f"[{projection}]"
+            return label
+        if isinstance(edge_prop, ParticleCollection):
+            return "\n".join(sorted(edge_prop.names))
+        raise NotImplementedError
+    if isinstance(graph, Topology):
+        return str(edge_id)
+    raise NotImplementedError

--- a/tests/unit/io/test_dot.py
+++ b/tests/unit/io/test_dot.py
@@ -9,9 +9,14 @@ from expertsystem.reaction.topology import Edge, Topology
 
 
 def test_dot_syntax(jpsi_to_gamma_pi_pi_helicity_solutions: Result):
-    for i in jpsi_to_gamma_pi_pi_helicity_solutions.solutions:
-        dot_data = io.convert_to_dot(i)
+    result = jpsi_to_gamma_pi_pi_helicity_solutions
+    for graph in result.solutions:
+        dot_data = io.convert_to_dot(graph)
         assert pydot.graph_from_dot_data(dot_data) is not None
+    dot_data = io.convert_to_dot(result.solutions)
+    assert pydot.graph_from_dot_data(dot_data) is not None
+    dot_data = io.convert_to_dot(result.get_particle_graphs())
+    assert pydot.graph_from_dot_data(dot_data) is not None
 
 
 class TestWrite:

--- a/tests/unit/io/test_dot.py
+++ b/tests/unit/io/test_dot.py
@@ -17,6 +17,8 @@ def test_dot_syntax(jpsi_to_gamma_pi_pi_helicity_solutions: Result):
     assert pydot.graph_from_dot_data(dot_data) is not None
     dot_data = io.convert_to_dot(result.get_particle_graphs())
     assert pydot.graph_from_dot_data(dot_data) is not None
+    dot_data = io.convert_to_dot(result.collapse_graphs())
+    assert pydot.graph_from_dot_data(dot_data) is not None
 
 
 class TestWrite:

--- a/tests/unit/reaction/test_solving.py
+++ b/tests/unit/reaction/test_solving.py
@@ -29,3 +29,23 @@ class TestResult:
                 particle_graphs[0].edge_props[edge_id]
                 is particle_graphs[1].edge_props[edge_id]
             )
+
+    def test_collapse_graphs(
+        self,
+        jpsi_to_gamma_pi_pi_helicity_solutions: Result,
+        particle_database: ParticleCollection,
+    ):
+        pdg = particle_database
+        result = jpsi_to_gamma_pi_pi_helicity_solutions
+        particle_graphs = result.get_particle_graphs()
+        assert len(particle_graphs) == 2
+        collapsed_graphs = result.collapse_graphs()
+        assert len(collapsed_graphs) == 1
+        graph = collapsed_graphs[0]
+        edge_id = graph.get_intermediate_state_edges()[0]
+        f_resonances = pdg.filter(
+            lambda p: p.name in ["f(0)(980)", "f(0)(1500)"]
+        )
+        intermediate_states = graph.edge_props[edge_id]
+        assert isinstance(intermediate_states, ParticleCollection)
+        assert intermediate_states == f_resonances


### PR DESCRIPTION
_Rebased on #336_

As a follow-up to #336, I added some more functionality to the `Result` class that can help when investigating allowed transitions. There's now `Result.collapse_graphs` which returns a `list` of `StateTransitionGraph` that are unique up to isomorphism of the topology (well, sounds fancy, but I just check if the ID-to-particle `dict`s of the outer edge properties are different). The edge properties are `ParticleCollection`s that have all particles of the original graphs collected.

The `io.conver_to_dot` function can handle it, resulting in something like that. Ugly, I know, but that's just how `graphviz` renders it... Usage is described in the renewed visualization notebook (preview [here](https://pwa--341.org.readthedocs.build/projects/expertsystem/en/341/usage/visualization.html), but without cell output).

![image](https://user-images.githubusercontent.com/29308176/97455338-094f7f80-1938-11eb-895e-201b603213cf.png)
