### PR TITLE
ci: implement markdownlint pre-commit hook

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,8 +3,8 @@ root = true
 [*]
 end_of_line = lf
 indent_style = space
-trim_trailing_whitespace = true
 insert_final_newline = true
+trim_trailing_whitespace = true
 
 [Makefile]
 indent_style = tab

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -77,13 +77,11 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install .[precommit]
-          sudo npm install -g cspell markdownlint-cli pyright
+          sudo npm install -g cspell pyright
       - name: Perform style checks
         run: pre-commit run -a
       - name: Check spelling
         run: cspell $(git ls-files)
-      - name: Lint Markdown files
-        run: markdownlint .
       - name: Run pyright
         run: pyright
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,12 +107,10 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install .[precommit]
-          sudo npm install -g cspell markdownlint-cli pyright
+          sudo npm install -g cspell pyright
       - name: Perform style checks
         run: pre-commit run -a
       - name: Check spelling
         run: cspell $(git ls-files)
-      - name: Lint Markdown files
-        run: markdownlint .
       - name: Run pyright
         run: pyright

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,6 +27,11 @@ repos:
         args: ["--django"]
       - id: trailing-whitespace
 
+  - repo: https://github.com/igorshubovych/markdownlint-cli
+    rev: v0.25.0
+    hooks:
+      - id: markdownlint
+
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v2.2.0
     hooks:

--- a/cspell.json
+++ b/cspell.json
@@ -18,6 +18,7 @@
     ],
     "ignorePaths": [
         "*.bib",
+        "*.root",
         "*.rst_t",
         "*.svg",
         "*particle*.*ml",

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ classifiers =
     Typing :: Typed
 
 [options]
-python_requires = >=3.6
+python_requires = >=3.6, <3.9
 setup_requires =
     setuptools_scm
 install_requires =
@@ -109,14 +109,14 @@ precommit =
     %(format)s
     %(lint)s
     %(test)s
-    pre-commit==2.8.2
+    pre-commit==2.9.0
 tox =
     %(precommit)s
     sphinx-autobuild==2020.9.1
     tox==3.20.1
 tools =
     jupyterlab==2.2.9
-    jupyterlab_code_formatter==1.3.6
+    jupyterlab-code-formatter==1.3.8
     labels==20.1.0
 dev =
     %(doc)s

--- a/tox.ini
+++ b/tox.ini
@@ -94,7 +94,6 @@ commands =
     mypy .  # run separately because of potential caching problems
     pre-commit run {posargs} -a
     - bash -ec "cspell $(git ls-files)"
-    - bash -ec "markdownlint . --ignore docs/_build"
 
 [testenv:test]
 description =
@@ -157,10 +156,10 @@ add_ignore =
     D407, # missing dashed underline after section
 
 [pytest]
-filterwarnings =
-    error
 addopts =
     --color=yes
     --durations=3
+filterwarnings =
+    error
 markers =
     slow: marks tests as slow (deselect with '-m "not slow"')


### PR DESCRIPTION
- Removes the need to `npm`-install `markdownlint`.
- Upgrades `pre-commit`.
- Also did some alphabetical sorts in config files.