### PR TITLE
feat: reduce edge qn domains to allowed states 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,8 @@ jobs:
         python-version: [3.6, 3.7, 3.8]
         exclude:
           - os: macos-10.15
+            python-version: 3.7 # temporarily exclude because of github maintenance
+          - os: macos-10.15
             python-version: 3.6
           - os: macos-10.15
             python-version: 3.8

--- a/src/expertsystem/reaction/solving.py
+++ b/src/expertsystem/reaction/solving.py
@@ -289,13 +289,15 @@ def _merge_particle_candidates_with_solutions(
             new_solutions_temp = []
             for current_new_solution in current_new_solutions:
                 for particle_edge in particle_edges:
-                    new_edge_qns = copy(particle_edge)
-                    new_edge_qns.update(
-                        solution.edge_quantum_numbers[int_edge_id]
-                    )
+                    # a "shallow" copy of the nested dicts is needed
+                    new_edge_qns = {
+                        k: copy(v)
+                        for k, v in current_new_solution.edge_quantum_numbers.items()
+                    }
+                    new_edge_qns[int_edge_id].update(particle_edge)
                     temp_solution = attr.evolve(
                         current_new_solution,
-                        edge_quantum_numbers={int_edge_id: new_edge_qns},
+                        edge_quantum_numbers=new_edge_qns,
                     )
                     new_solutions_temp.append(temp_solution)
             current_new_solutions = new_solutions_temp

--- a/tests/channels/test_y_to_d0_d0bar_pi0_pi0.py
+++ b/tests/channels/test_y_to_d0_d0bar_pi0_pi0.py
@@ -1,7 +1,3 @@
-# cspell:ignore skipif
-
-import os
-
 import pytest
 
 import expertsystem as es
@@ -29,10 +25,6 @@ def test_simple(formalism_type, n_solutions, particle_database):
     assert len(model.parameters) == 10
 
 
-@pytest.mark.skipif(
-    "PYTEST_RUN_SLOW_TESTS" not in os.environ,
-    reason="Test takes too long. Can be enabled again after Rule refactoring",
-)
 @pytest.mark.slow
 @pytest.mark.parametrize(
     "formalism_type, n_solutions",


### PR DESCRIPTION
In case allowed intermediate states are specified, reduce the edge
quantum numbers for intermediate edges to match the given allowed
states.
This can dramatically reduce the runtime, when intermediate states are
explicitly specified.