### PR TITLE
ci: fix release to pypi upon (pre)release

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -120,7 +120,7 @@ jobs:
           pip install setuptools wheel twine
       - name: Build and publish
         env:
-          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+          TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
         run: |
           python setup.py sdist bdist_wheel

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -109,15 +109,19 @@ jobs:
     needs: push
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
-      - name: Set up Python 3.8
-        uses: actions/setup-python@v1
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
         with:
           python-version: 3.8
-      - name: Create distribution
-        run: python setup.py sdist bdist_wheel
-      - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@master
-        with:
-          user: __token__
-          password: ${{ secrets.pypi_password }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install setuptools wheel twine
+      - name: Build and publish
+        env:
+          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        run: |
+          python setup.py sdist bdist_wheel
+          twine upload dist/*

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,14 +1,12 @@
-# cspell:ignore bdist noreply pypa sdist
+# cspell:ignore bdist noreply prereleased pypa sdist
 
 name: CD
 
 on:
-  create:
-    tags:
-      - "[0-9]+.[0-9]+.[0-9]+*"
   release:
     types:
-      - created
+      - prereleased
+      - released
 
 jobs:
   test:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -168,7 +168,7 @@ intersphinx_mapping = {
         None,
     ),
     "mypy": ("https://mypy.readthedocs.io/en/stable", None),
-    "pwa": ("https://pwa.readthedocs.io", None),
+    "pwa": ("https://pwa.readthedocs.io/en/latest", None),
     "pycompwa": ("https://compwa.github.io", None),
     "python": ("https://docs.python.org/3", None),
     "tensorwaves": (

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -168,7 +168,7 @@ intersphinx_mapping = {
         None,
     ),
     "mypy": ("https://mypy.readthedocs.io/en/stable", None),
-    "pwa": ("https://pwa.readthedocs.io/en/latest", None),
+    "pwa": ("https://pwa.readthedocs.io", None),
     "pycompwa": ("https://compwa.github.io", None),
     "python": ("https://docs.python.org/3", None),
     "tensorwaves": (


### PR DESCRIPTION
Closes #377

The CD job still does not trigger correctly. Hope this PR does the trick.

- [x] Following these instruction
  https://docs.github.com/en/free-pro-team@latest/actions/guides/building-and-testing-python#publishing-to-package-registries
  (which uses `twine`) instead of
  https://packaging.python.org/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
- [x] Trigger on `(pre)release` instead of `create`


Edit: `(pre)released` types work. Was tested on a fork.