### PR TITLE
refactor!: make solving module graph independent

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -99,6 +99,7 @@
     "ignoreWords": [
         "adrs",
         "arange",
+        "asdict",
         "cano",
         "celltoolbar",
         "codacy",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -156,7 +156,7 @@ nitpick_ignore = [
     ("py:class", "StateTransitionGraph"),
     ("py:class", "a set-like object providing a view on D's items"),
     ("py:class", "a set-like object providing a view on D's keys"),
-    ("py:class", "_T"),
+    ("py:class", "_EdgeType"),
     ("py:class", "an object providing a view on D's values"),
     ("py:class", "typing_extensions.Protocol"),
 ]

--- a/docs/usage/workflow.ipynb
+++ b/docs/usage/workflow.ipynb
@@ -185,7 +185,7 @@
    "metadata": {},
    "source": [
     "```{toggle}\n",
-    "This step takes about 10 sec on an Intel(R) Core(TM) i7-6820HQ CPU of 2.70GHz running, multi-threaded.\n",
+    "This step takes about 23 sec on an Intel(R) Core(TM) i7-6820HQ CPU of 2.70GHz running, multi-threaded.\n",
     "```"
    ]
   },

--- a/docs/usage/workflow.ipynb
+++ b/docs/usage/workflow.ipynb
@@ -11,9 +11,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "jupyter": {
-     "source_hidden": true
-    },
     "tags": [
      "remove-cell"
     ]
@@ -93,17 +90,6 @@
     "stm = StateTransitionManager(\n",
     "    initial_state=[\"J/psi(1S)\"],\n",
     "    final_state=[\"gamma\", \"pi0\", \"pi0\"],\n",
-    "    allowed_intermediate_particles=[\n",
-    "        \"f(0)(980)\",\n",
-    "        \"f(0)(1500)\",\n",
-    "        \"f(2)(1270)\",\n",
-    "        \"f(2)(1950)\",\n",
-    "        \"omega(782)\",\n",
-    "        \"D*(2007)0\",\n",
-    "        \"rho(770)0\",\n",
-    "        \"phi(1020)\",\n",
-    "        \"a(0)(980)0\",\n",
-    "    ],\n",
     "    formalism_type=\"helicity\",\n",
     ")"
    ]
@@ -118,11 +104,11 @@
     "\n",
     "  The `.StateTransitionManager` (STM) is the main user interface class of the {mod}`expertsystem`. The boundary conditions of your physics problem, such as the initial state, final state, formalism type, etc., are defined through this interface.\n",
     "\n",
-    "  * `.prepare_graphs` of the STM creates all topology graphs ― here, using the isobar model (a tree of two-body decays). The function also initializes the graphs with the initial and final state and a set of conservation laws at each interaction node.\n",
+    "  * `.create_problem_sets` of the STM creates all problem sets ― using the boundary conditions of the `.StateTransitionManager` instance. In total 3 steps are performed. The creation of reaction topologies. The creation of `.InitialFacts`, based on a topology and the initial and final state information. And finally the solving settings such as the conservation laws and quantum number domains to use at which point of the topology.\n",
     "\n",
     "  * By default, all three interaction types (`~.InteractionTypes.EM`, `~.InteractionTypes.Strong`, and `~.InteractionTypes.Weak`) are used in the preparation stage. However, it is also possible to choose the allowed interaction types globally via `.set_allowed_interaction_types`.\n",
     "\n",
-    "  After the preparation step, you can modify the settings returned by `.prepare_graphs` to your liking. Since the output of this function contains quite a lot of information, the `expertsystem` aids in the configuration (especially the STM).\n",
+    "  After the preparation step, you can modify the problem sets returned by `.create_problem_sets` to your liking. Since the output of this function contains quite a lot of information, the `expertsystem` aids in the configuration (especially the STM).\n",
     "\n",
     "  * A subset of particles that are allowed as intermediate states can also be specified: either through the `STM's constructor <.StateTransitionManager>` or by setting the instance :code:`allowed_intermediate_particles`.\n",
     "```"
@@ -132,16 +118,15 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 1.2. Prepare topologies"
+    "## 1.2. Prepare Problem Sets"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Create all topology graphs using the **isobar model** (tree of two-body\n",
-    "decays) and initialize the graphs with the initial and final state. Remember\n",
-    "that each interaction node defines its own set of conservation laws."
+    "Create all `~.ProblemSet`'s using the boundary conditions of the `~.StateTransitionManager` instance. By default it uses the **isobar model** (tree of two-body\n",
+    "decays) to build `~.Topology`'s. Various `~.InitialFacts` are created for each topology based on the initial and final state. Lastly some reasonable default settings for the solving process are chosen. Remember that each interaction node defines its own set of conservation laws."
    ]
   },
   {
@@ -166,7 +151,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "By default, all three are used in the preparation stage. The {meth}`~.StateTransitionManager.prepare_graphs` method of the STM generates graphs with all possible combinations of interaction nodes. An overall interaction strength is assigned to each graph and they are grouped according to this strength."
+    "By default, all three are used in the preparation stage. The {meth}`~.StateTransitionManager.create_problem_sets` method of the STM generates graphs with all possible combinations of interaction nodes. An overall interaction strength is assigned to each graph and they are grouped according to this strength."
    ]
   },
   {
@@ -175,7 +160,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "graph_interaction_settings_groups = stm.prepare_graphs()"
+    "problem_sets = stm.create_problem_sets()"
    ]
   },
   {
@@ -197,7 +182,7 @@
    "metadata": {},
    "source": [
     "```{toggle}\n",
-    "This step takes about 30 sec on an Intel(R) Core(TM) i7-6820HQ CPU of 2.70GHz running, multi-threaded.\n",
+    "This step takes about 10 sec on an Intel(R) Core(TM) i7-6820HQ CPU of 2.70GHz running, multi-threaded.\n",
     "```"
    ]
   },
