### PR TITLE
fix: use defaultdict in convert_to_names

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -207,10 +207,7 @@ nb_render_priority = {
 nb_render_priority["doctest"] = nb_render_priority["html"]
 
 jupyter_execute_notebooks = "off"
-if (
-    "EXECUTE_NB" in os.environ
-    or "READTHEDOCS" in os.environ  # PR preview on RTD
-):
+if "EXECUTE_NB" in os.environ:
     print("\033[93;1mWill run Jupyter notebooks!\033[0m")
     jupyter_execute_notebooks = "force"
 

--- a/src/expertsystem/reaction/solving.py
+++ b/src/expertsystem/reaction/solving.py
@@ -103,7 +103,7 @@ def convert_to_names(
             return rule
         return rule.__class__.__name__
 
-    converted_dict = {}
+    converted_dict = defaultdict(set)
     for node_id, rule_set in rules.items():
         rule_name_set = set()
         for rule_tuple in rule_set:


### PR DESCRIPTION
Causes problems in the `Result` class, at least for final states with more than 3 particles.

<details>

<summary>Snippet to cause that shows the bug</summary>

```python
import graphviz
from expertsystem.reaction import InteractionTypes, StateTransitionManager

stm = StateTransitionManager(
    initial_state=["D(s)+"],
    final_state=["pi0", "pi+", "K+", "K-"],
    allowed_intermediate_particles=["phi(1020)", "rho(770)+"],
)
stm.set_allowed_interaction_types([InteractionTypes.Strong, InteractionTypes.EM]),
stm.add_final_state_grouping([["pi0", "pi+"], ["K+", "K-"]])
graph_interaction_settings = stm.prepare_graphs()
result = stm.find_solutions(graph_interaction_settings)
print("Solutions:", len(result.solutions))
dot = es.io.convert_to_dot(result.collapse_graphs())
graphviz.Source(dot)
```

</details>