### PR TITLE
ci: split tox coverage job

### DIFF
--- a/doc/contribute.rst
+++ b/doc/contribute.rst
@@ -116,14 +116,14 @@ command
 
   tox
 
-This command will run :code:`pytest`, check for test coverage, build the
-documentation, and verify cross-references in the documentation and the API.
-It's especially recommended to *run tox before submitting a pull request!*
+This command will run :code:`pytest`, build the documentation, and verify
+cross-references in the documentation and the API. It's especially recommended
+to **run tox before submitting a pull request!**
 
 More specialized :code:`tox` tests are defined in the `tox.ini
 <https://github.com/ComPWA/expertsystem/blob/master/tox.ini>`__ file, under
-each :code:`testenv`. You can list all environments, along with a description
-of what they do, by running:
+each :code:`testenv` section. You can list all environments, along with a
+description of what they do, by running:
 
 .. code-block:: shell
 
@@ -133,10 +133,7 @@ Try to keep test coverage high. You can compute current coverage by running
 
 .. code-block:: shell
 
-  pytest \
-    --cov-report=html \
-    --cov-report=xml \
-    --cov=expertsystem
+  tox -e cov
 
 and opening :file:`htmlcov/index.html` in a browser. In VScode, you can
 visualize which lines in the code base are covered by tests with the `Coverage
@@ -152,6 +149,7 @@ extension (for this you need to run :code:`pytest` with the flag
   file.
 
 .. admonition:: Organizing unit tests
+  :class: dropdown
 
   When **unit** tests are well-organized, you avoid writing duplicate tests. In
   addition, it allows you to check for coverage of specific parts of the code.

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,14 @@ description =
 whitelist_externals =
     pytest
 commands =
+    pytest {posargs:tests/unit}
+
+[testenv:cov]
+description =
+    Compute the test coverage of all unit tests
+whitelist_externals =
+    pytest
+commands =
     pytest {posargs:tests/unit} \
         --cov-fail-under=90 \
         --cov-report=html \
@@ -75,7 +83,7 @@ commands =
 
 [testenv:test]
 description =
-    Run ALL tests, including the slow channel tests
+    Run ALL tests, including the slow channel tests, and compute coverage
 whitelist_externals =
     pytest
 commands =


### PR DESCRIPTION
Currently, it takes around one minute to run `tox -e py` (the default test environment). This has been reduced to a third, because the test coverage job has been moved to the specialised command `tox -e cov`. See updated contribute page.