@@ -207,7 +192,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "result = stm.find_solutions(graph_interaction_settings_groups)"
+    "result = stm.find_solutions(problem_sets)"
    ]
   },
   {
@@ -257,7 +242,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In general, you can modify the dictionary returned by {meth}`~.StateTransitionManager.prepare_graphs` directly, but the STM also comes with functionality to globally choose the allowed interaction types. So, go ahead and **disable** the {attr}`~.InteractionTypes.EM` and {attr}`~.InteractionTypes.Weak` interactions:"
+    "In general, you can modify the `~.ProblemSet`s returned by {meth}`~.StateTransitionManager.create_problem_sets` directly, but the STM also comes with functionality to globally choose the allowed interaction types. So, go ahead and **disable** the {attr}`~.InteractionTypes.EM` and {attr}`~.InteractionTypes.Weak` interactions:"
    ]
   },
   {
@@ -267,8 +252,8 @@
    "outputs": [],
    "source": [
     "stm.set_allowed_interaction_types([InteractionTypes.Strong])\n",
-    "graph_interaction_settings_groups = stm.prepare_graphs()\n",
-    "result = stm.find_solutions(graph_interaction_settings_groups)\n",
+    "problem_sets = stm.create_problem_sets()\n",
+    "result = stm.find_solutions(problem_sets)\n",
     "\n",
     "print(\"found\", len(result.solutions), \"solutions!\")\n",
     "result.get_intermediate_particles().names"
@@ -292,8 +277,8 @@
    "outputs": [],
    "source": [
     "stm.set_allowed_interaction_types([InteractionTypes.Strong, InteractionTypes.EM])\n",
-    "graph_interaction_settings_groups = stm.prepare_graphs()\n",
-    "result = stm.find_solutions(graph_interaction_settings_groups)\n",
+    "problem_sets = stm.create_problem_sets()\n",
+    "result = stm.find_solutions(problem_sets)\n",
     "\n",
     "print(\"found\", len(result.solutions), \"solutions!\")\n",
     "result.get_intermediate_particles().names"
@@ -331,9 +316,9 @@
    "source": [
     "# particles are found by name comparison,\n",
     "# i.e. f2 will find all f2's and f all f's independent of their spin\n",
-    "stm.allowed_intermediate_particles = [\"f(0)\", \"f(2)\"]\n",
+    "stm.set_allowed_intermediate_particles([\"f(0)\", \"f(2)\"])\n",
     "\n",
-    "result = stm.find_solutions(graph_interaction_settings_groups)\n",
+    "result = stm.find_solutions(problem_sets)\n",
     "\n",
     "print(\"found\", len(result.solutions), \"solutions!\")\n",
     "result.get_intermediate_particles().names"
@@ -503,7 +488,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.6.9"
   }
  },
  "nbformat": 4,

--- a/docs/usage/workflow.ipynb
+++ b/docs/usage/workflow.ipynb
@@ -11,6 +11,9 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    },
     "tags": [
      "remove-cell"
     ]
@@ -488,7 +491,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.9"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,

--- a/src/expertsystem/amplitude/__init__.py
+++ b/src/expertsystem/amplitude/__init__.py
@@ -10,7 +10,7 @@ possible.
 """
 
 
-from expertsystem.reaction.solving import Result
+from expertsystem.reaction import Result
 
 from .canonical_decay import CanonicalAmplitudeGenerator
 from .helicity_decay import HelicityAmplitudeGenerator

--- a/src/expertsystem/io/_dot.py
+++ b/src/expertsystem/io/_dot.py
@@ -49,8 +49,8 @@ def __graph_to_dot_content(
     graph: StateTransitionGraph, prefix: str = ""
 ) -> str:
     dot_source = ""
-    top = graph.get_initial_state_edges()
-    outs = graph.get_final_state_edges()
+    top = graph.get_initial_state_edge_ids()
+    outs = graph.get_final_state_edge_ids()
     for edge_id in top + outs:
         dot_source += _DOT_DEFAULT_NODE.format(
             prefix + __node_name(edge_id), __edge_label(graph, edge_id)
@@ -86,9 +86,9 @@ def __rank_string(node_edge_ids: List[int], prefix: str = "") -> str:
 
 def __edge_label(graph: StateTransitionGraph, edge_id: int) -> str:
     if isinstance(graph, StateTransitionGraph):
-        if edge_id not in graph.edge_props:
+        edge_prop = graph.get_edge_props(edge_id)
+        if not edge_prop:
             return str(edge_id)
-        edge_prop = graph.edge_props[edge_id]
         if isinstance(edge_prop, Particle):
             return edge_prop.name
         if isinstance(edge_prop, tuple):

--- a/src/expertsystem/io/_yaml/_dump.py
+++ b/src/expertsystem/io/_yaml/_dump.py
@@ -103,7 +103,7 @@ def __from_spin(instance: Spin) -> Union[Dict[str, Union[float, int]], int]:
 def __attempt_to_int(value: Union[Spin, float, int]) -> Union[float, int]:
     if isinstance(value, Spin):
         value = float(value)
-    if value.is_integer():
+    if isinstance(value, float) and value.is_integer():
         return int(value)
     return value
 

--- a/src/expertsystem/reaction/__init__.py
+++ b/src/expertsystem/reaction/__init__.py
@@ -8,7 +8,8 @@ particle reaction problems.
 
 import logging
 import multiprocessing
-from copy import copy, deepcopy
+from collections import defaultdict
+from copy import deepcopy
 from enum import Enum, auto
 from itertools import product
 from multiprocessing import Pool
@@ -24,10 +25,11 @@ from typing import (
     Union,
 )
 
+import attr
 from tqdm import tqdm
 
 from expertsystem import io
-from expertsystem.particle import ParticleCollection
+from expertsystem.particle import Particle, ParticleCollection
 from expertsystem.reaction.conservation_rules import (
     BaryonNumberConservation,
     BottomnessConservation,
@@ -57,16 +59,19 @@ from ._default_settings import (
 from ._system_control import (
     CompareGraphNodePropertiesFunctor,
     GammaCheck,
-    GraphSettingsGroups,
     InteractionDeterminator,
+    InteractionTypes,
     LeptonCheck,
+    create_edge_properties,
+    create_interaction_properties,
+    create_node_properties,
+    create_particle,
     filter_interaction_types,
-    group_by_strength,
     remove_duplicate_solutions,
 )
 from .combinatorics import (
     StateDefinition,
-    initialize_graph,
+    create_initial_facts,
     match_external_edges,
 )
 from .quantum_numbers import (
@@ -78,12 +83,13 @@ from .quantum_numbers import (
 from .solving import (
     CSPSolver,
     EdgeSettings,
+    GraphElementProperties,
     GraphSettings,
-    InteractionTypes,
     NodeSettings,
-    Result,
+    ProblemSet,
+    QNResult,
     Rule,
-    validate_fully_initialized_graph,
+    validate_full_solution,
 )
 from .topology import (
     InteractionNode,
@@ -100,6 +106,282 @@ class SolvingMode(Enum):
     """find "likeliest" solutions only"""
     Full = auto()
     """find all possible solutions"""
+
+
+class Result:
+    """Defines a result to a problem set processed by the solving code."""
+
+    # pylint: disable=too-many-arguments
+    def __init__(
+        self,
+        solutions: Optional[
+            List[StateTransitionGraph[ParticleWithSpin]]
+        ] = None,
+        not_executed_node_rules: Optional[Dict[int, Set[str]]] = None,
+        violated_node_rules: Optional[Dict[int, Set[str]]] = None,
+        not_executed_edge_rules: Optional[Dict[int, Set[str]]] = None,
+        violated_edge_rules: Optional[Dict[int, Set[str]]] = None,
+        formalism_type: Optional[str] = None,
+    ) -> None:
+        # pylint: disable=too-many-locals
+        if solutions and (violated_node_rules or violated_edge_rules):
+            raise ValueError(
+                "Invalid Result! Found solutions, but also violated rules."
+            )
+
+        self.__formalism_type = formalism_type
+        self.__solutions: List[StateTransitionGraph[ParticleWithSpin]] = list()
+        if solutions is not None:
+            self.__solutions = solutions
+
+        self.__not_executed_node_rules: Dict[int, Set[str]] = defaultdict(set)
+        if not_executed_node_rules is not None:
+            self.__not_executed_node_rules = not_executed_node_rules
+
+        self.__violated_node_rules: Dict[int, Set[str]] = defaultdict(set)
+        if violated_node_rules is not None:
+            self.__violated_node_rules = violated_node_rules
+
+        self.__not_executed_edge_rules: Dict[int, Set[str]] = defaultdict(set)
+        if not_executed_edge_rules is not None:
+            self.__not_executed_edge_rules = not_executed_edge_rules
+
+        self.__violated_edge_rules: Dict[int, Set[str]] = defaultdict(set)
+        if violated_edge_rules is not None:
+            self.__violated_edge_rules = violated_edge_rules
+
+    @property
+    def formalism_type(self) -> Optional[str]:
+        return self.__formalism_type
+
+    @property
+    def solutions(self) -> List[StateTransitionGraph[ParticleWithSpin]]:
+        return self.__solutions
+
+    @property
+    def not_executed_node_rules(self) -> Dict[int, Set[str]]:
+        return self.__not_executed_node_rules
+
+    @property
+    def violated_node_rules(self) -> Dict[int, Set[str]]:
+        return self.__violated_node_rules
+
+    @property
+    def not_executed_edge_rules(self) -> Dict[int, Set[str]]:
+        return self.__not_executed_edge_rules
+
+    @property
+    def violated_edge_rules(self) -> Dict[int, Set[str]]:
+        return self.__violated_edge_rules
+
+    def extend(
+        self, other_result: "Result", intersect_violations: bool = False
+    ) -> None:
+        if self.solutions or other_result.solutions:
+            self.__solutions.extend(other_result.solutions)
+            self.__not_executed_node_rules.clear()
+            self.__violated_node_rules.clear()
+            self.__not_executed_edge_rules.clear()
+            self.__violated_edge_rules.clear()
+        else:
+            for key, rules in other_result.not_executed_node_rules.items():
+                self.__not_executed_node_rules[key].update(rules)
+
+            for key, rules in other_result.not_executed_edge_rules.items():
+                self.__not_executed_edge_rules[key].update(rules)
+
+            for key, rules2 in other_result.violated_node_rules.items():
+                if intersect_violations:
+                    self.__violated_node_rules[key] &= rules2
+                else:
+                    self.__violated_node_rules[key].update(rules2)
+
+            for key, rules2 in other_result.violated_edge_rules.items():
+                if intersect_violations:
+                    self.__violated_edge_rules[key] &= rules2
+                else:
+                    self.__violated_edge_rules[key].update(rules2)
+
+    def get_initial_state(self) -> List[Particle]:
+        graph = self.__get_first_graph()
+        return [
+            x[0]
+            for x in map(
+                graph.get_edge_props, graph.get_initial_state_edge_ids()
+            )
+            if x
+        ]
+
+    def get_final_state(self) -> List[Particle]:
+        graph = self.__get_first_graph()
+        return [
+            x[0]
+            for x in map(
+                graph.get_edge_props, graph.get_final_state_edge_ids()
+            )
+            if x
+        ]
+
+    def __get_first_graph(self) -> StateTransitionGraph:
+        if len(self.solutions) == 0:
+            raise ValueError(
+                f"No solutions in {self.__class__.__name__} object"
+            )
+        return self.solutions[0]
+
+    def get_intermediate_particles(self) -> ParticleCollection:
+        """Extract the names of the intermediate state particles."""
+        intermediate_states = ParticleCollection()
+        for graph in self.solutions:
+            for edge_props in map(
+                graph.get_edge_props, graph.get_intermediate_state_edge_ids()
+            ):
+                if edge_props:
+                    particle, _ = edge_props
+                    if particle not in intermediate_states:
+                        intermediate_states.add(particle)
+        return intermediate_states
+
+    def get_particle_graphs(self) -> List[StateTransitionGraph[Particle]]:
+        """Strip `list` of `.StateTransitionGraph` s of the spin projections.
+
+        Extract a `list` of `.StateTransitionGraph` instances with only
+        particles on the edges.
+
+        .. seealso:: :doc:`/usage/visualization`
+        """
+        inventory: List[StateTransitionGraph[Particle]] = list()
+        for graph in self.solutions:
+            if any(
+                [
+                    graph.compare(
+                        other, edge_comparator=lambda e1, e2: e1[0] == e2
+                    )
+                    for other in inventory
+                ]
+            ):
+                continue
+            new_edge_props = dict()
+            for edge_id in graph.edges:
+                edge_props = graph.get_edge_props(edge_id)
+                if edge_props:
+                    new_edge_props[edge_id] = edge_props[0]
+            inventory.append(
+                StateTransitionGraph[Particle](
+                    topology=Topology(nodes=graph.nodes, edges=graph.edges),
+                    node_props={
+                        i: node_props
+                        for i, node_props in zip(
+                            graph.nodes, map(graph.get_node_props, graph.nodes)
+                        )
+                        if node_props
+                    },
+                    edge_props=new_edge_props,
+                )
+            )
+        inventory = sorted(
+            inventory,
+            key=lambda g: [
+                g.get_edge_props(i).mass
+                for i in g.get_intermediate_state_edge_ids()
+            ],
+        )
+        return inventory
+
+    def collapse_graphs(
+        self,
+    ) -> List[StateTransitionGraph[ParticleCollection]]:
+        def merge_into(
+            graph: StateTransitionGraph[Particle],
+            merged_graph: StateTransitionGraph[ParticleCollection],
+        ) -> None:
+            if (
+                graph.get_intermediate_state_edge_ids()
+                != merged_graph.get_intermediate_state_edge_ids()
+            ):
+                raise ValueError(
+                    "Cannot merge graphs that don't have the same edge IDs"
+                )
+            for i in graph.edges:
+                particle = graph.get_edge_props(i)
+                other_particles = merged_graph.get_edge_props(i)
+                if particle not in other_particles:
+                    other_particles += particle
+
+        def is_same_shape(
+            graph: StateTransitionGraph[Particle],
+            merged_graph: StateTransitionGraph[ParticleCollection],
+        ) -> bool:
+            if graph.edges != merged_graph.edges:
+                return False
+            for edge_id in (
+                graph.get_initial_state_edge_ids()
+                + graph.get_final_state_edge_ids()
+            ):
+                edge_prop = merged_graph.get_edge_props(edge_id)
+                if len(edge_prop) != 1:
+                    return False
+                other_particle = next(iter(edge_prop))
+                if other_particle != graph.get_edge_props(edge_id):
+                    return False
+            return True
+
+        graphs = self.get_particle_graphs()
+        inventory: List[StateTransitionGraph[ParticleCollection]] = list()
+        for graph in graphs:
+            append_to_inventory = True
+            for merged_graph in inventory:
+                if is_same_shape(graph, merged_graph):
+                    merge_into(graph, merged_graph)
+                    append_to_inventory = False
+                    break
+            if append_to_inventory:
+                new_edge_props = {
+                    edge_id: ParticleCollection(
+                        {graph.get_edge_props(edge_id)}
+                    )
+                    for edge_id in graph.edges
+                }
+                inventory.append(
+                    StateTransitionGraph[ParticleCollection](
+                        topology=Topology(
+                            nodes=graph.nodes, edges=graph.edges
+                        ),
+                        node_props={
+                            i: graph.get_node_props(i) for i in graph.nodes
+                        },
+                        edge_props=new_edge_props,
+                    )
+                )
+        return inventory
+
+
+@attr.s(frozen=True)
+class InitialFacts:
+    edge_props: Dict[int, ParticleWithSpin] = attr.ib(factory=dict)
+    node_props: Dict[int, InteractionProperties] = attr.ib(factory=dict)
+
+
+def _group_by_strength(
+    problem_sets: List[ProblemSet],
+) -> Dict[float, List[ProblemSet]]:
+    def calculate_strength(
+        node_interaction_settings: Dict[int, NodeSettings]
+    ) -> float:
+        strength = 1.0
+        for int_setting in node_interaction_settings.values():
+            strength *= int_setting.interaction_strength
+        return strength
+
+    strength_sorted_problem_sets: Dict[float, List[ProblemSet]] = defaultdict(
+        list
+    )
+    for problem_set in problem_sets:
+        strength = calculate_strength(
+            problem_set.solving_settings.node_settings
+        )
+        strength_sorted_problem_sets[strength].append(problem_set)
+    return strength_sorted_problem_sets
 
 
 class StateTransitionManager:  # pylint: disable=too-many-instance-attributes
@@ -200,16 +482,20 @@ class StateTransitionManager:  # pylint: disable=too-many-instance-attributes
         if reload_pdg or len(self.__particles) == 0:
             self.__particles = load_default_particles()
 
-        self.__allowed_intermediate_particles = self.__particles
+        self.__allowed_intermediate_particles = list()
         if allowed_intermediate_particles is not None:
             self.set_allowed_intermediate_particles(
                 allowed_intermediate_particles
             )
+        else:
+            self.__allowed_intermediate_particles = [
+                create_edge_properties(x) for x in self.__particles
+            ]
 
     def set_allowed_intermediate_particles(
         self, particle_names: List[str]
     ) -> None:
-        self.__allowed_intermediate_particles = ParticleCollection()
+        self.__allowed_intermediate_particles = list()
         for particle_name in particle_names:
             matches = self.__particles.filter(
                 lambda p: particle_name  # pylint: disable=cell-var-from-loop
@@ -220,7 +506,9 @@ class StateTransitionManager:  # pylint: disable=too-many-instance-attributes
                     "Could not find any matches for allowed intermediate "
                     f' particle "{particle_name}"'
                 )
-            self.__allowed_intermediate_particles += matches
+            self.__allowed_intermediate_particles += [
+                create_edge_properties(x) for x in matches
+            ]
 
     @property
     def formalism_type(self) -> str:
@@ -262,87 +550,86 @@ class StateTransitionManager:  # pylint: disable=too-many-instance-attributes
                 )
         self.allowed_interaction_types = allowed_interaction_types
 
-    def prepare_graphs(self) -> GraphSettingsGroups:
-        topology_graphs = self._build_topologies()
-        seed_graphs = self._create_seed_graphs(topology_graphs)
-        graph_setting_pairs = []
-        for seed_graph in seed_graphs:
-            graph_setting_pairs.extend(
-                [
-                    (seed_graph, x)
-                    for x in self._determine_graph_settings(seed_graph)
-                ]
-            )
+    def create_problem_sets(self) -> Dict[float, List[ProblemSet]]:
+        topology_graphs = self.__build_topologies()
+        problem_sets = []
+        for topology in topology_graphs:
+            for initial_facts in self.__create_initial_facts(topology):
+                problem_sets.extend(
+                    [
+                        ProblemSet(
+                            topology=topology,
+                            initial_facts=_convert_to_graph_props(
+                                initial_facts
+                            ),
+                            solving_settings=x,
+                        )
+                        for x in self.__determine_graph_settings(
+                            topology, initial_facts
+                        )
+                    ]
+                )
         # create groups of settings ordered by "probability"
-        graph_settings_groups = group_by_strength(graph_setting_pairs)
-        return graph_settings_groups
+        return _group_by_strength(problem_sets)
 
-    def _build_topologies(self) -> List[Topology]:
+    def __build_topologies(self) -> List[Topology]:
         all_graphs = self.topology_builder.build_graphs(
             len(self.initial_state), len(self.final_state)
         )
         logging.info(f"number of topology graphs: {len(all_graphs)}")
         return all_graphs
 
-    def _create_seed_graphs(
-        self, topology_graphs: List[Topology]
-    ) -> List[StateTransitionGraph[ParticleWithSpin]]:
+    def __create_initial_facts(self, topology: Topology) -> List[InitialFacts]:
         # initialize the graph edges (initial and final state)
-        init_graphs: List[StateTransitionGraph[ParticleWithSpin]] = []
-        for topology_graph in topology_graphs:
-            initialized_graphs = initialize_graph(
-                topology=topology_graph,
-                particles=self.__particles,
-                initial_state=self.initial_state,
-                final_state=self.final_state,
-                final_state_groupings=self.final_state_groupings,
-            )
-            init_graphs.extend(initialized_graphs)
-        for graph in init_graphs:
-            graph.graph_node_properties_comparator = (
-                CompareGraphNodePropertiesFunctor()
-            )
 
-        logging.info(f"initialized {len(init_graphs)} graphs!")
-        return init_graphs
+        initial_facts = create_initial_facts(
+            topology=topology,
+            particles=self.__particles,
+            initial_state=self.initial_state,
+            final_state=self.final_state,
+            final_state_groupings=self.final_state_groupings,
+        )
 
-    def _determine_graph_settings(
-        self, graph: StateTransitionGraph[ParticleWithSpin]
+        logging.info(f"initialized {len(initial_facts)} graphs!")
+        return [InitialFacts(edge_props=x) for x in initial_facts]
+
+    def __determine_graph_settings(
+        self, topology: Topology, initial_facts: InitialFacts
     ) -> List[GraphSettings]:
         # pylint: disable=too-many-locals
-        final_state_edges = graph.get_final_state_edges()
-        initial_state_edges = graph.get_initial_state_edges()
+        final_state_edges = topology.get_final_state_edge_ids()
+        initial_state_edges = topology.get_initial_state_edge_ids()
         graph_settings: List[GraphSettings] = [
             GraphSettings(
                 edge_settings={
                     edge_id: self.interaction_type_settings[
                         InteractionTypes.Weak
                     ][0]
-                    for edge_id in graph.edges
+                    for edge_id in topology.edges
                 },
                 node_settings={},
             )
         ]
 
-        for node_id in graph.nodes:
+        for node_id in topology.nodes:
             interaction_types: List[InteractionTypes] = []
-            out_edge_ids = graph.get_edges_outgoing_from_node(node_id)
-            in_edge_ids = graph.get_edges_outgoing_from_node(node_id)
+            out_edge_ids = topology.get_edge_ids_outgoing_from_node(node_id)
+            in_edge_ids = topology.get_edge_ids_outgoing_from_node(node_id)
             in_edge_props = [
-                graph.edge_props[edge_id]
+                initial_facts.edge_props[edge_id]
                 for edge_id in [
                     x for x in in_edge_ids if x in initial_state_edges
                 ]
             ]
             out_edge_props = [
-                graph.edge_props[edge_id]
+                initial_facts.edge_props[edge_id]
                 for edge_id in [
                     x for x in out_edge_ids if x in final_state_edges
                 ]
             ]
             node_props = InteractionProperties()
-            if node_id in graph.node_props:
-                node_props = graph.node_props[node_id]
+            if node_id in initial_facts.node_props:
+                node_props = initial_facts.node_props[node_id]
             for int_det in self.interaction_determinators:
                 determined_interactions = int_det.check(
                     in_edge_props, out_edge_props, node_props
@@ -376,41 +663,39 @@ class StateTransitionManager:  # pylint: disable=too-many-instance-attributes
 
     def find_solutions(
         self,
-        graph_setting_groups: GraphSettingsGroups,
+        problem_sets: Dict[float, List[ProblemSet]],
     ) -> Result:  # pylint: disable=too-many-locals
         """Check for solutions for a specific set of interaction settings."""
         results: Dict[float, Result] = {}
         logging.info(
             "Number of interaction settings groups being processed: %d",
-            len(graph_setting_groups),
+            len(problem_sets),
         )
-        total = sum(map(len, graph_setting_groups.values()))
+        total = sum(map(len, problem_sets.values()))
         progress_bar = tqdm(
             total=total,
             desc="Propagating quantum numbers",
             disable=logging.getLogger().level > logging.WARNING,
         )
-        for strength, graph_setting_group in sorted(
-            graph_setting_groups.items(), reverse=True
-        ):
+        for strength, problems in sorted(problem_sets.items(), reverse=True):
             logging.info(
                 "processing interaction settings group with "
                 f"strength {strength}",
             )
-            logging.info(f"{graph_setting_group} entries in this group")
+            logging.info(f"{len(problems)} entries in this group")
             logging.info(f"running with {self.number_of_threads} threads...")
 
             temp_results: List[Result] = []
             if self.number_of_threads > 1:
                 with Pool(self.number_of_threads) as pool:
                     for result in pool.imap_unordered(
-                        self._solve, graph_setting_group, 1
+                        self._solve, problems, 1
                     ):
                         temp_results.append(result)
                         progress_bar.update()
             else:
-                for graph_setting_pair in graph_setting_group:
-                    temp_results.append(self._solve(graph_setting_pair))
+                for problem in problems:
+                    temp_results.append(self._solve(problem))
                     progress_bar.update()
             for temp_result in temp_results:
                 if strength not in results:
@@ -452,15 +737,65 @@ class StateTransitionManager:  # pylint: disable=too-many-instance-attributes
             formalism_type=self.formalism_type,
         )
 
-    def _solve(
-        self,
-        state_graph_node_settings_pair: Tuple[
-            StateTransitionGraph[ParticleWithSpin], GraphSettings
-        ],
-    ) -> Result:
+    def _solve(self, problem_set: ProblemSet) -> Result:
         solver = CSPSolver(self.__allowed_intermediate_particles)
 
-        return solver.find_solutions(*state_graph_node_settings_pair)
+        qn_result = solver.find_solutions(problem_set)
+
+        return _convert_result(
+            problem_set.topology, qn_result, self.__particles
+        )
+
+
+def _convert_result(
+    topology: Topology, qn_result: QNResult, particles: ParticleCollection
+) -> Result:
+    """Converts a `.QNResult` with a `.Topology` into a `.Result.
+
+    There is currently a ParticleCollection that has to be handed through in
+    order to retrieve the Particle name from a pid. This has to be fixed nicely
+    in the future!
+    """
+    solutions = []
+    for solution in qn_result.solutions:
+        graph = StateTransitionGraph[ParticleWithSpin](
+            topology=topology,
+            node_props={
+                i: create_interaction_properties(x)
+                for i, x in solution.node_quantum_numbers.items()
+            },
+            edge_props={
+                i: create_particle(x, particles)
+                for i, x in solution.edge_quantum_numbers.items()
+            },
+        )
+        graph.graph_node_properties_comparator = (
+            CompareGraphNodePropertiesFunctor()
+        )
+        solutions.append(graph)
+
+    return Result(
+        solutions=solutions,
+        violated_edge_rules=qn_result.violated_edge_rules,
+        violated_node_rules=qn_result.violated_node_rules,
+        not_executed_node_rules=qn_result.not_executed_node_rules,
+        not_executed_edge_rules=qn_result.not_executed_edge_rules,
+    )
+
+
+def _convert_to_graph_props(
+    initial_facts: InitialFacts,
+) -> GraphElementProperties:
+    node_props = {
+        k: create_node_properties(v)
+        for k, v in initial_facts.node_props.items()
+    }
+    edge_props = {
+        k: create_edge_properties(v[0], v[1])
+        for k, v in initial_facts.edge_props.items()
+    }
+
+    return GraphElementProperties(node_props=node_props, edge_props=edge_props)
 
 
 def check_reaction_violations(
@@ -491,30 +826,40 @@ def check_reaction_violations(
         initial_state = [initial_state]  # type: ignore
 
     def _check_violations(
-        graph: StateTransitionGraph, node_rules: Set[Rule]
-    ) -> Set[str]:
-        node_id = list(graph.nodes)[0]
-        return validate_fully_initialized_graph(
-            graph,
-            rules_per_node={node_id: node_rules},
-            rules_per_edge={},
-        ).violated_node_rules[node_id]
+        facts: InitialFacts,
+        node_rules: Dict[int, Set[Rule]],
+        edge_rules: Dict[int, Set[GraphElementRule]],
+    ) -> QNResult:
+        return validate_full_solution(
+            ProblemSet(
+                topology=topology,
+                initial_facts=_convert_to_graph_props(facts),
+                solving_settings=GraphSettings(
+                    node_settings={
+                        i: NodeSettings(conservation_rules=rules)
+                        for i, rules in node_rules.items()
+                    },
+                    edge_settings={
+                        i: EdgeSettings(conservation_rules=rules)
+                        for i, rules in edge_rules.items()
+                    },
+                ),
+            )
+        )
 
-    def check_pure_edge_rules(
-        graph: StateTransitionGraph[ParticleWithSpin],
-    ) -> None:
+    def check_pure_edge_rules() -> None:
         pure_edge_rules: Set[GraphElementRule] = {
             gellmann_nishijima,
             isospin_validity,
         }
 
-        edge_check_result = validate_fully_initialized_graph(
-            graph,
-            rules_per_node={},
-            rules_per_edge={
+        edge_check_result = _check_violations(
+            initial_facts[0],
+            node_rules={},
+            edge_rules={
                 edge_id: pure_edge_rules
-                for edge_id in graph.get_initial_state_edges()
-                + graph.get_final_state_edges()
+                for edge_id in topology.get_initial_state_edge_ids()
+                + topology.get_final_state_edge_ids()
             },
         )
 
@@ -536,9 +881,7 @@ def check_reaction_violations(
             len(initial_state), len(final_state)
         )[0]
 
-    def check_edge_qn_conservation(
-        graph: StateTransitionGraph[ParticleWithSpin],
-    ) -> Set[FrozenSet[str]]:
+    def check_edge_qn_conservation() -> Set[FrozenSet[str]]:
         """Check if edge quantum numbers are conserved.
 
         Those rules give the same results, independent on the node and spin
@@ -561,23 +904,33 @@ def check_reaction_violations(
 
         return {
             frozenset((x,))
-            for x in _check_violations(graph, edge_qn_conservation_rules)
+            for x in _check_violations(
+                initial_facts[0],
+                node_rules={
+                    i: edge_qn_conservation_rules for i in topology.nodes
+                },
+                edge_rules={},
+            ).violated_node_rules[node_id]
         }
 
     # Using a n-body topology is enough, to determine the violations reliably
     # since only certain spin rules require the isobar model. These spin rules
     # are not required here though.
     topology = create_n_body_topology()
+    node_id = next(iter(topology.nodes))
 
-    initialized_graphs = initialize_graph(
-        topology=topology,
-        particles=load_default_particles(),
-        initial_state=initial_state,
-        final_state=final_state,
-    )
+    initial_facts = [
+        InitialFacts(edge_props=x)
+        for x in create_initial_facts(
+            topology=topology,
+            particles=load_default_particles(),
+            initial_state=initial_state,
+            final_state=final_state,
+        )
+    ]
 
-    check_pure_edge_rules(initialized_graphs[0])
-    violations = check_edge_qn_conservation(initialized_graphs[0])
+    check_pure_edge_rules()
+    violations = check_edge_qn_conservation()
 
     # Create combinations of graphs for magnitudes of S and L, but only
     # if it is a two body reaction
@@ -585,29 +938,35 @@ def check_reaction_violations(
         InteractionProperties(l_magnitude=l_mag, s_magnitude=s_mag)
         for l_mag, s_mag in product([0, 1], [0, 0.5, 1, 1.5, 2])
     ]
-    node_id = next(iter(topology.nodes))
-    graphs = []
+
+    initial_facts_list = []
     for ls_combi in ls_combinations:
-        for graph in initialized_graphs:
-            new_graph = copy(graph)
-            new_graph.node_props = {node_id: ls_combi}
-            graphs.append(new_graph)
+        for facts_combination in initial_facts:
+            new_facts = attr.evolve(
+                facts_combination,
+                node_props={node_id: ls_combi},
+            )
+            initial_facts_list.append(new_facts)
 
     # Verify each graph with the interaction rules.
     # Spin projection rules are skipped as they can only be checked reliably
     # for a isobar topology (too difficult to solve)
-    conservation_rules: Set[Rule] = {
-        c_parity_conservation,
-        clebsch_gordan_helicity_to_canonical,
-        g_parity_conservation,
-        parity_conservation,
-        spin_magnitude_conservation,
-        identical_particle_symmetrization,
+    conservation_rules: Dict[int, Set[Rule]] = {
+        node_id: {
+            c_parity_conservation,
+            clebsch_gordan_helicity_to_canonical,
+            g_parity_conservation,
+            parity_conservation,
+            spin_magnitude_conservation,
+            identical_particle_symmetrization,
+        }
     }
 
     conservation_rule_violations: List[Set[str]] = []
-    for graph in graphs:
-        rule_violations = _check_violations(graph, conservation_rules)
+    for facts in initial_facts_list:
+        rule_violations = _check_violations(
+            facts=facts, node_rules=conservation_rules, edge_rules={}
+        ).violated_node_rules[node_id]
         conservation_rule_violations.append(rule_violations)
 
     # first add rules which consistently fail
@@ -736,8 +1095,8 @@ def generate(  # pylint: disable=too-many-arguments
             allowed_interaction_types
         )
         stm.set_allowed_interaction_types(list(interaction_types))
-    graph_interaction_settings_groups = stm.prepare_graphs()
-    return stm.find_solutions(graph_interaction_settings_groups)
+    problem_sets = stm.create_problem_sets()
+    return stm.find_solutions(problem_sets)
 
 
 def _determine_interaction_types(

--- a/src/expertsystem/reaction/__init__.py
+++ b/src/expertsystem/reaction/__init__.py
@@ -67,6 +67,7 @@ from ._system_control import (
     remove_duplicate_solutions,
 )
 from .combinatorics import (
+    InitialFacts,
     StateDefinition,
     create_initial_facts,
     match_external_edges,
@@ -363,12 +364,6 @@ class Result:
         return inventory
 
 
-@attr.s(frozen=True)
-class InitialFacts:
-    edge_props: Dict[int, ParticleWithSpin] = attr.ib(factory=dict)
-    node_props: Dict[int, InteractionProperties] = attr.ib(factory=dict)
-
-
 @attr.s
 class ProblemSet:
     """Particle reaction problem set, defined as a graph like data structure.
@@ -602,8 +597,6 @@ class StateTransitionManager:  # pylint: disable=too-many-instance-attributes
         return all_graphs
 
     def __create_initial_facts(self, topology: Topology) -> List[InitialFacts]:
-        # initialize the graph edges (initial and final state)
-
         initial_facts = create_initial_facts(
             topology=topology,
             particles=self.__particles,
@@ -613,7 +606,7 @@ class StateTransitionManager:  # pylint: disable=too-many-instance-attributes
         )
 
         logging.info(f"initialized {len(initial_facts)} graphs!")
-        return [InitialFacts(edge_props=x) for x in initial_facts]
+        return initial_facts
 
     def __determine_graph_settings(
         self, topology: Topology, initial_facts: InitialFacts
@@ -957,15 +950,12 @@ def check_reaction_violations(
     topology = create_n_body_topology()
     node_id = next(iter(topology.nodes))
 
-    initial_facts = [
-        InitialFacts(edge_props=x)
-        for x in create_initial_facts(
-            topology=topology,
-            particles=load_default_particles(),
-            initial_state=initial_state,
-            final_state=final_state,
-        )
-    ]
+    initial_facts = create_initial_facts(
+        topology=topology,
+        particles=load_default_particles(),
+        initial_state=initial_state,
+        final_state=final_state,
+    )
 
     check_pure_edge_rules()
     violations = check_edge_qn_conservation()

--- a/src/expertsystem/reaction/_default_settings.py
+++ b/src/expertsystem/reaction/_default_settings.py
@@ -4,6 +4,7 @@ from copy import deepcopy
 from os.path import dirname, join, realpath
 from typing import Dict, List, Tuple, Union
 
+from expertsystem.reaction._system_control import InteractionTypes
 from expertsystem.reaction.conservation_rules import (
     BaryonNumberConservation,
     BottomnessConservation,
@@ -36,11 +37,7 @@ from expertsystem.reaction.quantum_numbers import (
     EdgeQuantumNumbers,
     NodeQuantumNumbers,
 )
-from expertsystem.reaction.solving import (
-    EdgeSettings,
-    InteractionTypes,
-    NodeSettings,
-)
+from expertsystem.reaction.solving import EdgeSettings, NodeSettings
 
 __EXPERT_SYSTEM_PATH = dirname(dirname(realpath(__file__)))
 __DEFAULT_PARTICLE_LIST_FILE = "additional_particle_definitions.yml"

--- a/src/expertsystem/reaction/_system_control.py
+++ b/src/expertsystem/reaction/_system_control.py
@@ -40,26 +40,25 @@ def create_edge_properties(
         if not qn_name.startswith("__")
     }  # Note using attr.fields does not work here because init=False
     property_map: GraphEdgePropertyMap = {}
+    isospin = None
     for qn_name, value in attr.asdict(particle).items():
-        if value is None:
-            continue
         if isinstance(value, Parity):
             value = value.value
         if qn_name in edge_qn_mapping:
             property_map[edge_qn_mapping[qn_name]] = value
         else:
             if "isospin" in qn_name:
-                property_map[
-                    EdgeQuantumNumbers.isospin_magnitude
-                ] = value.magnitude
-                property_map[
-                    EdgeQuantumNumbers.isospin_projection
-                ] = value.projection
+                isospin = value
             elif "spin" in qn_name:
                 property_map[EdgeQuantumNumbers.spin_magnitude] = value
 
     if spin_projection is not None:
         property_map[EdgeQuantumNumbers.spin_projection] = spin_projection
+    if isospin is not None:
+        property_map[EdgeQuantumNumbers.isospin_magnitude] = isospin.magnitude
+        property_map[
+            EdgeQuantumNumbers.isospin_projection
+        ] = isospin.projection
     return property_map
 
 

--- a/src/expertsystem/reaction/_system_control.py
+++ b/src/expertsystem/reaction/_system_control.py
@@ -2,12 +2,12 @@
 
 import logging
 from abc import ABC, abstractmethod
-from enum import Enum, auto
 from typing import Callable, Dict, List, Optional, Set, Tuple, Type
 
 import attr
 
 from expertsystem.particle import Parity, Particle, ParticleCollection
+from expertsystem.reaction.default_settings import InteractionTypes
 from expertsystem.reaction.quantum_numbers import (
     EdgeQuantumNumber,
     EdgeQuantumNumbers,
@@ -28,14 +28,6 @@ Strength = float
 GraphSettingsGroups = Dict[
     Strength, List[Tuple[StateTransitionGraph, GraphSettings]]
 ]
-
-
-class InteractionTypes(Enum):
-    """Types of interactions in the form of an enumerate."""
-
-    Strong = auto()
-    EM = auto()
-    Weak = auto()
 
 
 def create_edge_properties(
@@ -110,8 +102,8 @@ def create_particle(
     Raises:
         KeyError: If the edge properties do not contain the pid information or
           no particle with the same pid is found in the `.ParticleCollection`.
-        ValueError: If the edge properties do not contain spin projection info.
 
+        ValueError: If the edge properties do not contain spin projection info.
     """
     particle = particles.find(int(edge_props[EdgeQuantumNumbers.pid]))
     if EdgeQuantumNumbers.spin_projection not in edge_props:

--- a/src/expertsystem/reaction/_system_control.py
+++ b/src/expertsystem/reaction/_system_control.py
@@ -2,20 +2,24 @@
 
 import logging
 from abc import ABC, abstractmethod
+from enum import Enum, auto
 from typing import Callable, Dict, List, Optional, Set, Tuple, Type
 
 import attr
 
+from expertsystem.particle import Parity, Particle, ParticleCollection, Spin
 from expertsystem.reaction.quantum_numbers import (
+    EdgeQuantumNumber,
+    EdgeQuantumNumbers,
     InteractionProperties,
     NodeQuantumNumber,
+    NodeQuantumNumbers,
     ParticleWithSpin,
 )
 from expertsystem.reaction.solving import (
+    GraphEdgePropertyMap,
+    GraphNodePropertyMap,
     GraphSettings,
-    InteractionTypes,
-    NodeSettings,
-    _get_node_quantum_number,
 )
 from expertsystem.reaction.topology import StateTransitionGraph
 
@@ -24,6 +28,123 @@ Strength = float
 GraphSettingsGroups = Dict[
     Strength, List[Tuple[StateTransitionGraph, GraphSettings]]
 ]
+
+
+class InteractionTypes(Enum):
+    """Types of interactions in the form of an enumerate."""
+
+    Strong = auto()
+    EM = auto()
+    Weak = auto()
+
+
+def create_edge_properties(
+    particle: Particle,
+    spin_projection: Optional[float] = None,
+) -> GraphEdgePropertyMap:
+    edge_qn_mapping: Dict[str, Type[EdgeQuantumNumber]] = {
+        qn_name: qn_type
+        for qn_name, qn_type in EdgeQuantumNumbers.__dict__.items()
+        if not qn_name.startswith("__")
+    }  # Note using attr.fields does not work here because init=False
+    property_map: GraphEdgePropertyMap = {}
+    for qn_name, value in attr.asdict(particle).items():
+        if value is None:
+            continue
+        if isinstance(value, Parity):
+            value = value.value
+        if qn_name in edge_qn_mapping:
+            property_map[edge_qn_mapping[qn_name]] = value
+        else:
+            if "isospin" in qn_name:
+                property_map[
+                    EdgeQuantumNumbers.isospin_magnitude
+                ] = value.magnitude
+                property_map[
+                    EdgeQuantumNumbers.isospin_projection
+                ] = value.projection
+            elif "spin" in qn_name:
+                property_map[EdgeQuantumNumbers.spin_magnitude] = value
+
+    if spin_projection is not None:
+        property_map[EdgeQuantumNumbers.spin_projection] = spin_projection
+    return property_map
+
+
+def create_node_properties(
+    node_props: InteractionProperties,
+) -> GraphNodePropertyMap:
+    node_qn_mapping: Dict[str, Type[NodeQuantumNumber]] = {
+        qn_name: qn_type
+        for qn_name, qn_type in NodeQuantumNumbers.__dict__.items()
+        if not qn_name.startswith("__")
+    }  # Note using attr.fields does not work here because init=False
+    property_map: GraphNodePropertyMap = {}
+    for qn_name, value in attr.asdict(node_props).items():
+        if value is None:
+            continue
+        if qn_name in node_qn_mapping:
+            property_map[node_qn_mapping[qn_name]] = value
+        else:
+            raise TypeError(
+                f"Missmatch between InteractionProperties and "
+                f"NodeQuantumNumbers. NodeQuantumNumbers does not define "
+                f"{qn_name}"
+            )
+    return property_map
+
+
+def create_particle(
+    edge_props: GraphEdgePropertyMap, particles: ParticleCollection
+) -> ParticleWithSpin:
+    particle_kwargs = {}
+    spin_magnitude = None
+    spin_projection = None
+    isospin_magnitude = None
+    isospin_projection = None
+
+    for qn_type, qn_value in edge_props.items():
+        if qn_type == EdgeQuantumNumbers.spin_magnitude:
+            spin_magnitude = qn_value
+        elif qn_type == EdgeQuantumNumbers.spin_projection:
+            spin_projection = qn_value
+        elif qn_type == EdgeQuantumNumbers.isospin_magnitude:
+            isospin_magnitude = qn_value
+        elif qn_type == EdgeQuantumNumbers.isospin_projection:
+            isospin_projection = qn_value
+        else:
+            particle_kwargs[qn_type.__name__] = qn_value
+
+    if isospin_magnitude is not None and isospin_projection is not None:
+        particle_kwargs["isospin"] = Spin(  # type: ignore
+            isospin_magnitude, isospin_projection
+        )
+    if spin_magnitude is None:
+        raise ValueError(
+            "GraphEdgePropertyMap does not contain a spin magnitude!"
+        )
+    particle_kwargs["spin"] = spin_magnitude
+    particle_kwargs["name"] = particles.find(particle_kwargs["pid"]).name
+
+    if spin_projection is None:
+        raise ValueError(
+            "GraphEdgePropertyMap does not contain a spin projection!"
+        )
+
+    return (Particle(**particle_kwargs), spin_projection)  # type: ignore
+
+
+def create_interaction_properties(
+    qn_solution: GraphNodePropertyMap,
+) -> InteractionProperties:
+    converted_solution = {k.__name__: v for k, v in qn_solution.items()}
+    kw_args = {
+        x.name: converted_solution[x.name]
+        for x in attr.fields(InteractionProperties)
+        if x.name in converted_solution
+    }
+
+    return attr.evolve(InteractionProperties(), **kw_args)
 
 
 class CompareGraphNodePropertiesFunctor:
@@ -37,20 +158,16 @@ class CompareGraphNodePropertiesFunctor:
 
     def __call__(
         self,
-        node_props1: Dict[int, InteractionProperties],
-        node_props2: Dict[int, InteractionProperties],
+        node_props1: InteractionProperties,
+        node_props2: InteractionProperties,
     ) -> bool:
-        for node_id, node_props in node_props1.items():
-            other_node_props = node_props2[node_id]
-            if attr.evolve(
-                node_props,
-                **{x.__name__: None for x in self.__ignored_qn_list},
-            ) != attr.evolve(
-                other_node_props,
-                **{x.__name__: None for x in self.__ignored_qn_list},
-            ):
-                return False
-        return True
+        return attr.evolve(
+            node_props1,
+            **{x.__name__: None for x in self.__ignored_qn_list},
+        ) == attr.evolve(
+            node_props2,
+            **{x.__name__: None for x in self.__ignored_qn_list},
+        )
 
 
 def filter_interaction_types(
@@ -161,14 +278,13 @@ def _remove_qns_from_graph(  # pylint: disable=too-many-branches
     qn_list: Set[Type[NodeQuantumNumber]],
 ) -> StateTransitionGraph[ParticleWithSpin]:
     new_node_props = {}
-    for node_id, node_props in graph.node_props.items():
+    for node_id in graph.nodes:
+        node_props = graph.get_node_props(node_id)
         new_node_props[node_id] = attr.evolve(
             node_props, **{x.__name__: None for x in qn_list}
         )
 
-    graph.node_props = new_node_props
-
-    return graph
+    return graph.evolve(node_props=new_node_props)
 
 
 def _check_equal_ignoring_qns(
@@ -236,7 +352,7 @@ def require_interaction_property(
     ingoing_particle_name: str,
     interaction_qn: Type[NodeQuantumNumber],
     allowed_values: List,
-) -> Callable[[StateTransitionGraph], bool]:
+) -> Callable[[StateTransitionGraph[ParticleWithSpin]], bool]:
     """Filter function.
 
     Closure, which can be used as a filter function in :func:`.filter_graphs`.
@@ -261,7 +377,7 @@ def require_interaction_property(
             - *False* otherwise
     """
 
-    def check(graph: StateTransitionGraph) -> bool:
+    def check(graph: StateTransitionGraph[ParticleWithSpin]) -> bool:
         node_ids = _find_node_ids_with_ingoing_particle_name(
             graph, ingoing_particle_name
         )
@@ -269,7 +385,7 @@ def require_interaction_property(
             return False
         for i in node_ids:
             if (
-                _get_node_quantum_number(interaction_qn, graph.node_props[i])
+                getattr(graph.get_node_props(i), interaction_qn.__name__)
                 not in allowed_values
             ):
                 return False
@@ -283,32 +399,10 @@ def _find_node_ids_with_ingoing_particle_name(
 ) -> List[int]:
     found_node_ids = []
     for node_id in graph.nodes:
-        edge_ids = graph.get_edges_ingoing_to_node(node_id)
-        for edge_id in edge_ids:
-            edge_props = graph.edge_props[edge_id]
+        for edge_id in graph.get_edge_ids_ingoing_to_node(node_id):
+            edge_props = graph.get_edge_props(edge_id)
             edge_particle_name = edge_props[0].name
             if str(ingoing_particle_name) in str(edge_particle_name):
                 found_node_ids.append(node_id)
                 break
     return found_node_ids
-
-
-def group_by_strength(
-    graph_node_setting_pairs: List[Tuple[StateTransitionGraph, GraphSettings]]
-) -> GraphSettingsGroups:
-    graph_settings_groups: GraphSettingsGroups = {}
-    for (instance, graph_settings) in graph_node_setting_pairs:
-        strength = _calculate_strength(graph_settings.node_settings)
-        if strength not in graph_settings_groups:
-            graph_settings_groups[strength] = []
-        graph_settings_groups[strength].append((instance, graph_settings))
-    return graph_settings_groups
-
-
-def _calculate_strength(
-    node_interaction_settings: Dict[int, NodeSettings]
-) -> float:
-    strength = 1.0
-    for int_setting in node_interaction_settings.values():
-        strength *= int_setting.interaction_strength
-    return strength

--- a/src/expertsystem/reaction/argument_handling.py
+++ b/src/expertsystem/reaction/argument_handling.py
@@ -39,7 +39,7 @@ Rule = Union[GraphElementRule, EdgeQNConservationRule, ConservationRule]
 
 _ElementType = TypeVar("_ElementType", EdgeQuantumNumber, NodeQuantumNumber)
 
-GraphElementPropertyMap = Dict[Type[_ElementType], Union[int, float, None]]
+GraphElementPropertyMap = Dict[Type[_ElementType], Scalar]
 GraphEdgePropertyMap = GraphElementPropertyMap[EdgeQuantumNumber]
 GraphNodePropertyMap = GraphElementPropertyMap[NodeQuantumNumber]
 

--- a/src/expertsystem/reaction/argument_handling.py
+++ b/src/expertsystem/reaction/argument_handling.py
@@ -144,9 +144,9 @@ class _ValueExtractor(Generic[_ElementType]):
     def __extract(
         self, props: GraphElementPropertyMap[_ElementType]
     ) -> _ElementType:
-        # print(props, self.__obj_type)
         value = props[self.__obj_type]
-
+        if value is None:
+            return None
         if (
             "__supertype__" in self.__obj_type.__dict__
             and self.__obj_type.__supertype__ == Parity  # type: ignore

--- a/src/expertsystem/reaction/combinatorics.py
+++ b/src/expertsystem/reaction/combinatorics.py
@@ -15,6 +15,7 @@ from typing import (
     Dict,
     Generator,
     List,
+    Mapping,
     Optional,
     Sequence,
     Set,
@@ -147,7 +148,8 @@ class _KinematicRepresentation:
 
 
 def _get_kinematic_representation(
-    graph: StateTransitionGraph[StateWithSpins],
+    topology: Topology,
+    initial_facts: Mapping[int, StateWithSpins],
 ) -> _KinematicRepresentation:
     r"""Group final or initial states by node, sorted by length of the group.
 
@@ -194,19 +196,21 @@ def _get_kinematic_representation(
     def get_state_groupings(
         edge_per_node_getter: Callable[[int], List[int]]
     ) -> List[List[int]]:
-        return [edge_per_node_getter(i) for i in graph.nodes]
+        return [edge_per_node_getter(i) for i in topology.nodes]
 
-    def fill_groupings(grouping_with_ids: List[List[Any]]) -> List[List[Any]]:
+    def fill_groupings(
+        grouping_with_ids: List[List[int]],
+    ) -> List[List[StateWithSpins]]:
         return [
-            [graph.edge_props[edge_id] for edge_id in group]
+            [initial_facts[edge_id] for edge_id in group]
             for group in grouping_with_ids
         ]
 
     initial_state_edge_groups = fill_groupings(
-        get_state_groupings(graph.get_originating_initial_state_edges)
+        get_state_groupings(topology.get_originating_initial_state_edge_ids)
     )
     final_state_edge_groups = fill_groupings(
-        get_state_groupings(graph.get_originating_final_state_edges)
+        get_state_groupings(topology.get_originating_final_state_edge_ids)
     )
     return _KinematicRepresentation(
         initial_state=initial_state_edge_groups,
@@ -214,7 +218,7 @@ def _get_kinematic_representation(
     )
 
 
-def initialize_graph(  # pylint: disable=too-many-locals
+def create_initial_facts(  # pylint: disable=too-many-locals
     topology: Topology,
     particles: ParticleCollection,
     initial_state: Sequence[StateDefinition],
@@ -222,7 +226,7 @@ def initialize_graph(  # pylint: disable=too-many-locals
     final_state_groupings: Optional[
         Union[List[List[List[str]]], List[List[str]], List[str]]
     ] = None,
-) -> List[StateTransitionGraph[ParticleWithSpin]]:
+) -> List[Dict[int, ParticleWithSpin]]:
     def embed_in_list(some_list: List[Any]) -> List[List[Any]]:
         if not isinstance(some_list[0], list):
             return [some_list]
@@ -261,7 +265,7 @@ def _generate_kinematic_permutations(
     allowed_kinematic_groupings: Optional[
         List[_KinematicRepresentation]
     ] = None,
-) -> List[StateTransitionGraph[StateWithSpins]]:
+) -> List[Dict[int, StateWithSpins]]:
     def assert_number_of_states(
         state_definitions: Sequence, edge_ids: Sequence[int]
     ) -> None:
@@ -271,8 +275,10 @@ def _generate_kinematic_permutations(
                 f"(len({state_definitions}) != len({edge_ids})"
             )
 
-    assert_number_of_states(initial_state, topology.get_initial_state_edges())
-    assert_number_of_states(final_state, topology.get_final_state_edges())
+    assert_number_of_states(
+        initial_state, topology.get_initial_state_edge_ids()
+    )
+    assert_number_of_states(final_state, topology.get_final_state_edge_ids())
 
     def is_allowed_grouping(
         kinematic_representation: _KinematicRepresentation,
@@ -291,26 +297,24 @@ def _generate_kinematic_permutations(
         final_state, particles
     )
 
-    graphs: List[StateTransitionGraph[StateWithSpins]] = list()
+    initial_facts_combinations: List[Dict[int, StateWithSpins]] = list()
     kinematic_representations: List[_KinematicRepresentation] = list()
     for permutation in _generate_outer_edge_permutations(
         topology,
         initial_state_with_projections,
         final_state_with_projections,
     ):
-        graph: StateTransitionGraph[
-            StateWithSpins
-        ] = StateTransitionGraph.from_topology(topology)
-        graph.edge_props.update(permutation)
-        kinematic_representation = _get_kinematic_representation(graph)
+        kinematic_representation = _get_kinematic_representation(
+            topology, permutation
+        )
         if kinematic_representation in kinematic_representations:
             continue
         if not is_allowed_grouping(kinematic_representation):
             continue
         kinematic_representations.append(kinematic_representation)
-        graphs.append(graph)
+        initial_facts_combinations.append(permutation)
 
-    return graphs
+    return initial_facts_combinations
 
 
 def _safe_set_spin_projections(
@@ -352,8 +356,8 @@ def _generate_outer_edge_permutations(
     initial_state: Sequence[StateWithSpins],
     final_state: Sequence[StateWithSpins],
 ) -> Generator[Dict[int, StateWithSpins], None, None]:
-    initial_state_ids = topology.get_initial_state_edges()
-    final_state_ids = topology.get_final_state_edges()
+    initial_state_ids = topology.get_initial_state_edge_ids()
+    final_state_ids = topology.get_final_state_edge_ids()
     for initial_state_permutation in permutations(initial_state):
         for final_state_permutation in permutations(final_state):
             yield dict(
@@ -365,43 +369,47 @@ def _generate_outer_edge_permutations(
 
 
 def _generate_spin_permutations(
-    graph: StateTransitionGraph[StateWithSpins],
+    initial_facts: Dict[int, StateWithSpins],
     particle_db: ParticleCollection,
-) -> List[StateTransitionGraph[ParticleWithSpin]]:
+) -> List[Dict[int, ParticleWithSpin]]:
     def populate_edge_with_spin_projections(
-        uninitialized_graph: StateTransitionGraph[ParticleWithSpin],
+        permutation: Dict[int, ParticleWithSpin],
         edge_id: int,
         state: StateWithSpins,
-    ) -> List[StateTransitionGraph[ParticleWithSpin]]:
+    ) -> List[Dict[int, ParticleWithSpin]]:
         particle_name, spin_projections = state
         particle = particle_db[particle_name]
-        output_graph = []
+        new_permutations = []
         for projection in spin_projections:
-            graph_copy = deepcopy(uninitialized_graph)
-            graph_copy.edge_props[edge_id] = (particle, projection)
-            output_graph.append(graph_copy)
-        return output_graph
+            temp_permutation = deepcopy(permutation)
+            temp_permutation.update({edge_id: (particle, projection)})
+            new_permutations.append(temp_permutation)
+        return new_permutations
 
-    edge_particle_dict = {
-        edge_id: graph.edge_props[edge_id]
-        for edge_id in graph.get_initial_state_edges()
-        + graph.get_final_state_edges()
-    }
-
-    # now add more quantum numbers given by user (spin_projection)
-    uninitialized_graph = StateTransitionGraph.from_topology(graph)
-    output_graphs: List[StateTransitionGraph[ParticleWithSpin]] = [
-        uninitialized_graph
-    ]
-    for edge_id, state in edge_particle_dict.items():
-        temp_graphs = output_graphs
-        output_graphs = []
-        for temp_graph in temp_graphs:
-            output_graphs.extend(
-                populate_edge_with_spin_projections(temp_graph, edge_id, state)
+    initial_facts_permutations: List[Dict[int, ParticleWithSpin]] = [dict()]
+    for edge_id, state in initial_facts.items():
+        temp_permutations = initial_facts_permutations
+        initial_facts_permutations = []
+        for temp_permutation in temp_permutations:
+            initial_facts_permutations.extend(
+                populate_edge_with_spin_projections(
+                    temp_permutation, edge_id, state
+                )
             )
 
-    return output_graphs
+    return initial_facts_permutations
+
+
+def __get_initial_state_edge_ids(
+    graph: StateTransitionGraph[ParticleWithSpin],
+) -> List[int]:
+    return graph.get_initial_state_edge_ids()
+
+
+def __get_final_state_edge_ids(
+    graph: StateTransitionGraph[ParticleWithSpin],
+) -> List[int]:
+    return graph.get_final_state_edge_ids()
 
 
 def match_external_edges(
@@ -412,24 +420,28 @@ def match_external_edges(
     if not graphs:
         return
     ref_graph_id = 0
-    _match_external_edge_ids(graphs, ref_graph_id, "get_final_state_edges")
-    _match_external_edge_ids(graphs, ref_graph_id, "get_initial_state_edges")
+    _match_external_edge_ids(graphs, ref_graph_id, __get_final_state_edge_ids)
+    _match_external_edge_ids(
+        graphs, ref_graph_id, __get_initial_state_edge_ids
+    )
 
 
 def _match_external_edge_ids(  # pylint: disable=too-many-locals
     graphs: List[StateTransitionGraph[ParticleWithSpin]],
     ref_graph_id: int,
-    external_edge_getter_function: str,
+    external_edge_getter_function: Callable[
+        [StateTransitionGraph], Sequence[int]
+    ],
 ) -> None:
     ref_graph = graphs[ref_graph_id]
     # create external edge to particle mapping
     ref_edge_id_particle_mapping = _create_edge_id_particle_mapping(
-        ref_graph, external_edge_getter_function
+        ref_graph, external_edge_getter_function(ref_graph)
     )
 
     for graph in graphs[:ref_graph_id] + graphs[ref_graph_id + 1 :]:
         edge_id_particle_mapping = _create_edge_id_particle_mapping(
-            graph, external_edge_getter_function
+            graph, external_edge_getter_function(graph)
         )
         # remove matching entries
         ref_mapping_copy = deepcopy(ref_edge_id_particle_mapping)
@@ -465,13 +477,13 @@ def perform_external_edge_identical_particle_combinatorics(
     if not isinstance(graph, StateTransitionGraph):
         raise TypeError("graph argument is not of type StateTransitionGraph!")
     temp_new_graphs = _external_edge_identical_particle_combinatorics(
-        graph, "get_final_state_edges"
+        graph, __get_final_state_edge_ids
     )
     new_graphs = []
     for new_graph in temp_new_graphs:
         new_graphs.extend(
             _external_edge_identical_particle_combinatorics(
-                new_graph, "get_initial_state_edges"
+                new_graph, __get_initial_state_edge_ids
             )
         )
     return new_graphs
@@ -479,12 +491,14 @@ def perform_external_edge_identical_particle_combinatorics(
 
 def _external_edge_identical_particle_combinatorics(
     graph: StateTransitionGraph[ParticleWithSpin],
-    external_edge_getter_function: str,
+    external_edge_getter_function: Callable[
+        [StateTransitionGraph], Sequence[int]
+    ],
 ) -> List[StateTransitionGraph]:
     # pylint: disable=too-many-locals
     new_graphs = [graph]
     edge_particle_mapping = _create_edge_id_particle_mapping(
-        graph, external_edge_getter_function
+        graph, external_edge_getter_function(graph)
     )
     identical_particle_groups: Dict[str, Set[int]] = {}
     for key, value in edge_particle_mapping.items():
@@ -536,10 +550,10 @@ def _calculate_swappings(id_mapping: Dict[int, int]) -> OrderedDict:
 
 
 def _create_edge_id_particle_mapping(
-    graph: StateTransitionGraph[ParticleWithSpin],
-    external_edge_getter_function: str,
+    graph: StateTransitionGraph[ParticleWithSpin], edge_ids: Sequence[int]
 ) -> Dict[int, str]:
     return {
-        i: graph.edge_props[i][0].name
-        for i in getattr(graph, external_edge_getter_function)()
+        i: graph.get_edge_props(i)[0].name
+        for i in edge_ids
+        if graph.get_edge_props(i)
     }

--- a/src/expertsystem/reaction/combinatorics.py
+++ b/src/expertsystem/reaction/combinatorics.py
@@ -248,13 +248,13 @@ def create_initial_facts(  # pylint: disable=too-many-locals
         final_state=final_state,
         allowed_kinematic_groupings=allowed_kinematic_groupings,
     )
-    output_graphs = list()
+    edge_initial_facts = list()
     for kinematic_permutation in kinematic_permutation_graphs:
         spin_permutations = _generate_spin_permutations(
             kinematic_permutation, particles
         )
-        output_graphs.extend(spin_permutations)
-    return output_graphs
+        edge_initial_facts.extend(spin_permutations)
+    return edge_initial_facts
 
 
 def _generate_kinematic_permutations(

--- a/src/expertsystem/reaction/combinatorics.py
+++ b/src/expertsystem/reaction/combinatorics.py
@@ -23,13 +23,21 @@ from typing import (
     Union,
 )
 
+import attr
+
 from expertsystem.particle import Particle, ParticleCollection
 
-from .quantum_numbers import ParticleWithSpin
+from .quantum_numbers import InteractionProperties, ParticleWithSpin
 from .topology import StateTransitionGraph, Topology
 
 StateWithSpins = Tuple[str, Sequence[float]]
 StateDefinition = Union[str, StateWithSpins]
+
+
+@attr.s(frozen=True)
+class InitialFacts:
+    edge_props: Dict[int, ParticleWithSpin] = attr.ib(factory=dict)
+    node_props: Dict[int, InteractionProperties] = attr.ib(factory=dict)
 
 
 class _KinematicRepresentation:
@@ -226,7 +234,7 @@ def create_initial_facts(  # pylint: disable=too-many-locals
     final_state_groupings: Optional[
         Union[List[List[List[str]]], List[List[str]], List[str]]
     ] = None,
-) -> List[Dict[int, ParticleWithSpin]]:
+) -> List[InitialFacts]:
     def embed_in_list(some_list: List[Any]) -> List[List[Any]]:
         if not isinstance(some_list[0], list):
             return [some_list]
@@ -253,7 +261,9 @@ def create_initial_facts(  # pylint: disable=too-many-locals
         spin_permutations = _generate_spin_permutations(
             kinematic_permutation, particles
         )
-        edge_initial_facts.extend(spin_permutations)
+        edge_initial_facts.extend(
+            [InitialFacts(edge_props=x) for x in spin_permutations]
+        )
     return edge_initial_facts
 
 

--- a/src/expertsystem/reaction/default_settings.py
+++ b/src/expertsystem/reaction/default_settings.py
@@ -1,10 +1,10 @@
 """Default configuration for the `expertsystem`."""
 
 from copy import deepcopy
+from enum import Enum, auto
 from os.path import dirname, join, realpath
 from typing import Dict, List, Tuple, Union
 
-from expertsystem.reaction._system_control import InteractionTypes
 from expertsystem.reaction.conservation_rules import (
     BaryonNumberConservation,
     BottomnessConservation,
@@ -77,6 +77,14 @@ __EDGE_RULE_PRIORITIES: Dict[GraphElementRule, int] = {
     isospin_validity: 61,
     spin_validity: 62,
 }
+
+
+class InteractionTypes(Enum):
+    """Types of interactions in the form of an enumerate."""
+
+    Strong = auto()
+    EM = auto()
+    Weak = auto()
 
 
 def _get_spin_magnitudes(is_nbody: bool) -> List[float]:

--- a/src/expertsystem/reaction/solving.py
+++ b/src/expertsystem/reaction/solving.py
@@ -322,8 +322,6 @@ def __is_sub_mapping(
     qn_state: GraphEdgePropertyMap, reference_qn_state: GraphEdgePropertyMap
 ) -> bool:
     for qn_type, qn_value in qn_state.items():
-        if qn_value is None:
-            continue
         if qn_type is EdgeQuantumNumbers.spin_projection:
             continue
         if qn_type not in reference_qn_state:

--- a/src/expertsystem/reaction/solving.py
+++ b/src/expertsystem/reaction/solving.py
@@ -322,6 +322,8 @@ def __is_sub_mapping(
     qn_state: GraphEdgePropertyMap, reference_qn_state: GraphEdgePropertyMap
 ) -> bool:
     for qn_type, qn_value in qn_state.items():
+        if qn_value is None:
+            continue
         if qn_type is EdgeQuantumNumbers.spin_projection:
             continue
         if qn_type not in reference_qn_state:

--- a/src/expertsystem/reaction/solving.py
+++ b/src/expertsystem/reaction/solving.py
@@ -14,8 +14,6 @@ import inspect
 import logging
 from abc import ABC, abstractmethod
 from collections import defaultdict
-from copy import copy
-from enum import Enum, auto
 from typing import (
     Any,
     Callable,
@@ -40,8 +38,6 @@ from constraint import (
     Variable,
 )
 
-from expertsystem.particle import Parity, Particle, ParticleCollection, Spin
-
 from .argument_handling import (
     GraphEdgePropertyMap,
     GraphElementRule,
@@ -54,19 +50,9 @@ from .argument_handling import (
 from .quantum_numbers import (
     EdgeQuantumNumber,
     EdgeQuantumNumbers,
-    InteractionProperties,
     NodeQuantumNumber,
-    ParticleWithSpin,
 )
-from .topology import StateTransitionGraph
-
-
-class InteractionTypes(Enum):
-    """Types of interactions in the form of an enumerate."""
-
-    Strong = auto()
-    EM = auto()
-    Weak = auto()
+from .topology import Topology
 
 
 @attr.s
@@ -102,6 +88,35 @@ class NodeSettings:
 class GraphSettings:
     edge_settings: Dict[int, EdgeSettings] = attr.ib(factory=dict)
     node_settings: Dict[int, NodeSettings] = attr.ib(factory=dict)
+
+
+@attr.s
+class GraphElementProperties:
+    edge_props: Dict[int, GraphEdgePropertyMap] = attr.ib(factory=dict)
+    node_props: Dict[int, GraphNodePropertyMap] = attr.ib(factory=dict)
+
+
+@attr.s(frozen=True)
+class ProblemSet:
+    """Particle reaction problem set, defined as a graph like data structure.
+
+    initial_facts
+    solving_settings
+    """
+
+    topology: Topology = attr.ib()
+    initial_facts: GraphElementProperties = attr.ib()
+    solving_settings: GraphSettings = attr.ib()
+
+    # def __validate(self):
+    #     """validate if initial_facts and solving settings match the topology."""
+    #     pass
+
+
+@attr.s(frozen=True)
+class _QuantumNumberSolution:
+    node_quantum_numbers: Dict[int, GraphNodePropertyMap] = attr.ib()
+    edge_quantum_numbers: Dict[int, GraphEdgePropertyMap] = attr.ib()
 
 
 def convert_violated_rules_to_names(
@@ -148,15 +163,13 @@ def convert_non_executed_rules_to_names(
     return converted_dict
 
 
-class Result:
+class QNResult:
     """Defines a result to a problem set processed by the solving code."""
 
     # pylint: disable=too-many-arguments
     def __init__(
         self,
-        solutions: Optional[
-            List[StateTransitionGraph[ParticleWithSpin]]
-        ] = None,
+        solutions: Optional[List[_QuantumNumberSolution]] = None,
         not_executed_node_rules: Optional[Dict[int, Set[str]]] = None,
         violated_node_rules: Optional[Dict[int, Set[str]]] = None,
         not_executed_edge_rules: Optional[Dict[int, Set[str]]] = None,
@@ -170,7 +183,7 @@ class Result:
             )
 
         self.__formalism_type = formalism_type
-        self.__solutions: List[StateTransitionGraph[ParticleWithSpin]] = list()
+        self.__solutions: List[_QuantumNumberSolution] = list()
         if solutions is not None:
             self.__solutions = solutions
 
@@ -195,7 +208,7 @@ class Result:
         return self.__formalism_type
 
     @property
-    def solutions(self) -> List[StateTransitionGraph[ParticleWithSpin]]:
+    def solutions(self) -> List[_QuantumNumberSolution]:
         return self.__solutions
 
     @property
@@ -215,7 +228,7 @@ class Result:
         return self.__violated_edge_rules
 
     def extend(
-        self, other_result: "Result", intersect_violations: bool = False
+        self, other_result: "QNResult", intersect_violations: bool = False
     ) -> None:
         if self.solutions or other_result.solutions:
             self.__solutions.extend(other_result.solutions)
@@ -242,144 +255,12 @@ class Result:
                 else:
                     self.__violated_edge_rules[key].update(rules2)
 
-    def get_initial_state(self) -> List[Particle]:
-        graph = self.__get_first_graph()
-        return [
-            graph.edge_props[i][0] for i in graph.get_initial_state_edges()
-        ]
-
-    def get_final_state(self) -> List[Particle]:
-        graph = self.__get_first_graph()
-        return [graph.edge_props[i][0] for i in graph.get_final_state_edges()]
-
-    def __get_first_graph(self) -> StateTransitionGraph:
-        if len(self.solutions) == 0:
-            raise ValueError(
-                f"No solutions in {self.__class__.__name__} object"
-            )
-        return self.solutions[0]
-
-    def get_intermediate_particles(self) -> ParticleCollection:
-        """Extract the names of the intermediate state particles."""
-        intermediate_states = ParticleCollection()
-        for graph in self.solutions:
-            for edge_id in graph.get_intermediate_state_edges():
-                particle, _ = graph.edge_props[edge_id]
-                if particle not in intermediate_states:
-                    intermediate_states.add(particle)
-        return intermediate_states
-
-    def get_particle_graphs(self) -> List[StateTransitionGraph[Particle]]:
-        """Strip `list` of `.StateTransitionGraph` s of the spin projections.
-
-        Extract a `list` of `.StateTransitionGraph` instances with only
-        particles on the edges.
-
-        .. seealso:: :doc:`/usage/visualization`
-        """
-        inventory: List[StateTransitionGraph[Particle]] = list()
-        for graph in self.solutions:
-            if any(
-                [
-                    graph.compare(
-                        other, edge_comparator=lambda e1, e2: e1[0] == e2
-                    )
-                    for other in inventory
-                ]
-            ):
-                continue
-            new_graph: StateTransitionGraph[
-                Particle
-            ] = StateTransitionGraph.from_topology(graph)
-            for i, edge_prop in graph.edge_props.items():
-                particle, _ = edge_prop
-                new_graph.edge_props[i] = particle
-            inventory.append(new_graph)
-        inventory = sorted(
-            inventory,
-            key=lambda g: [
-                g.edge_props[i].mass for i in g.get_intermediate_state_edges()
-            ],
-        )
-        return inventory
-
-    def collapse_graphs(
-        self,
-    ) -> List[StateTransitionGraph[ParticleCollection]]:
-        def merge_into(
-            graph: StateTransitionGraph[Particle],
-            merged_graph: StateTransitionGraph[ParticleCollection],
-        ) -> None:
-            if (
-                graph.get_intermediate_state_edges()
-                != merged_graph.get_intermediate_state_edges()
-            ):
-                raise ValueError(
-                    "Cannot merge graphs that don't have the same edge IDs"
-                )
-            for i in graph.edges:
-                particle = graph.edge_props[i]
-                other_particles = merged_graph.edge_props[i]
-                if particle not in other_particles:
-                    other_particles += particle
-
-        def is_same_shape(
-            graph: StateTransitionGraph[Particle],
-            merged_graph: StateTransitionGraph[ParticleCollection],
-        ) -> bool:
-            if graph.edges != merged_graph.edges:
-                return False
-            for edge_id in (
-                graph.get_initial_state_edges() + graph.get_final_state_edges()
-            ):
-                edge_prop = merged_graph.edge_props[edge_id]
-                if len(edge_prop) != 1:
-                    return False
-                other_particle = next(iter(edge_prop))
-                if other_particle != graph.edge_props[edge_id]:
-                    return False
-            return True
-
-        graphs = self.get_particle_graphs()
-        inventory: List[StateTransitionGraph[ParticleCollection]] = list()
-        for graph in graphs:
-            append_to_inventory = True
-            for merged_graph in inventory:
-                if is_same_shape(graph, merged_graph):
-                    merge_into(graph, merged_graph)
-                    append_to_inventory = False
-                    break
-            if append_to_inventory:
-                converted: StateTransitionGraph[
-                    ParticleCollection
-                ] = StateTransitionGraph.from_topology(graph)
-                converted.edge_props = {
-                    edge_id: ParticleCollection({particle})
-                    for edge_id, particle in graph.edge_props.items()
-                }
-                inventory.append(converted)
-        return inventory
-
-
-@attr.s(frozen=True)
-class _QuantumNumberSolution:
-    node_quantum_numbers: Dict[
-        int, Dict[Type[NodeQuantumNumber], Scalar]
-    ] = attr.field(factory=lambda: defaultdict(dict))
-    edge_quantum_numbers: Dict[
-        int, Dict[Type[EdgeQuantumNumber], Scalar]
-    ] = attr.field(factory=lambda: defaultdict(dict))
-
 
 class Solver(ABC):
     """Interface of a Solver."""
 
     @abstractmethod
-    def find_solutions(
-        self,
-        graph: StateTransitionGraph[ParticleWithSpin],
-        graph_settings: GraphSettings,
-    ) -> Result:
+    def find_solutions(self, problem_set: ProblemSet) -> QNResult:
         """Find solutions for the given input.
 
         It is expected that this function determines and returns all of the
@@ -401,26 +282,17 @@ class Solver(ABC):
         """
 
 
-def _merge_solutions_with_graph(
+def _merge_particle_candidates_with_solutions(
     solutions: List[_QuantumNumberSolution],
-    graph: StateTransitionGraph[ParticleWithSpin],
-    allowed_particles: ParticleCollection,
-) -> List[StateTransitionGraph[ParticleWithSpin]]:
-    initialized_graphs = []
+    topology: Topology,
+    allowed_particles: List[GraphEdgePropertyMap],
+) -> List[_QuantumNumberSolution]:
+    merged_solutions = []
 
     logging.debug("merging solutions with graph...")
-    intermediate_edges = graph.get_intermediate_state_edges()
+    intermediate_edges = topology.get_intermediate_state_edge_ids()
     for solution in solutions:
-        temp_graph = copy(graph)
-        for node_id in temp_graph.nodes:
-            if node_id in solution.node_quantum_numbers:
-                temp_graph.node_props[
-                    node_id
-                ] = _create_interaction_properties(
-                    solution.node_quantum_numbers[node_id]
-                )
-
-        current_new_graphs = [temp_graph]
+        current_new_solutions = [solution]
         for int_edge_id in intermediate_edges:
             particle_edges = __get_particle_candidates_for_state(
                 solution.edge_quantum_numbers[int_edge_id],
@@ -431,61 +303,52 @@ def _merge_solutions_with_graph(
                 logging.debug("edge id: %d", int_edge_id)
                 logging.debug("edge properties:")
                 logging.debug(solution.edge_quantum_numbers[int_edge_id])
-            new_graphs_temp = []
-            for current_new_graph in current_new_graphs:
+            new_solutions_temp = []
+            for current_new_solution in current_new_solutions:
                 for particle_edge in particle_edges:
-                    temp_graph = copy(current_new_graph)
-                    temp_graph.edge_props[int_edge_id] = particle_edge
-                    new_graphs_temp.append(temp_graph)
-            current_new_graphs = new_graphs_temp
+                    particle_edge.update(
+                        solution.edge_quantum_numbers[int_edge_id]
+                    )
+                    temp_solution = attr.evolve(
+                        current_new_solution,
+                        edge_quantum_numbers={int_edge_id: particle_edge},
+                    )
+                    new_solutions_temp.append(temp_solution)
+            current_new_solutions = new_solutions_temp
 
-        initialized_graphs.extend(current_new_graphs)
+        merged_solutions.extend(current_new_solutions)
 
-    return initialized_graphs
+    return merged_solutions
 
 
 def __get_particle_candidates_for_state(
-    state: Dict[Type[EdgeQuantumNumber], Scalar],
-    allowed_particles: ParticleCollection,
-) -> List[ParticleWithSpin]:
-    particle_edges: List[ParticleWithSpin] = []
+    state: GraphEdgePropertyMap,
+    allowed_particles: List[GraphEdgePropertyMap],
+) -> List[GraphEdgePropertyMap]:
+    particle_edges = []
 
-    for allowed_particle in allowed_particles:
-        if __check_qns_equal(state, allowed_particle):
-            particle_edges.append(
-                (allowed_particle, state[EdgeQuantumNumbers.spin_projection])
-            )
+    for particle_qns in allowed_particles:
+        if __is_sub_mapping(state, particle_qns):
+            particle_edges.append(particle_qns)
 
     return particle_edges
 
 
-def __check_qns_equal(
-    state: Dict[Type[EdgeQuantumNumber], Scalar], particle: Particle
+def __is_sub_mapping(
+    qn_state: GraphEdgePropertyMap, reference_qn_state: GraphEdgePropertyMap
 ) -> bool:
-    # This function assumes the attribute names of Particle and the quantum
-    # numbers defined by new type match
-    changes_dict: Dict[str, Union[int, float, Parity, Spin]] = {
-        edge_qn.__name__: value
-        for edge_qn, value in state.items()
-        if "magnitude" not in edge_qn.__name__
-        and "projection" not in edge_qn.__name__
-    }
+    for qn_type, qn_value in qn_state.items():
+        if qn_type is EdgeQuantumNumbers.spin_projection:
+            continue
+        if qn_type not in reference_qn_state:
+            return False
+        if qn_value != reference_qn_state[qn_type]:
+            return False
 
-    if EdgeQuantumNumbers.isospin_magnitude in state:
-        changes_dict["isospin"] = Spin(
-            state[EdgeQuantumNumbers.isospin_magnitude],
-            state[EdgeQuantumNumbers.isospin_projection],
-        )
-    if EdgeQuantumNumbers.spin_magnitude in state:
-        changes_dict["spin"] = state[EdgeQuantumNumbers.spin_magnitude]
-    return attr.evolve(particle, **changes_dict) == particle
+    return True
 
 
-def validate_fully_initialized_graph(
-    graph: StateTransitionGraph[ParticleWithSpin],
-    rules_per_node: Dict[int, Set[Rule]],
-    rules_per_edge: Dict[int, Set[GraphElementRule]],
-) -> Result:
+def validate_full_solution(problem_set: ProblemSet) -> QNResult:
     # pylint: disable=too-many-locals
     logging.debug("validating graph...")
 
@@ -496,13 +359,12 @@ def validate_fully_initialized_graph(
     ) -> Dict[Type[NodeQuantumNumber], Scalar]:
         """Create variables for the quantum numbers of the specified node."""
         variables = {}
-        if node_id in graph.node_props:
+        if node_id in problem_set.initial_facts.node_props:
+            node_props = problem_set.initial_facts.node_props[node_id]
+            variables = node_props
             for qn_type in qn_list:
-                value = _get_node_quantum_number(
-                    qn_type, graph.node_props[node_id]
-                )
-                if value is not None:
-                    variables[qn_type] = value
+                if qn_type in node_props:
+                    variables[qn_type] = node_props[qn_type]
         return variables
 
     def _create_edge_variables(
@@ -517,25 +379,26 @@ def validate_fully_initialized_graph(
         """
         variables = []
         for edge_id in edge_ids:
-            if edge_id in graph.edge_props:
+            if edge_id in problem_set.initial_facts.edge_props:
+                edge_props = problem_set.initial_facts.edge_props[edge_id]
                 edge_vars = {}
-                edge_props = graph.edge_props[edge_id]
                 for qn_type in qn_list:
-                    value = _get_particle_property(edge_props, qn_type)
-                    if value is not None:
-                        edge_vars[qn_type] = value
+                    if qn_type in edge_props:
+                        edge_vars[qn_type] = edge_props[qn_type]
                 variables.append(edge_vars)
         return variables
 
     def _create_variable_containers(
         node_id: int, cons_law: Rule
     ) -> Tuple[List[dict], List[dict], dict]:
-        in_edges = graph.get_edges_ingoing_to_node(node_id)
-        out_edges = graph.get_edges_outgoing_from_node(node_id)
+        in_edges = problem_set.topology.get_edge_ids_ingoing_to_node(node_id)
+        out_edges = problem_set.topology.get_edge_ids_outgoing_from_node(
+            node_id
+        )
 
         edge_qns, node_qns = get_required_qns(cons_law)
-        in_edges_vars = _create_edge_variables(in_edges, edge_qns)  # type: ignore
-        out_edges_vars = _create_edge_variables(out_edges, edge_qns)  # type: ignore
+        in_edges_vars = _create_edge_variables(in_edges, edge_qns)
+        out_edges_vars = _create_edge_variables(out_edges, edge_qns)
 
         node_vars = _create_node_variables(node_id, node_qns)
 
@@ -547,7 +410,11 @@ def validate_fully_initialized_graph(
     )
     node_violated_rules: Dict[int, Set[Rule]] = defaultdict(set)
     node_not_executed_rules: Dict[int, Set[Rule]] = defaultdict(set)
-    for edge_id, edge_rules in rules_per_edge.items():
+    for (
+        edge_id,
+        edge_settings,
+    ) in problem_set.solving_settings.edge_settings.items():
+        edge_rules = edge_settings.conservation_rules
         for edge_rule in edge_rules:
             # get the needed qns for this conservation law
             # for all edges and the node
@@ -570,8 +437,12 @@ def validate_fully_initialized_graph(
             else:
                 edge_not_executed_rules[edge_id].add(edge_rule)
 
-    for node_id, rules in rules_per_node.items():
-        for rule in rules:
+    for (
+        node_id,
+        node_settings,
+    ) in problem_set.solving_settings.node_settings.items():
+        node_rules = node_settings.conservation_rules
+        for rule in node_rules:
             # get the needed qns for this conservation law
             # for all edges and the node
             (
@@ -596,14 +467,21 @@ def validate_fully_initialized_graph(
             else:
                 node_not_executed_rules[node_id].add(rule)
     if node_violated_rules or node_not_executed_rules:
-        return Result(
+        return QNResult(
             [],
             convert_non_executed_rules_to_names(node_not_executed_rules),
             convert_violated_rules_to_names(node_violated_rules),
             convert_non_executed_rules_to_names(edge_not_executed_rules),
             convert_violated_rules_to_names(edge_violated_rules),
         )
-    return Result([graph])
+    return QNResult(
+        [
+            _QuantumNumberSolution(
+                edge_quantum_numbers=problem_set.initial_facts.edge_props,
+                node_quantum_numbers=problem_set.initial_facts.node_props,
+            )
+        ]
+    )
 
 
 _EdgeVariableInfo = Tuple[int, Type[EdgeQuantumNumber]]
@@ -620,17 +498,15 @@ def _create_variable_string(
 @attr.s
 class _VariableContainer:
     ingoing_edge_variables: Set[_EdgeVariableInfo] = attr.ib(factory=set)
-    fixed_ingoing_edge_variables: Dict[
-        int, Dict[Type[EdgeQuantumNumber], Scalar]
-    ] = attr.ib(factory=dict)
-    outgoing_edge_variables: Set[_EdgeVariableInfo] = attr.ib(factory=set)
-    fixed_outgoing_edge_variables: Dict[
-        int, Dict[Type[EdgeQuantumNumber], Scalar]
-    ] = attr.ib(factory=dict)
-    node_variables: Set[_NodeVariableInfo] = attr.ib(factory=set)
-    fixed_node_variables: Dict[Type[NodeQuantumNumber], Scalar] = attr.ib(
+    fixed_ingoing_edge_variables: Dict[int, GraphEdgePropertyMap] = attr.ib(
         factory=dict
     )
+    outgoing_edge_variables: Set[_EdgeVariableInfo] = attr.ib(factory=set)
+    fixed_outgoing_edge_variables: Dict[int, GraphEdgePropertyMap] = attr.ib(
+        factory=dict
+    )
+    node_variables: Set[_NodeVariableInfo] = attr.ib(factory=set)
+    fixed_node_variables: GraphNodePropertyMap = attr.ib(factory=dict)
 
 
 class CSPSolver(Solver):
@@ -645,8 +521,9 @@ class CSPSolver(Solver):
     """
 
     # pylint: disable=too-many-instance-attributes
-    def __init__(self, allowed_intermediate_particles: ParticleCollection):
-        self.__graph = StateTransitionGraph[ParticleWithSpin]()
+    def __init__(
+        self, allowed_intermediate_particles: List[GraphEdgePropertyMap]
+    ):
         self.__variables: Set[
             Union[_EdgeVariableInfo, _NodeVariableInfo]
         ] = set()
@@ -665,14 +542,9 @@ class CSPSolver(Solver):
         self.__allowed_intermediate_particles = allowed_intermediate_particles
         self.__scoresheet = Scoresheet()
 
-    def find_solutions(
-        self,
-        graph: StateTransitionGraph[ParticleWithSpin],
-        graph_settings: GraphSettings,
-    ) -> Result:
+    def find_solutions(self, problem_set: ProblemSet) -> QNResult:
         # pylint: disable=too-many-locals
-        self.__graph = graph
-        self.__initialize_constraints(graph_settings)
+        self.__initialize_constraints(problem_set)
         solutions = self.__problem.getSolutions()
 
         node_not_executed_rules = self.__non_executable_node_rules
@@ -695,33 +567,61 @@ class CSPSolver(Solver):
                 elif self.__scoresheet.rule_passes[(edge_id, rule)] == 0:
                     edge_not_satisfied_rules[edge_id].add(rule)
 
-        # insert particle instances
         solutions = self.__convert_solution_keys(solutions)
+
+        # insert particle instances
         if self.__node_rules or self.__edge_rules:
-            full_particle_graphs = _merge_solutions_with_graph(
-                solutions, graph, self.__allowed_intermediate_particles
+            full_particle_solutions = (
+                _merge_particle_candidates_with_solutions(
+                    solutions,
+                    problem_set.topology,
+                    self.__allowed_intermediate_particles,
+                )
             )
         else:
-            full_particle_graphs = [graph]
+            full_particle_solutions = [
+                _QuantumNumberSolution(
+                    node_quantum_numbers=problem_set.initial_facts.node_props,
+                    edge_quantum_numbers=problem_set.initial_facts.edge_props,
+                )
+            ]
 
-        if full_particle_graphs and (
+        if full_particle_solutions and (
             node_not_executed_rules or edge_not_executed_rules
         ):
             # rerun solver on these graphs using not executed rules
             # and combine results
-            result = Result()
-            for full_particle_graph in full_particle_graphs:
+            result = QNResult()
+            for full_particle_solution in full_particle_solutions:
+                node_props = full_particle_solution.node_quantum_numbers
+                edge_props = full_particle_solution.edge_quantum_numbers
+                node_props.update(problem_set.initial_facts.node_props)
+                edge_props.update(problem_set.initial_facts.edge_props)
                 result.extend(
-                    validate_fully_initialized_graph(
-                        full_particle_graph,
-                        node_not_executed_rules,
-                        edge_not_executed_rules,
+                    validate_full_solution(
+                        ProblemSet(
+                            topology=problem_set.topology,
+                            initial_facts=GraphElementProperties(
+                                node_props=node_props,
+                                edge_props=edge_props,
+                            ),
+                            solving_settings=GraphSettings(
+                                node_settings={
+                                    i: NodeSettings(conservation_rules=rules)
+                                    for i, rules in node_not_executed_rules.items()
+                                },
+                                edge_settings={
+                                    i: EdgeSettings(conservation_rules=rules)
+                                    for i, rules in edge_not_executed_rules.items()
+                                },
+                            ),
+                        )
                     )
                 )
             return result
 
-        return Result(
-            full_particle_graphs,
+        return QNResult(
+            full_particle_solutions,
             convert_non_executed_rules_to_names(node_not_executed_rules),
             convert_violated_rules_to_names(node_not_satisfied_rules),
             convert_non_executed_rules_to_names(edge_not_executed_rules),
@@ -736,7 +636,7 @@ class CSPSolver(Solver):
         self.__problem = Problem(BacktrackingSolver(True))
         self.__scoresheet = Scoresheet()
 
-    def __initialize_constraints(self, graph_settings: GraphSettings) -> None:
+    def __initialize_constraints(self, problem_set: ProblemSet) -> None:
         """Initialize all of the constraints for this graph.
 
         For each interaction node a set of independent constraints/conservation
@@ -771,10 +671,9 @@ class CSPSolver(Solver):
 
         arg_handler = RuleArgumentHandler()
 
-        for edge_id in self.__graph.edges:
-            for rule in get_rules_by_priority(
-                graph_settings.edge_settings[edge_id]
-            ):
+        for edge_id in problem_set.topology.edges:
+            edge_settings = problem_set.solving_settings.edge_settings[edge_id]
+            for rule in get_rules_by_priority(edge_settings):
                 variable_mapping = _VariableContainer()
                 # from cons law and graph determine needed var lists
                 edge_qns, node_qns = get_required_qns(rule)
@@ -784,7 +683,7 @@ class CSPSolver(Solver):
                         edge_id,
                     ],
                     edge_qns,
-                    graph_settings.edge_settings,
+                    problem_set,
                 )
 
                 score_callback = self.__scoresheet.register_rule(edge_id, rule)
@@ -807,17 +706,19 @@ class CSPSolver(Solver):
                         rule  # type: ignore
                     )
 
-        for node_id in self.__graph.nodes:
+        for node_id in problem_set.topology.nodes:
             for rule in get_rules_by_priority(
-                graph_settings.node_settings[node_id]
+                problem_set.solving_settings.node_settings[node_id]
             ):
                 variable_mapping = _VariableContainer()
                 # from cons law and graph determine needed var lists
                 edge_qns, node_qns = get_required_qns(rule)
 
-                in_edges = self.__graph.get_edges_ingoing_to_node(node_id)
+                in_edges = problem_set.topology.get_edge_ids_ingoing_to_node(
+                    node_id
+                )
                 in_edge_vars = self.__create_edge_variables(
-                    in_edges, edge_qns, graph_settings.edge_settings
+                    in_edges, edge_qns, problem_set
                 )
                 variable_mapping.ingoing_edge_variables = in_edge_vars[0]
                 variable_mapping.fixed_ingoing_edge_variables = in_edge_vars[1]
@@ -825,9 +726,13 @@ class CSPSolver(Solver):
                     Union[_EdgeVariableInfo, _NodeVariableInfo]
                 ] = list(variable_mapping.ingoing_edge_variables)
 
-                out_edges = self.__graph.get_edges_outgoing_from_node(node_id)
+                out_edges = (
+                    problem_set.topology.get_edge_ids_outgoing_from_node(
+                        node_id
+                    )
+                )
                 out_edge_vars = self.__create_edge_variables(
-                    out_edges, edge_qns, graph_settings.edge_settings
+                    out_edges, edge_qns, problem_set
                 )
                 variable_mapping.outgoing_edge_variables = out_edge_vars[0]
                 variable_mapping.fixed_outgoing_edge_variables = out_edge_vars[
@@ -839,7 +744,7 @@ class CSPSolver(Solver):
                 int_node_vars = self.__create_node_variables(
                     node_id,
                     node_qns,
-                    graph_settings.node_settings,
+                    problem_set,
                 )
                 variable_mapping.node_variables = int_node_vars[0]
                 variable_mapping.fixed_node_variables = int_node_vars[1]
@@ -871,8 +776,8 @@ class CSPSolver(Solver):
         self,
         node_id: int,
         qn_list: Set[Type[NodeQuantumNumber]],
-        node_settings: Dict[int, NodeSettings],
-    ) -> Tuple[Set[_NodeVariableInfo], Dict[Type[NodeQuantumNumber], Scalar],]:
+        problem_set: ProblemSet,
+    ) -> Tuple[Set[_NodeVariableInfo], GraphNodePropertyMap]:
         """Create variables for the quantum numbers of the specified node.
 
         If a quantum number is already defined for a node, then a fixed
@@ -880,25 +785,22 @@ class CSPSolver(Solver):
         Otherwise the node is initialized with the specified domain of that
         quantum number.
         """
-        variables: Tuple[
-            Set[_NodeVariableInfo],
-            Dict[Type[NodeQuantumNumber], Scalar],
-        ] = (
+        variables: Tuple[Set[_NodeVariableInfo], GraphNodePropertyMap] = (
             set(),
             dict(),
         )
 
-        if node_id in self.__graph.node_props:
-            node_props = self.__graph.node_props[node_id]
+        if node_id in problem_set.initial_facts.node_props:
+            node_props = problem_set.initial_facts.node_props[node_id]
             for qn_type in qn_list:
-                value = _get_node_quantum_number(qn_type, node_props)
-                if value is not None:
-                    variables[1].update({qn_type: value})
+                if qn_type in node_props:
+                    variables[1].update({qn_type: node_props[qn_type]})
         else:
+            node_settings = problem_set.solving_settings.node_settings[node_id]
             for qn_type in qn_list:
                 var_info = (node_id, qn_type)
-                if qn_type in node_settings[node_id].qn_domains:
-                    qn_domain = node_settings[node_id].qn_domains[qn_type]
+                if qn_type in node_settings.qn_domains:
+                    qn_domain = node_settings.qn_domains[qn_type]
                     self.__add_variable(var_info, qn_domain)
                     variables[0].add(var_info)
         return variables
@@ -907,11 +809,8 @@ class CSPSolver(Solver):
         self,
         edge_ids: Sequence[int],
         qn_list: Set[Type[EdgeQuantumNumber]],
-        edge_settings: Dict[int, EdgeSettings],
-    ) -> Tuple[
-        Set[_EdgeVariableInfo],
-        Dict[int, Dict[Type[EdgeQuantumNumber], Scalar]],
-    ]:
+        problem_set: ProblemSet,
+    ) -> Tuple[Set[_EdgeVariableInfo], Dict[int, GraphEdgePropertyMap]]:
         """Create variables for the quantum numbers of the specified edges.
 
         If a quantum number is already defined for an edge, then a fixed
@@ -921,24 +820,29 @@ class CSPSolver(Solver):
         """
         variables: Tuple[
             Set[_EdgeVariableInfo],
-            Dict[int, Dict[Type[EdgeQuantumNumber], Scalar]],
+            Dict[int, GraphEdgePropertyMap],
         ] = (
             set(),
             dict(),
         )
+
         for edge_id in edge_ids:
             variables[1][edge_id] = {}
-            if edge_id in self.__graph.edge_props:
-                edge_props = self.__graph.edge_props[edge_id]
+            if edge_id in problem_set.initial_facts.edge_props:
+                edge_props = problem_set.initial_facts.edge_props[edge_id]
                 for qn_type in qn_list:
-                    value = _get_particle_property(edge_props, qn_type)
-                    if value is not None:
-                        variables[1][edge_id].update({qn_type: value})
+                    if qn_type in edge_props:
+                        variables[1][edge_id].update(
+                            {qn_type: edge_props[qn_type]}
+                        )
             else:
+                edge_settings = problem_set.solving_settings.edge_settings[
+                    edge_id
+                ]
                 for qn_type in qn_list:
                     var_info = (edge_id, qn_type)
-                    if qn_type in edge_settings[edge_id].qn_domains:
-                        qn_domain = edge_settings[edge_id].qn_domains[qn_type]
+                    if qn_type in edge_settings.qn_domains:
+                        qn_domain = edge_settings.qn_domains[qn_type]
                         self.__add_variable(var_info, qn_domain)
                         variables[0].add(var_info)
         return variables
@@ -959,29 +863,32 @@ class CSPSolver(Solver):
         solutions: List[Dict[str, Scalar]],
     ) -> List[_QuantumNumberSolution]:
         """Convert keys of CSP solutions from string to quantum number types."""
-        initial_edges = self.__graph.get_initial_state_edges()
-        final_edges = self.__graph.get_final_state_edges()
-
         converted_solutions = list()
         for solution in solutions:
-            qn_solution = _QuantumNumberSolution()
+            edge_quantum_numbers: Dict[
+                int, GraphEdgePropertyMap
+            ] = defaultdict(dict)
+            node_quantum_numbers: Dict[
+                int, GraphNodePropertyMap
+            ] = defaultdict(dict)
             for var_string, value in solution.items():
                 ele_id, qn_type = self.__var_string_to_data[var_string]
 
                 if qn_type in getattr(  # noqa: B009
                     EdgeQuantumNumber, "__args__"
                 ):
-                    if ele_id in initial_edges or ele_id in final_edges:
-                        # skip if its an initial or final state edge
-                        continue
-                    qn_solution.edge_quantum_numbers[ele_id].update(
+                    edge_quantum_numbers[ele_id].update(
                         {qn_type: value}  # type: ignore
                     )
                 else:
-                    qn_solution.node_quantum_numbers[ele_id].update(
+                    node_quantum_numbers[ele_id].update(
                         {qn_type: value}  # type: ignore
                     )
-            converted_solutions.append(qn_solution)
+            converted_solutions.append(
+                _QuantumNumberSolution(
+                    node_quantum_numbers, edge_quantum_numbers
+                )
+            )
 
         return converted_solutions
 
@@ -1297,56 +1204,7 @@ class _ConservationRuleConstraintWrapper(Constraint):
                 self.__node_qns[qn_type] = value  # type: ignore
             else:
                 raise ValueError(
-                    "The variable with name "
-                    + qn_type.__name__
-                    + "does not appear in the variable mapping!"
+                    f"The variable with name {qn_type.__name__} and a graph "
+                    f"element index of {index} does not appear in the variable "
+                    f"mapping!"
                 )
-
-
-def _get_particle_property(
-    edge_property: ParticleWithSpin, qn_type: Type[EdgeQuantumNumber]
-) -> Optional[Union[float, int]]:
-    """Convert a data member of `.Particle` into one of `.EdgeQuantumNumbers`.
-
-    The `.reaction` model requires a list of 'flat' values, such as `int` and
-    `float`. It cannot handle `.Spin` (which contains `~.Spin.magnitude` and
-    `~.Spin.projection`). The `.reaction` module also works with spin
-    projection, which a general `.Particle` instance does not carry.
-    """
-    particle, spin_projection = edge_property
-    value = None
-    if hasattr(particle, qn_type.__name__):
-        value = getattr(particle, qn_type.__name__)
-    else:
-        if qn_type is EdgeQuantumNumbers.spin_magnitude:
-            value = particle.spin
-        elif qn_type is EdgeQuantumNumbers.spin_projection:
-            value = spin_projection
-        if particle.isospin is not None:
-            if qn_type is EdgeQuantumNumbers.isospin_magnitude:
-                value = particle.isospin.magnitude
-            elif qn_type is EdgeQuantumNumbers.isospin_projection:
-                value = particle.isospin.projection
-
-    if isinstance(value, Parity):
-        return int(value)
-    return value
-
-
-def _get_node_quantum_number(
-    qn_type: Type[NodeQuantumNumber], node_props: InteractionProperties
-) -> Optional[Scalar]:
-    return getattr(node_props, qn_type.__name__)
-
-
-def _create_interaction_properties(
-    qn_solution: Dict[Type[NodeQuantumNumber], Scalar]
-) -> InteractionProperties:
-    converted_solution = {k.__name__: v for k, v in qn_solution.items()}
-    kw_args = {
-        x.name: converted_solution[x.name]
-        for x in attr.fields(InteractionProperties)
-        if x.name in converted_solution
-    }
-
-    return attr.evolve(InteractionProperties(), **kw_args)

--- a/src/expertsystem/reaction/topology.py
+++ b/src/expertsystem/reaction/topology.py
@@ -12,9 +12,9 @@ import copy
 import itertools
 import logging
 from typing import (
-    Any,
     Callable,
     Dict,
+    FrozenSet,
     Generic,
     Iterable,
     List,
@@ -34,8 +34,8 @@ from .quantum_numbers import InteractionProperties
 class Edge:
     """Struct-like definition of an edge, used in `Topology`."""
 
-    ending_node_id: Optional[int] = attr.ib(default=None)
     originating_node_id: Optional[int] = attr.ib(default=None)
+    ending_node_id: Optional[int] = attr.ib(default=None)
 
     def get_connected_nodes(self) -> Set[int]:
         connected_nodes = {self.ending_node_id, self.originating_node_id}
@@ -61,7 +61,7 @@ class Topology:
         if nodes is not None:
             self.__nodes = set(nodes)
         if edges is not None:
-            self.__edges = edges
+            self.__edges = dict(edges)
         self.verify()
 
     @property
@@ -73,7 +73,7 @@ class Topology:
         return self.__edges
 
     def __repr__(self) -> str:
-        return f"{self.__class__.__name__}{(self.nodes, self.edges)}"
+        return f"{self.__class__.__name__}{(self.__nodes, self.__edges)}"
 
     def __eq__(self, other: object) -> bool:
         if isinstance(other, Topology):
@@ -145,13 +145,13 @@ class Topology:
 
     def verify(self) -> None:
         """Verify if there are no dangling edges or nodes."""
-        for edge_id, edge in self.edges.items():
+        for edge_id, edge in self.__edges.items():
             connected_nodes = edge.get_connected_nodes()
             if not connected_nodes:
                 raise ValueError(
                     f"Edge nr. {edge_id} is not connected to any node ({edge})"
                 )
-            if not connected_nodes <= self.nodes:
+            if not connected_nodes <= self.__nodes:
                 raise ValueError(
                     f"{edge} (ID: {edge_id}) has non-existing node IDs.\n"
                     f"Available node IDs: {self.nodes}"
@@ -185,21 +185,9 @@ class Topology:
                 True if the two graphs have a one-to-one mapping of the node IDs
                 and edge IDs.
         """
-        # EdgeIndexMapping = {}
-        # NodeIndexMapping = {}
+        raise NotImplementedError
 
-        # get start edges
-        # CurrentEdges = [graph1.getInitial]
-
-        # while(CurrentEdges):
-        #    TempEdges = CurrentEdges
-        #    CurrentEdges = []
-
-        # check if the mapping is still valid and can be extended
-
-    def get_originating_node_list(
-        self, edge_ids: Iterable[int]
-    ) -> List[Optional[int]]:
+    def get_originating_node_list(self, edge_ids: Iterable[int]) -> List[int]:
         """Get list of node ids from which the supplied edges originate from.
 
         Args:
@@ -209,60 +197,20 @@ class Topology:
         Returns:
             [int]: a list of node ids
         """
+
+        def __get_originating_node(edge_id: int) -> Optional[int]:
+            return self.__edges[edge_id].originating_node_id
+
         return [
-            self.edges[edge_id].originating_node_id for edge_id in edge_ids
+            node_id
+            for node_id in map(__get_originating_node, edge_ids)
+            if node_id
         ]
 
-    def get_initial_state_edges(self) -> List[int]:
-        return sorted(
-            [
-                edge_id
-                for edge_id, edge in self.edges.items()
-                if edge.originating_node_id is None
-            ]
-        )
-
-    def get_final_state_edges(self) -> List[int]:
-        return sorted(
-            [
-                edge_id
-                for edge_id, edge in self.edges.items()
-                if edge.ending_node_id is None
-            ]
-        )
-
-    def get_intermediate_state_edges(self) -> List[int]:
-        return sorted(
-            [
-                edge_id
-                for edge_id, edge in self.edges.items()
-                if edge.ending_node_id is not None
-                and edge.originating_node_id is not None
-            ]
-        )
-
-    def get_edges_ingoing_to_node(self, node_id: Optional[int]) -> List[int]:
-        return [
-            edge_id
-            for edge_id, edge in self.edges.items()
-            if edge.ending_node_id == node_id
-        ]
-
-    def get_edges_outgoing_from_node(
-        self, node_id: Optional[int]
-    ) -> List[int]:
-        return [
-            edge_id
-            for edge_id, edge in self.edges.items()
-            if edge.originating_node_id == node_id
-        ]
-
-    def get_originating_final_state_edges(
-        self, node_id: Optional[int]
-    ) -> List[int]:
-        fs_edges = self.get_final_state_edges()
+    def get_originating_final_state_edge_ids(self, node_id: int) -> List[int]:
+        fs_edges = self.get_final_state_edge_ids()
         edge_list = []
-        temp_edge_list = self.get_edges_outgoing_from_node(node_id)
+        temp_edge_list = self.get_edge_ids_outgoing_from_node(node_id)
         while temp_edge_list:
             new_temp_edge_list = []
             for edge_id in temp_edge_list:
@@ -270,16 +218,19 @@ class Topology:
                     edge_list.append(edge_id)
                 else:
                     new_node_id = self.edges[edge_id].ending_node_id
-                    new_temp_edge_list.extend(
-                        self.get_edges_outgoing_from_node(new_node_id)
-                    )
+                    if new_node_id is not None:
+                        new_temp_edge_list.extend(
+                            self.get_edge_ids_outgoing_from_node(new_node_id)
+                        )
             temp_edge_list = new_temp_edge_list
         return edge_list
 
-    def get_originating_initial_state_edges(self, node_id: int) -> List[int]:
-        is_edges = self.get_initial_state_edges()
+    def get_originating_initial_state_edge_ids(
+        self, node_id: int
+    ) -> List[int]:
+        is_edges = self.get_initial_state_edge_ids()
         edge_list = []
-        temp_edge_list = self.get_edges_ingoing_to_node(node_id)
+        temp_edge_list = self.get_edge_ids_ingoing_to_node(node_id)
         while temp_edge_list:
             new_temp_edge_list = []
             for edge_id in temp_edge_list:
@@ -287,11 +238,54 @@ class Topology:
                     edge_list.append(edge_id)
                 else:
                     new_node_id = self.edges[edge_id].originating_node_id
-                    new_temp_edge_list.extend(
-                        self.get_edges_ingoing_to_node(new_node_id)
-                    )
+                    if new_node_id is not None:
+                        new_temp_edge_list.extend(
+                            self.get_edge_ids_ingoing_to_node(new_node_id)
+                        )
             temp_edge_list = new_temp_edge_list
         return edge_list
+
+    def get_initial_state_edge_ids(self) -> List[int]:
+        return sorted(
+            [
+                edge_id
+                for edge_id, edge in self.__edges.items()
+                if edge.originating_node_id is None
+            ]
+        )
+
+    def get_final_state_edge_ids(self) -> List[int]:
+        return sorted(
+            [
+                edge_id
+                for edge_id, edge in self.__edges.items()
+                if edge.ending_node_id is None
+            ]
+        )
+
+    def get_intermediate_state_edge_ids(self) -> List[int]:
+        return sorted(
+            [
+                edge_id
+                for edge_id, edge in self.__edges.items()
+                if edge.ending_node_id is not None
+                and edge.originating_node_id is not None
+            ]
+        )
+
+    def get_edge_ids_ingoing_to_node(self, node_id: int) -> List[int]:
+        return [
+            edge_id
+            for edge_id, edge in self.edges.items()
+            if edge.ending_node_id == node_id
+        ]
+
+    def get_edge_ids_outgoing_from_node(self, node_id: int) -> List[int]:
+        return [
+            edge_id
+            for edge_id, edge in self.edges.items()
+            if edge.originating_node_id == node_id
+        ]
 
     def swap_edges(self, edge_id1: int, edge_id2: int) -> None:
         popped_edge_id1 = self.__edges.pop(edge_id1)
@@ -303,7 +297,7 @@ class Topology:
 _EdgeType = TypeVar("_EdgeType")
 
 
-class StateTransitionGraph(Topology, Generic[_EdgeType]):
+class StateTransitionGraph(Generic[_EdgeType]):
     """Graph class that contains edges and nodes.
 
     Similar to feynman graphs. The graphs are directed, meaning the edges are
@@ -315,19 +309,28 @@ class StateTransitionGraph(Topology, Generic[_EdgeType]):
 
     def __init__(
         self,
-        nodes: Optional[Set[int]] = None,
-        edges: Optional[Dict[int, Edge]] = None,
+        topology: Topology,
+        node_props: Dict[int, InteractionProperties] = None,
+        edge_props: Dict[int, _EdgeType] = None,
     ) -> None:
-        super().__init__(nodes, edges)
-        self.node_props: Dict[int, InteractionProperties] = {}
-        self.edge_props: Dict[int, _EdgeType] = {}
+        self.__topology = topology
+        self.__topology.verify()
+        self.__node_props: Dict[int, InteractionProperties] = {}
+        self.__edge_props: Dict[int, _EdgeType] = {}
+        if node_props:
+            self.__node_props = node_props
+        if edge_props:
+            self.__edge_props = edge_props
+
         self.graph_node_properties_comparator: Optional[Callable] = None
 
     def __repr__(self) -> str:
         return (
-            f"{self.__class__.__name__}(nodes={self.nodes}, edges={self.edges})"
-            f"\n    node props: {self.node_props}"
-            f"\n    edge props: {self.edge_props}"
+            f"{self.__class__.__name__}("
+            f"nodes={self.nodes},"
+            f"edges={self.edges},"
+            f"node_props={self.__node_props},"
+            f"edge_props={self.__edge_props})"
         )
 
     def __eq__(self, other: object) -> bool:
@@ -336,42 +339,139 @@ class StateTransitionGraph(Topology, Generic[_EdgeType]):
                 return False
             if self.edges != other.edges:
                 return False
-            if self.edge_props != other.edge_props:
+            if any(
+                self.get_edge_props(i) != other.get_edge_props(i)
+                for i in self.edges
+            ):
                 return False
             if self.graph_node_properties_comparator is not None:
-                return self.graph_node_properties_comparator(
-                    self.node_props, other.node_props
+                return all(
+                    self.graph_node_properties_comparator(
+                        self.get_node_props(i), other.get_node_props(i)
+                    )
+                    for i in self.nodes
                 )
-            return self.node_props == other.node_props
+            return all(
+                self.get_node_props(i) == other.get_node_props(i)
+                for i in self.nodes
+            )
 
         raise NotImplementedError
 
-    def __copy__(self) -> "StateTransitionGraph[_EdgeType]":
-        """Makes a *shallow* copy.
+    @property
+    def nodes(self) -> FrozenSet[int]:
+        return frozenset(self.__topology.nodes)
 
-        The default shallow copy behavior was overwritten to also make copies
-        one level deeper. In other words copies of the containers (`nodes`,
-        `edges`, `node_props`, `edge_props`) are made as well. Just like the
-        default copy behavior, the existing contents of the containers are
-        **NOT** copied!
-        """
-        new_nodes = copy.copy(self.nodes)
-        new_edges = copy.copy(self.edges)
-        new_graph = type(self)(nodes=new_nodes, edges=new_edges)
-        new_graph.node_props = copy.copy(self.node_props)
-        new_graph.edge_props = copy.copy(self.edge_props)
-        return new_graph
+    @property
+    def edges(self) -> Dict[int, Edge]:
+        return self.__topology.edges
 
-    @staticmethod
-    def from_topology(topology: Topology) -> "StateTransitionGraph":
-        """Create a `StateTransitionGraph` from a `Topology`."""
-        return StateTransitionGraph(topology.nodes, topology.edges)
+    def get_initial_state_edge_ids(self) -> List[int]:
+        return self.__topology.get_initial_state_edge_ids()
+
+    def get_final_state_edge_ids(self) -> List[int]:
+        return self.__topology.get_final_state_edge_ids()
+
+    def get_intermediate_state_edge_ids(self) -> List[int]:
+        return self.__topology.get_intermediate_state_edge_ids()
+
+    def get_edge_ids_ingoing_to_node(self, node_id: int) -> List[int]:
+        return [
+            edge_id
+            for edge_id, edge in self.__topology.edges.items()
+            if edge.ending_node_id == node_id
+        ]
+
+    def get_edge_ids_outgoing_from_node(self, node_id: int) -> List[int]:
+        return [
+            edge_id
+            for edge_id, edge in self.__topology.edges.items()
+            if edge.originating_node_id == node_id
+        ]
+
+    def get_originating_node_list(self, edge_ids: Iterable[int]) -> List[int]:
+        return self.__topology.get_originating_node_list(edge_ids)
+
+    def get_originating_final_state_edge_ids(self, node_id: int) -> List[int]:
+        fs_edges = self.__topology.get_final_state_edge_ids()
+        edge_list = []
+        temp_edge_list = self.get_edge_ids_outgoing_from_node(node_id)
+        while temp_edge_list:
+            new_temp_edge_list = []
+            for edge_id in temp_edge_list:
+                if edge_id in fs_edges:
+                    edge_list.append(edge_id)
+                else:
+                    new_node_id = self.__topology.edges[edge_id].ending_node_id
+                    if new_node_id is not None:
+                        new_temp_edge_list.extend(
+                            self.get_edge_ids_outgoing_from_node(new_node_id)
+                        )
+            temp_edge_list = new_temp_edge_list
+        return edge_list
+
+    def get_originating_initial_state_edge_ids(
+        self, node_id: int
+    ) -> List[int]:
+        is_edges = self.__topology.get_initial_state_edge_ids()
+        edge_list = []
+        temp_edge_list = self.get_edge_ids_ingoing_to_node(node_id)
+        while temp_edge_list:
+            new_temp_edge_list = []
+            for edge_id in temp_edge_list:
+                if edge_id in is_edges:
+                    edge_list.append(edge_id)
+                else:
+                    new_node_id = self.__topology.edges[
+                        edge_id
+                    ].originating_node_id
+                    if new_node_id is not None:
+                        new_temp_edge_list.extend(
+                            self.get_edge_ids_ingoing_to_node(new_node_id)
+                        )
+            temp_edge_list = new_temp_edge_list
+        return edge_list
+
+    def get_node_props(self, node_id: int) -> InteractionProperties:
+        return self.__node_props[node_id]
+
+    def get_edge_props(self, edge_id: int) -> _EdgeType:
+        return self.__edge_props[edge_id]
+
+    def evolve(
+        self,
+        node_props: Optional[Dict[int, InteractionProperties]] = None,
+        edge_props: Optional[Dict[int, _EdgeType]] = None,
+    ) -> "StateTransitionGraph[_EdgeType]":
+        new_node_props = copy.copy(self.__node_props)
+        if node_props:
+            for node_id, node_prop in node_props.items():
+                if node_id not in self.nodes:
+                    raise KeyError(f"Node id {node_id} does not exist!")
+                new_node_props[node_id] = node_prop
+
+        new_edge_props = copy.copy(self.__edge_props)
+        if edge_props:
+            for edge_id, edge_prop in edge_props.items():
+                if edge_id not in self.edges:
+                    raise KeyError(f"Edge id {edge_id} does not exist!")
+                new_edge_props[edge_id] = edge_prop
+
+        return StateTransitionGraph[_EdgeType](
+            topology=self.__topology,
+            node_props=new_node_props,
+            edge_props=new_edge_props,
+        )
 
     def compare(
         self,
         other: "StateTransitionGraph",
-        edge_comparator: Optional[Callable[[Any, Any], bool]] = None,
-        node_comparator: Optional[Callable[[Any, Any], bool]] = None,
+        edge_comparator: Optional[
+            Callable[[_EdgeType, _EdgeType], bool]
+        ] = None,
+        node_comparator: Optional[
+            Callable[[InteractionProperties, InteractionProperties], bool]
+        ] = None,
     ) -> bool:
         if self.nodes != other.nodes:
             return False
@@ -380,29 +480,29 @@ class StateTransitionGraph(Topology, Generic[_EdgeType]):
         if edge_comparator is not None:
             for i in self.edges:
                 if not edge_comparator(
-                    self.edge_props[i], other.edge_props[i]
+                    self.get_edge_props(i), other.get_edge_props(i)
                 ):
                     return False
         if node_comparator is not None:
             for i in self.nodes:
                 if not node_comparator(
-                    self.node_props[i], other.node_props[i]
+                    self.get_node_props(i), other.get_node_props(i)
                 ):
                     return False
         return True
 
     def swap_edges(self, edge_id1: int, edge_id2: int) -> None:
-        super().swap_edges(edge_id1, edge_id2)
+        self.__topology.swap_edges(edge_id1, edge_id2)
         value1: Optional[_EdgeType] = None
         value2: Optional[_EdgeType] = None
-        if edge_id1 in self.edge_props:
-            value1 = self.edge_props.pop(edge_id1)
-        if edge_id2 in self.edge_props:
-            value2 = self.edge_props.pop(edge_id2)
+        if edge_id1 in self.__edge_props:
+            value1 = self.__edge_props.pop(edge_id1)
+        if edge_id2 in self.__edge_props:
+            value2 = self.__edge_props.pop(edge_id2)
         if value1 is not None:
-            self.edge_props[edge_id2] = value1
+            self.__edge_props[edge_id2] = value1
         if value2 is not None:
-            self.edge_props[edge_id1] = value2
+            self.__edge_props[edge_id1] = value2
 
 
 class InteractionNode:  # pylint: disable=too-few-public-methods
@@ -475,17 +575,6 @@ class SimpleStateTransitionTopologyBuilder:
                     continue
 
                 extendable_graph_list.extend(self.extend_graph(active_graph))
-
-            # check if two topologies are the same
-            for graph_index1, graph_index2 in itertools.combinations(
-                range(len(extendable_graph_list)), 2
-            ):
-                if extendable_graph_list[graph_index1][0].is_isomorphic(
-                    extendable_graph_list[graph_index2][0]
-                ):
-                    extendable_graph_list.remove(
-                        extendable_graph_list[graph_index2]
-                    )
 
         logging.info("finished building topology graphs...")
         # strip the current open end edges list from the result graph tuples

--- a/src/expertsystem/reaction/topology.py
+++ b/src/expertsystem/reaction/topology.py
@@ -298,6 +298,7 @@ class Topology:
 
 
 _EdgeType = TypeVar("_EdgeType")
+"""A TypeVar representing the type of edge properties."""
 
 
 class StateTransitionGraph(Generic[_EdgeType]):

--- a/src/expertsystem/reaction/topology.py
+++ b/src/expertsystem/reaction/topology.py
@@ -49,7 +49,7 @@ class Topology:
 
     Forms the underlying topology of `StateTransitionGraph`. The graphs are
     directed, meaning the edges are ingoing and outgoing to specific nodes
-    (since feynman graphs also have a time axis)
+    (since feynman graphs also have a time axis).
     Note that a `Topology` is not strictly speaking a graph from graph theory,
     because it allows open edges, like a Feynman-diagram.
     """
@@ -409,7 +409,7 @@ class StateTransitionGraph(Generic[_EdgeType]):
     ) -> "StateTransitionGraph[_EdgeType]":
         """Changes the node and edge properties of a graph instance.
 
-        Since a `.StateTransitionGraph` is frozen (cannot by modified), the
+        Since a `.StateTransitionGraph` is frozen (cannot be modified), the
         evolve function will also create a shallow copy the properties.
         """
         new_node_props = copy.copy(self.__node_props)

--- a/tests/channels/test_jpsi_to_gamma_pi0_pi0.py
+++ b/tests/channels/test_jpsi_to_gamma_pi0_pi0.py
@@ -54,15 +54,15 @@ def test_id_to_particle_mappings(particle_database):
     )
     assert len(result.solutions) == 4
     ref_mapping_fs = _create_edge_id_particle_mapping(
-        result.solutions[0], "get_final_state_edges"
+        result.solutions[0], result.solutions[0].get_final_state_edge_ids()
     )
     ref_mapping_is = _create_edge_id_particle_mapping(
-        result.solutions[0], "get_initial_state_edges"
+        result.solutions[0], result.solutions[0].get_initial_state_edge_ids()
     )
     for solution in result.solutions[1:]:
         assert ref_mapping_fs == _create_edge_id_particle_mapping(
-            solution, "get_final_state_edges"
+            solution, solution.get_final_state_edge_ids()
         )
         assert ref_mapping_is == _create_edge_id_particle_mapping(
-            solution, "get_initial_state_edges"
+            solution, solution.get_initial_state_edge_ids()
         )

--- a/tests/channels/test_y_to_d0_d0bar_pi0_pi0.py
+++ b/tests/channels/test_y_to_d0_d0bar_pi0_pi0.py
@@ -52,8 +52,8 @@ def test_full(formalism_type, n_solutions, particle_database):
     )
     stm.set_allowed_interaction_types([InteractionTypes.Strong])
     stm.add_final_state_grouping([["D0", "pi0"], ["D~0", "pi0"]])
-    graph_node_setting_pairs = stm.prepare_graphs()
-    result = stm.find_solutions(graph_node_setting_pairs)
+    problem_sets = stm.create_problem_sets()
+    result = stm.find_solutions(problem_sets)
     assert len(result.solutions) == n_solutions
     model = es.generate_amplitudes(result)
     assert len(model.parameters) == 10

--- a/tests/unit/amplitude/test_parity_prefactor.py
+++ b/tests/unit/amplitude/test_parity_prefactor.py
@@ -67,9 +67,9 @@ def test_parity_prefactor(
 
     for solution in result.solutions:
         in_edge = [
-            k
-            for k, v in solution.edge_props.items()
-            if v[0].name == ingoing_state
+            i
+            for i in solution.edges
+            if solution.get_edge_props(i)[0].name == ingoing_state
         ]
         assert len(in_edge) == 1
         node_id = solution.edges[in_edge[0]].ending_node_id
@@ -78,7 +78,7 @@ def test_parity_prefactor(
 
         assert (
             relative_parity_prefactor
-            == solution.node_props[node_id].parity_prefactor
+            == solution.get_node_props(node_id).parity_prefactor
         )
 
     amplitude_model = es.generate_amplitudes(result)

--- a/tests/unit/amplitude/test_parity_prefactor.py
+++ b/tests/unit/amplitude/test_parity_prefactor.py
@@ -61,9 +61,9 @@ def test_parity_prefactor(
     )
     stm.add_final_state_grouping(test_input.final_state_grouping)
     stm.set_allowed_interaction_types([InteractionTypes.EM])
-    graph_interaction_settings_groups = stm.prepare_graphs()
+    problem_sets = stm.create_problem_sets()
 
-    result = stm.find_solutions(graph_interaction_settings_groups)
+    result = stm.find_solutions(problem_sets)
 
     for solution in result.solutions:
         in_edge = [

--- a/tests/unit/amplitude/test_parity_prefactor.py
+++ b/tests/unit/amplitude/test_parity_prefactor.py
@@ -67,9 +67,9 @@ def test_parity_prefactor(
 
     for solution in result.solutions:
         in_edge = [
-            i
-            for i in solution.edges
-            if solution.get_edge_props(i)[0].name == ingoing_state
+            edge_id
+            for edge_id in solution.edges
+            if solution.get_edge_props(edge_id)[0].name == ingoing_state
         ]
         assert len(in_edge) == 1
         node_id = solution.edges[in_edge[0]].ending_node_id

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -5,7 +5,7 @@ import pytest
 
 import expertsystem as es
 from expertsystem.amplitude.model import AmplitudeModel
-from expertsystem.reaction.solving import Result
+from expertsystem.reaction import Result
 
 logging.basicConfig(level=logging.ERROR)
 

--- a/tests/unit/io/test_dot.py
+++ b/tests/unit/io/test_dot.py
@@ -4,7 +4,7 @@ import pydot
 import pytest
 
 from expertsystem import io
-from expertsystem.reaction.solving import Result
+from expertsystem.reaction import Result
 from expertsystem.reaction.topology import Edge, Topology
 
 

--- a/tests/unit/reaction/test_solving.py
+++ b/tests/unit/reaction/test_solving.py
@@ -1,7 +1,7 @@
 # pylint: disable=no-self-use
 
 from expertsystem.particle import ParticleCollection
-from expertsystem.reaction.solving import Result
+from expertsystem.reaction import Result
 
 
 class TestResult:
@@ -21,14 +21,13 @@ class TestResult:
         result = jpsi_to_gamma_pi_pi_helicity_solutions
         particle_graphs = result.get_particle_graphs()
         assert len(particle_graphs) == 2
-        assert particle_graphs[0].edge_props[1] == pdg["f(0)(980)"]
-        assert particle_graphs[1].edge_props[1] == pdg["f(0)(1500)"]
+        assert particle_graphs[0].get_edge_props(1) == pdg["f(0)(980)"]
+        assert particle_graphs[1].get_edge_props(1) == pdg["f(0)(1500)"]
         assert len(particle_graphs[0].edges) == 5
         for edge_id in (0, 2, 3, 4):
-            assert (
-                particle_graphs[0].edge_props[edge_id]
-                is particle_graphs[1].edge_props[edge_id]
-            )
+            assert particle_graphs[0].get_edge_props(
+                edge_id
+            ) is particle_graphs[1].get_edge_props(edge_id)
 
     def test_collapse_graphs(
         self,
@@ -42,10 +41,10 @@ class TestResult:
         collapsed_graphs = result.collapse_graphs()
         assert len(collapsed_graphs) == 1
         graph = collapsed_graphs[0]
-        edge_id = graph.get_intermediate_state_edges()[0]
+        edge_id = graph.get_intermediate_state_edge_ids()[0]
         f_resonances = pdg.filter(
             lambda p: p.name in ["f(0)(980)", "f(0)(1500)"]
         )
-        intermediate_states = graph.edge_props[edge_id]
+        intermediate_states = graph.get_edge_props(edge_id)
         assert isinstance(intermediate_states, ParticleCollection)
         assert intermediate_states == f_resonances

--- a/tests/unit/reaction/test_system_control.py
+++ b/tests/unit/reaction/test_system_control.py
@@ -11,6 +11,7 @@ from expertsystem.reaction import (
 )
 from expertsystem.reaction._system_control import (
     CompareGraphNodePropertiesFunctor,
+    create_edge_properties,
     filter_graphs,
     remove_duplicate_solutions,
     require_interaction_property,
@@ -22,6 +23,7 @@ from expertsystem.reaction.combinatorics import (
     perform_external_edge_identical_particle_combinatorics,
 )
 from expertsystem.reaction.quantum_numbers import (
+    EdgeQuantumNumbers,
     InteractionProperties,
     NodeQuantumNumbers,
 )
@@ -112,11 +114,92 @@ def test_external_edge_initialization(
 
 
 @pytest.mark.parametrize(
-    "particle, spin_projection",
-    [],
+    "particle_name, spin_projection, expected_properties",
+    [
+        (
+            "pi0",
+            0,
+            {
+                EdgeQuantumNumbers.pid: 111,
+                EdgeQuantumNumbers.mass: 0.1349768,
+                EdgeQuantumNumbers.width: 7.73e-09,
+                EdgeQuantumNumbers.spin_magnitude: 0.0,
+                EdgeQuantumNumbers.spin_projection: 0,
+                EdgeQuantumNumbers.charge: 0,
+                EdgeQuantumNumbers.isospin_magnitude: 1.0,
+                EdgeQuantumNumbers.isospin_projection: 0.0,
+                EdgeQuantumNumbers.strangeness: 0,
+                EdgeQuantumNumbers.charmness: 0,
+                EdgeQuantumNumbers.bottomness: 0,
+                EdgeQuantumNumbers.topness: 0,
+                EdgeQuantumNumbers.baryon_number: 0,
+                EdgeQuantumNumbers.electron_lepton_number: 0,
+                EdgeQuantumNumbers.muon_lepton_number: 0,
+                EdgeQuantumNumbers.tau_lepton_number: 0,
+                EdgeQuantumNumbers.parity: -1,
+                EdgeQuantumNumbers.c_parity: 1,
+                EdgeQuantumNumbers.g_parity: -1,
+            },
+        ),
+        (
+            "D+",  # no g and c parity
+            0,
+            {
+                EdgeQuantumNumbers.pid: 411,
+                EdgeQuantumNumbers.mass: 1.86965,
+                EdgeQuantumNumbers.width: 6.33e-13,
+                EdgeQuantumNumbers.spin_magnitude: 0.0,
+                EdgeQuantumNumbers.spin_projection: 0,
+                EdgeQuantumNumbers.charge: 1,
+                EdgeQuantumNumbers.isospin_magnitude: 0.5,
+                EdgeQuantumNumbers.isospin_projection: 0.5,
+                EdgeQuantumNumbers.strangeness: 0,
+                EdgeQuantumNumbers.charmness: 1,
+                EdgeQuantumNumbers.bottomness: 0,
+                EdgeQuantumNumbers.topness: 0,
+                EdgeQuantumNumbers.baryon_number: 0,
+                EdgeQuantumNumbers.electron_lepton_number: 0,
+                EdgeQuantumNumbers.muon_lepton_number: 0,
+                EdgeQuantumNumbers.tau_lepton_number: 0,
+                EdgeQuantumNumbers.parity: -1,
+            },
+        ),
+        (
+            "f(2)(1270)",  # spin projection 1
+            1.0,
+            {
+                EdgeQuantumNumbers.pid: 225,
+                EdgeQuantumNumbers.mass: 1.2755,
+                EdgeQuantumNumbers.width: 0.18669999999999998,
+                EdgeQuantumNumbers.spin_magnitude: 2.0,
+                EdgeQuantumNumbers.spin_projection: 1.0,
+                EdgeQuantumNumbers.charge: 0,
+                EdgeQuantumNumbers.isospin_magnitude: 0.0,
+                EdgeQuantumNumbers.isospin_projection: 0.0,
+                EdgeQuantumNumbers.strangeness: 0,
+                EdgeQuantumNumbers.charmness: 0,
+                EdgeQuantumNumbers.bottomness: 0,
+                EdgeQuantumNumbers.topness: 0,
+                EdgeQuantumNumbers.baryon_number: 0,
+                EdgeQuantumNumbers.electron_lepton_number: 0,
+                EdgeQuantumNumbers.muon_lepton_number: 0,
+                EdgeQuantumNumbers.tau_lepton_number: 0,
+                EdgeQuantumNumbers.parity: 1,
+                EdgeQuantumNumbers.c_parity: 1,
+                EdgeQuantumNumbers.g_parity: 1,
+            },
+        ),
+    ],
 )
-def test_create_edge_properties(particle, spin_projection):
-    pass
+def test_create_edge_properties(
+    particle_name, spin_projection, expected_properties, particle_database
+):
+    particle = particle_database[particle_name]
+
+    assert (
+        create_edge_properties(particle, spin_projection)
+        == expected_properties
+    )
 
 
 def make_ls_test_graph(

--- a/tests/unit/reaction/test_system_control.py
+++ b/tests/unit/reaction/test_system_control.py
@@ -162,6 +162,8 @@ def test_external_edge_initialization(
                 EdgeQuantumNumbers.muon_lepton_number: 0,
                 EdgeQuantumNumbers.tau_lepton_number: 0,
                 EdgeQuantumNumbers.parity: -1,
+                EdgeQuantumNumbers.c_parity: None,
+                EdgeQuantumNumbers.g_parity: None,
             },
         ),
         (

--- a/tests/unit/reaction/test_topology.py
+++ b/tests/unit/reaction/test_topology.py
@@ -27,13 +27,13 @@ def two_to_three_decay() -> Topology:
     topology = Topology(
         nodes={0, 1, 2},
         edges={
-            0: Edge(0, None),
-            1: Edge(0, None),
-            2: Edge(1, 0),
-            3: Edge(2, 1),
-            4: Edge(None, 1),
-            5: Edge(None, 2),
-            6: Edge(None, 2),
+            0: Edge(None, 0),
+            1: Edge(None, 0),
+            2: Edge(0, 1),
+            3: Edge(1, 2),
+            4: Edge(1, None),
+            5: Edge(2, None),
+            6: Edge(2, None),
         },
     )
     return topology
@@ -182,23 +182,11 @@ class TestTopology:
     @staticmethod
     def test_getters(two_to_three_decay):
         topology: Topology = two_to_three_decay  # shorter name
-        assert topology.get_originating_node_list([0]) == [None]
+        assert topology.get_originating_node_list([0]) == []
         assert topology.get_originating_node_list([5, 6]) == [2, 2]
-        assert topology.get_initial_state_edges() == [0, 1]
-        assert topology.get_final_state_edges() == [4, 5, 6]
-        assert topology.get_intermediate_state_edges() == [2, 3]
-        assert topology.get_edges_ingoing_to_node(0) == [0, 1]
-        assert topology.get_edges_outgoing_from_node(0) == [2]
-        assert (
-            topology.get_edges_outgoing_from_node(None)
-            == topology.get_initial_state_edges()
-        )
-        assert (
-            topology.get_edges_ingoing_to_node(None)
-            == topology.get_final_state_edges()
-        )
-        assert topology.get_originating_initial_state_edges(0) == [0, 1]
-        assert topology.get_originating_final_state_edges(2) == [5, 6]
+        assert topology.get_initial_state_edge_ids() == [0, 1]
+        assert topology.get_final_state_edge_ids() == [4, 5, 6]
+        assert topology.get_intermediate_state_edge_ids() == [2, 3]
 
     @staticmethod
     def test_swap(two_to_three_decay):


### PR DESCRIPTION
- Change interface of Solver, to accept a new data structure ProblemSet
instead of the previous arguments. Also introduce a new data structure
QNResult which is now also the new return type of the Solver interface.
This removes the StateTransitionGraph and Particle from the module.
- Move Result to the reaction module to keep the interface for
find_solutions of the STM stable.
- Change prepare_graphs and underlying code to create_problem_sets. This
instead creates ProblemSet data structures that can be fed to the
solving module.
- Adapt other code pieces to these changes.

Closes #380 
Connects to #266