### PR TITLE
fix: build wheel and fix deploy job

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -6,6 +6,9 @@ on:
   create:
     tags:
       - "[0-9]+.[0-9]+.[0-9]+*"
+  release:
+    types:
+      - created
 
 jobs:
   test:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,4 +1,4 @@
-# cspell:ignore noreply pypa sdist
+# cspell:ignore bdist noreply pypa sdist
 
 name: CD
 
@@ -114,7 +114,7 @@ jobs:
         with:
           python-version: 3.8
       - name: Create distribution
-        run: python setup.py sdist
+        run: python setup.py sdist bdist_wheel
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@master
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 ]
 
 [tool.setuptools_scm]
-write_to = "expertsystem/version.py"
+write_to = "src/expertsystem/version.py"
 
 [tool.black]
 line-length = 79


### PR DESCRIPTION
Here's a first attempt at (partially) fixing #377. I'm not fully sure whether it works, but we want to have the #376 released for `tensorwaves`.

To be clear, trying to fix two things here:
- [x] Let the [CD GitHub workflow](https://github.com/ComPWA/expertsystem/actions?query=workflow%3ACD) trigger again
- [x] Make the package on PyPI PEP517 compatible (see problem with Colab in #377).