### PR TITLE
fix: officially remove top NormalizedIntensity

### DIFF
--- a/src/expertsystem/amplitude/helicity_decay.py
+++ b/src/expertsystem/amplitude/helicity_decay.py
@@ -25,7 +25,6 @@ from .model import (
     IncoherentIntensity,
     IntensityNode,
     Kinematics,
-    NormalizedIntensity,
     ParticleDynamics,
     RecoilSystem,
     SequentialAmplitude,
@@ -444,14 +443,11 @@ class HelicityAmplitudeGenerator:
                 graph_group
             )
             incoherent_intensity.intensities.append(coherent_intensity)
-        if len(incoherent_intensity.intensities) > 1:
-            intensity: IntensityNode = NormalizedIntensity(
-                incoherent_intensity
-            )
-        else:
+        if len(incoherent_intensity.intensities) == 1:
             intensity = incoherent_intensity.intensities[0]
-        strength_intensity = self.__prepend_strength(intensity)
-        return strength_intensity
+        else:
+            intensity = incoherent_intensity
+        return intensity
 
     def __create_parameter_couplings(
         self, graph_groups: List[List[StateTransitionGraph[ParticleWithSpin]]]

--- a/src/expertsystem/amplitude/helicity_decay.py
+++ b/src/expertsystem/amplitude/helicity_decay.py
@@ -442,11 +442,11 @@ class HelicityAmplitudeGenerator:
                 graph_group
             )
             incoherent_intensity.intensities.append(coherent_intensity)
+        if len(incoherent_intensity.intensities) == 0:
+            raise ValueError("List of incoherent intensities cannot be empty")
         if len(incoherent_intensity.intensities) == 1:
-            intensity = incoherent_intensity.intensities[0]
-        else:
-            intensity = incoherent_intensity
-        return intensity
+            return incoherent_intensity.intensities[0]
+        return incoherent_intensity
 
     def __create_parameter_couplings(
         self, graph_groups: List[List[StateTransitionGraph[ParticleWithSpin]]]

--- a/src/expertsystem/amplitude/helicity_decay.py
+++ b/src/expertsystem/amplitude/helicity_decay.py
@@ -28,7 +28,6 @@ from .model import (
     ParticleDynamics,
     RecoilSystem,
     SequentialAmplitude,
-    StrengthIntensity,
 )
 
 
@@ -473,20 +472,6 @@ class HelicityAmplitudeGenerator:
                     self.__generate_sequential_decay(seq_graph)
                 )
         return coherent_intensity
-
-    def __prepend_strength(
-        self, intensity: IntensityNode
-    ) -> StrengthIntensity:
-        strength = self.__register_parameter(
-            name="strength_incoherent",
-            value=1.0,
-            fix=True,
-        )
-        return StrengthIntensity(
-            component="incoherent_with_strength",
-            strength=strength,
-            intensity=intensity,
-        )
 
     def __generate_sequential_decay(
         self, graph: StateTransitionGraph[ParticleWithSpin]

--- a/tests/channels/test_d0_to_ks_kp_km.py
+++ b/tests/channels/test_d0_to_ks_kp_km.py
@@ -21,6 +21,6 @@ def test_script(output_dir):
         "phi(1020)",
     }
     model = es.generate_amplitudes(result)
-    assert len(model.parameters) == 12
+    assert len(model.parameters) == 11
     es.io.write(model, output_dir + "D0_to_K0bar_Kp_Km.xml")
     es.io.write(model, output_dir + "D0_to_K0bar_Kp_Km.yml")

--- a/tests/channels/test_y_to_d0_d0bar_pi0_pi0.py
+++ b/tests/channels/test_y_to_d0_d0bar_pi0_pi0.py
@@ -22,7 +22,7 @@ def test_simple(formalism_type, n_solutions, particle_database):
     )
     assert len(result.solutions) == n_solutions
     model = es.generate_amplitudes(result)
-    assert len(model.parameters) == 10
+    assert len(model.parameters) == 9
 
 
 @pytest.mark.slow
@@ -48,4 +48,4 @@ def test_full(formalism_type, n_solutions, particle_database):
     result = stm.find_solutions(problem_sets)
     assert len(result.solutions) == n_solutions
     model = es.generate_amplitudes(result)
-    assert len(model.parameters) == 10
+    assert len(model.parameters) == 9

--- a/tests/unit/amplitude/test_yaml_canonical.py
+++ b/tests/unit/amplitude/test_yaml_canonical.py
@@ -53,16 +53,14 @@ def test_particle_section(imported_dict):
 
 def test_parameter_section(imported_dict):
     parameter_list = imported_dict["Parameters"]
-    assert len(parameter_list) == 12
+    assert len(parameter_list) == 11
     for parameter in parameter_list:
         assert "Name" in parameter
         assert "Value" in parameter
 
 
 def test_clebsch_gordan(imported_dict):
-    strength_intensity = imported_dict["Intensity"]
-    normalized_intensity = strength_intensity["Intensity"]
-    incoherent_intensity = normalized_intensity["Intensity"]
+    incoherent_intensity = imported_dict["Intensity"]
     coherent_intensity = incoherent_intensity["Intensities"][0]
     coefficient_amplitude = coherent_intensity["Amplitudes"][0]
     sequential_amplitude = coefficient_amplitude["Amplitude"]

--- a/tests/unit/amplitude/test_yaml_helicity.py
+++ b/tests/unit/amplitude/test_yaml_helicity.py
@@ -91,7 +91,7 @@ def test_kinematics_section(imported_dict):
 
 def test_parameter_section(imported_dict):
     parameter_list = imported_dict["Parameters"]
-    assert len(parameter_list) == 12
+    assert len(parameter_list) == 11
     for parameter in parameter_list:
         assert "Name" in parameter
         assert "Value" in parameter
@@ -128,11 +128,6 @@ def test_dynamics_section(imported_dict):
 
 def test_intensity_section(imported_dict):
     intensity = imported_dict["Intensity"]
-    assert intensity["Class"] == "StrengthIntensity"
-    intensity = intensity["Intensity"]
-    assert intensity["Class"] == "NormalizedIntensity"
-
-    intensity = intensity["Intensity"]
     assert intensity["Class"] == "IncoherentIntensity"
     assert len(intensity["Intensities"]) == 4
 


### PR DESCRIPTION
Currently the expertsystem and tensorwaves are not compatible, as the highest level `NormalizedIntensity` is missing but is required when performing fits in tensorwaves.

To simplify things I propose the following:
We officially remove this highest level `NormalizedIntensity` as this is only required by fitting using a log likelihood estimator and belong there. This has several advantages:
1. It makes the amplitude model simpler as the normalization is not needed for the intensity definition
2. Data generation is fast as the normalization is skipped
3. The construction of the intensity in tensorwaves becomes more transparent
    ```python3
    builder = IntensityBuilder(part_list, kinematics) # note: the phase space sample here is optional
    intensity = builder.create_intensity(model)

    data_sample = generate_data(10000, kinematics, intensity)
    dataset = kinematics.convert(data_sample)

    phsp_sample = generate_phsp(100000, kinematics, random_generator, bunch_size=100)
    phspset = kinematics.convert(phsp_sample)

    estimator = UnbinnedNLL(intensity, dataset, phspset) # phspset is required here for the normalization
    ```
@redeboer @Leongrim @sebastianJaeger What do you think?