### PR TITLE
docs: hide logs from example pages

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -111,6 +111,7 @@
         "linkcheck",
         "macos",
         "markdownlint",
+        "mathrm",
         "maxdepth",
         "mimetype",
         "modindex",

--- a/doc/usage/particles.ipynb
+++ b/doc/usage/particles.ipynb
@@ -52,7 +52,7 @@
     "raw_mimetype": "text/restructuredtext"
    },
    "source": [
-    "In the following, we illustrate how to use the methods of the `.ParticleCollection` class to find and 'modify' `.Particle` s and `.ParticleCollection.add` them back to the `.ParticleCollection`."
+    "In the following, we illustrate how to use the methods of the `.ParticleCollection` class to find and 'modify' `.Particle` s and `~.ParticleCollection.add` them back to the `.ParticleCollection`."
    ]
   },
   {
@@ -68,7 +68,7 @@
     "raw_mimetype": "text/restructuredtext"
    },
    "source": [
-    "The `.ParticleCollection` class offers some methods to search for particles by name or by PID (see `.ParticleCollection.find`):"
+    "The `.ParticleCollection` class offers some methods to search for particles by name or by PID (see `~.ParticleCollection.find`):"
    ]
   },
   {
@@ -182,7 +182,9 @@
    "source": [
     ".. margin:: Duplicate names or PIDs\n",
     "\n",
-    "    The warning that you see here comes from the fact that names and PIDs are considered mere labels of a `.Particle` instance ― only its quantum numbers such as `~.Particle.spin` and `~.Particle.charge` uniquely define it. The warning is suppressed in the rest of this page."
+    "    The warning that you see here comes from the fact that names and PIDs are considered mere labels of a `.Particle` instance ― it is defined uniquely only by its quantum numbers, such as `~.Particle.spin` and `~.Particle.charge`. \n",
+    "    \n",
+    "    The warning is suppressed in the rest of this page."
    ]
   },
   {
@@ -248,6 +250,17 @@
    ]
   },
   {
+   "cell_type": "raw",
+   "metadata": {
+    "raw_mimetype": "text/restructuredtext"
+   },
+   "source": [
+    ".. margin::\n",
+    "\n",
+    "  .. note:: By convention, the `expertsystem` uses :math:`\\mathrm{GeV}/c^2` as energy unit."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -271,16 +284,6 @@
    "outputs": [],
    "source": [
     "particle_db.filter(lambda p: \"EpEm\" in p.name).names"
-   ]
-  },
-  {
-   "cell_type": "raw",
-   "metadata": {
-    "raw_mimetype": "text/restructuredtext"
-   },
-   "source": [
-    ".. note::\n",
-    "  By convention, the `expertsystem` uses GeV as energy unit."
    ]
   },
   {

--- a/doc/usage/particles.ipynb
+++ b/doc/usage/particles.ipynb
@@ -52,7 +52,7 @@
     "raw_mimetype": "text/restructuredtext"
    },
    "source": [
-    "In the following, we illustrate how to use the methods of the `.ParticleCollection` class to modify or add particle definitions in the particle database."
+    "In the following, we illustrate how to use the methods of the `.ParticleCollection` class to find and 'modify' `.Particle` s and `.ParticleCollection.add` them back to the `.ParticleCollection`."
    ]
   },
   {
@@ -175,6 +175,17 @@
    ]
   },
   {
+   "cell_type": "raw",
+   "metadata": {
+    "raw_mimetype": "text/restructuredtext"
+   },
+   "source": [
+    ".. margin:: Duplicate names or PIDs\n",
+    "\n",
+    "    The warning that you see here comes from the fact that names and PIDs are considered mere labels of a `.Particle` instance ― only its quantum numbers such as `~.Particle.spin` and `~.Particle.charge` uniquely define it. The warning is suppressed in the rest of this page."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -188,6 +199,20 @@
     "\n",
     "particle_db.add(new_N1650_plus)\n",
     "particle_db[\"Modified N(1650)+\"].width"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "nbsphinx": "hidden"
+   },
+   "outputs": [],
+   "source": [
+    "# This cell is not visible in the documentation\n",
+    "import logging\n",
+    "\n",
+    "logging.getLogger().setLevel(logging.ERROR)  # disable logging in docs"
    ]
   },
   {

--- a/doc/usage/quickstart.ipynb
+++ b/doc/usage/quickstart.ipynb
@@ -8,6 +8,20 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "nbsphinx": "hidden"
+   },
+   "outputs": [],
+   "source": [
+    "# This cell is not visible in the documentation\n",
+    "import logging\n",
+    "\n",
+    "logging.getLogger().setLevel(logging.ERROR)"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -271,16 +285,18 @@
     "raw_mimetype": "text/restructuredtext"
    },
    "source": [
-    "In general, you can modify the dictionary returned by\n",
-    ":meth:`.prepare_graphs` directly, but the STM also comes with functionality\n",
-    "to globally choose the allowed interaction types."
+    "In general, you can modify the dictionary returned by :meth:`.prepare_graphs` directly, but the STM also comes with functionality to globally choose the allowed interaction types. So, go ahead and **disable** the `~.InteractionTypes.EM` and `~.InteractionTypes.Weak` interactions:"
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "nbsphinx": "hidden"
+   },
+   "outputs": [],
    "source": [
-    "So, go ahead and **disable** the **EM** and **weak** interaction:"
+    "logging.getLogger().setLevel(logging.WARNING)"
    ]
   },
   {
@@ -298,21 +314,25 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "nbsphinx": "hidden"
+   },
+   "outputs": [],
+   "source": [
+    "logging.getLogger().setLevel(logging.CRITICAL)"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Huh, what happened here? Actually, since a $\\gamma$ particle appears in one\n",
-    "of the interaction nodes, the expert system knows that this node **must\n",
-    "involve EM interactions**! Because the node can be an effective interaction,\n",
-    "the weak interaction cannot be excluded, as it contains only a subset of\n",
-    "conservation laws.\n",
+    "Huh, what happened here? Actually, since a $\\gamma$ particle appears in one of the interaction nodes, the expert system knows that this node **must involve EM interactions**! Because the node can be an effective interaction, the weak interaction cannot be excluded, as it contains only a subset of conservation laws.\n",
     "\n",
-    "Since only the strong interaction was supposed to be used, this results in a\n",
-    "warning and the STM automatically corrects the mistake.\n",
+    "Since only the strong interaction was supposed to be used, this results in a warning and the STM automatically corrects the mistake.\n",
     "\n",
-    "Once the EM interaction is included, this warning disappears. Be aware,\n",
-    "however, that the EM interaction is now available globally. Hence, there now\n",
-    "might be solutions in which both nodes are electromagnetic."
+    "Once the EM interaction is included, this warning disappears. Be aware, however, that the EM interaction is now available globally. Hence, there now might be solutions in which both nodes are electromagnetic."
    ]
   },
   {
@@ -333,10 +353,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Great! Now we selected only the strongest contributions. Be aware, though,\n",
-    "that there are more effects that can suppress certain decays, like small\n",
-    "branching ratios. In this example, the initial state $J/\\Psi$ can decay into\n",
-    "$\\pi^0 + \\rho^0$ or $\\pi^0 + \\omega$."
+    "Great! Now we selected only the strongest contributions. Be aware, though, that there are more effects that can suppress certain decays, like small branching ratios. In this example, the initial state $J/\\Psi$ can decay into $\\pi^0 + \\rho^0$ or $\\pi^0 + \\omega$."
    ]
   },
   {
@@ -353,10 +370,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Unfortunately, the $\\rho^0$ mainly decays into $\\pi+\\pi$, not $\\gamma+\\pi^0$\n",
-    "and is therefore suppressed. This information is currently not known to the\n",
-    "expert system, but it is possible to hand the expert system a list of allowed\n",
-    "intermediate states."
+    "Unfortunately, the $\\rho^0$ mainly decays into $\\pi+\\pi$, not $\\gamma+\\pi^0$ and is therefore suppressed. This information is currently not known to the expert system, but it is possible to hand the expert system a list of allowed intermediate states."
    ]
   },
   {
@@ -379,10 +393,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now we have selected all amplitudes that involve **f** states. The warnings\n",
-    "appear only to notify the user that the list of solutions is not exhaustive:\n",
-    "for certain edges in the graph, no suitable particle was found (since\n",
-    "only f states were allowed)."
+    "Now we have selected all amplitudes that involve **f** states. The warnings appear only to notify the user that the list of solutions is not exhaustive: for certain edges in the graph, no suitable particle was found (since only f states were allowed)."
    ]
   },
   {
@@ -421,8 +432,7 @@
     "raw_mimetype": "text/restructuredtext"
    },
    "source": [
-    ".. note::\n",
-    "    In this example, we used the helicity formalism. If you want to work with the canonical formalism, you have to construct the :class:`.StateTransitionManager` with argument :code:`formalism_type=\"canonical-helicity\"` instead of :code:`formalism_type=\"helicity\"`."
+    ".. note:: In this example, we used the helicity formalism. If you want to work with the canonical formalism, you have to construct the :class:`.StateTransitionManager` with argument :code:`formalism_type=\"canonical-helicity\"` instead of :code:`formalism_type=\"helicity\"`."
    ]
   },
   {
@@ -472,11 +482,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Have a look through the sections of the resulting XML or YAML recipe file to see what you\n",
-    "recognize from the problem set defined above. There may also be some things\n",
-    "you want to change in there manually, so **make sure you store this recipe\n",
-    "file** carefully (e.g. track it with Git) as to avoid overwriting it your\n",
-    "changes after rerunning the expert system."
+    "Have a look through the sections of the resulting XML or YAML recipe file to see what you recognize from the problem set defined above. There may also be some things you want to change in there manually, so **make sure you store this recipe file** carefully (e.g. track it with Git) as to avoid overwriting it your changes after rerunning the expert system."
    ]
   },
   {

--- a/doc/usage/quickstart.ipynb
+++ b/doc/usage/quickstart.ipynb
@@ -74,6 +74,17 @@
    ]
   },
   {
+   "cell_type": "raw",
+   "metadata": {
+    "raw_mimetype": "text/restructuredtext"
+   },
+   "source": [
+    ".. margin::\n",
+    "\n",
+    "    .. hint:: How does the `.StateTransitionManager` know what a ``\"J/psi(1S)\"`` is? Upon construction, the `.StateTransitionManager` loads default definitions from the `PDG <https://pdg.lbl.gov/>`_. See :doc:`/usage/particles` for how to add custom particle definitions."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -131,16 +142,6 @@
     "      be specified: either through the\n",
     "      `STM's constructor <.StateTransitionManager>` or by\n",
     "      setting the instance attribute ``allowed_intermediate_particles``."
-   ]
-  },
-  {
-   "cell_type": "raw",
-   "metadata": {
-    "raw_mimetype": "text/restructuredtext"
-   },
-   "source": [
-    ".. hint::\n",
-    "    How does the `.StateTransitionManager` know what a ``\"J/psi(1S)\"`` is? Upon construction, the `.StateTransitionManager` loads default definitions from the `PDG <https://pdg.lbl.gov/>`_. See :doc:`/usage/particles` for how to add custom particle definitions."
    ]
   },
   {
@@ -415,6 +416,17 @@
    ]
   },
   {
+   "cell_type": "raw",
+   "metadata": {
+    "raw_mimetype": "text/restructuredtext"
+   },
+   "source": [
+    ".. margin:: Formalism\n",
+    "\n",
+    "  In this example, we used the helicity formalism. If you want to work with the canonical formalism, you have to construct the :class:`.StateTransitionManager` with argument :code:`formalism_type=\"canonical-helicity\"` instead of :code:`formalism_type=\"helicity\"`."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -424,15 +436,6 @@
     "\n",
     "amplitude_model = generate_amplitude_model(result)\n",
     "amplitude_model.particles.names"
-   ]
-  },
-  {
-   "cell_type": "raw",
-   "metadata": {
-    "raw_mimetype": "text/restructuredtext"
-   },
-   "source": [
-    ".. note:: In this example, we used the helicity formalism. If you want to work with the canonical formalism, you have to construct the :class:`.StateTransitionManager` with argument :code:`formalism_type=\"canonical-helicity\"` instead of :code:`formalism_type=\"helicity\"`."
    ]
   },
   {

--- a/doc/usage/visualization.ipynb
+++ b/doc/usage/visualization.ipynb
@@ -8,6 +8,20 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "nbsphinx": "hidden"
+   },
+   "outputs": [],
+   "source": [
+    "# This cell is not visible in the documentation\n",
+    "import logging\n",
+    "\n",
+    "logging.getLogger().setLevel(logging.ERROR)"
+   ]
+  },
+  {
    "cell_type": "raw",
    "metadata": {
     "raw_mimetype": "text/restructuredtext"
@@ -20,27 +34,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Generate solutions"
-   ]
-  },
-  {
-   "cell_type": "raw",
-   "metadata": {
-    "raw_mimetype": "text/restructuredtext"
-   },
-   "source": [
-    "First, we quickly create some dummy solutions. We're not interested in the propagate process, so we decrease the `logging` level as well"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import logging\n",
-    "\n",
-    "logging.basicConfig(level=logging.ERROR)"
+    "In this notebook, we'll visualize the allowed transitions for the decay $\\psi' \\to \\gamma\\eta\\eta$ as an example."
    ]
   },
   {


### PR DESCRIPTION
Since #348, the progress bar is visible in notebooks. Unfortunately, that also means the logs are rendered in the usage pages. This PR avoids that, as well as cleaning up the pages with [margin notes](https://sphinx-book-theme.readthedocs.io/en/latest/layout.html#margins).