### PR TITLE
fix: decouple parity violating amplitudes

### DIFF
--- a/src/expertsystem/amplitude/helicity_decay.py
+++ b/src/expertsystem/amplitude/helicity_decay.py
@@ -280,6 +280,9 @@ class _HelicityAmplitudeNameGenerator:
                 priority_partner_coefficient_suffix,
             ) = self._generate_amplitude_coefficient_couple(graph, node_id)
 
+            if graph.get_node_props(node_id).parity_prefactor is None:
+                continue
+
             if (
                 coefficient_suffix
                 not in self.parity_partner_coefficient_mapping
@@ -370,17 +373,10 @@ class _HelicityAmplitudeNameGenerator:
         """Generate unique suffix for a sequential amplitude graph."""
         output_suffix = ""
         for node_id in graph.nodes:
-            raw_suffix = self.generate_amplitude_coefficient_name(
-                graph, node_id
-            )
-            if raw_suffix not in self.parity_partner_coefficient_mapping:
-                raise KeyError(
-                    f"Coefficient name {raw_suffix} not found in mapping!"
-                )
-            coefficient_suffix = self.parity_partner_coefficient_mapping[
-                raw_suffix
-            ]
-            output_suffix += coefficient_suffix + ";"
+            suffix = self.generate_amplitude_coefficient_name(graph, node_id)
+            if suffix in self.parity_partner_coefficient_mapping:
+                suffix = self.parity_partner_coefficient_mapping[suffix]
+            output_suffix += suffix + ";"
         return output_suffix
 
 
@@ -577,14 +573,18 @@ class HelicityAmplitudeGenerator:
                     graph, node_id
                 )
             )
-            coefficient_suffix = (
-                self.name_generator.parity_partner_coefficient_mapping[
-                    raw_suffix
-                ]
-            )
-            if coefficient_suffix != raw_suffix:
-                if prefactor != 1.0 and prefactor is not None:
-                    return prefactor
+            if (
+                raw_suffix
+                in self.name_generator.parity_partner_coefficient_mapping
+            ):
+                coefficient_suffix = (
+                    self.name_generator.parity_partner_coefficient_mapping[
+                        raw_suffix
+                    ]
+                )
+                if coefficient_suffix != raw_suffix:
+                    if prefactor != 1.0 and prefactor is not None:
+                        return prefactor
         return None
 
     def __register_parameter(

--- a/src/expertsystem/amplitude/helicity_decay.py
+++ b/src/expertsystem/amplitude/helicity_decay.py
@@ -157,21 +157,15 @@ def _get_parent_recoil_edge(
 
 def _get_prefactor(
     graph: StateTransitionGraph[ParticleWithSpin],
-) -> Optional[float]:
+) -> float:
     """Calculate the product of all prefactors defined in this graph."""
-    prefactor = None
+    prefactor = 1.0
     for node_id in graph.nodes:
         node_props = graph.get_node_props(node_id)
         if node_props:
             temp_prefactor = __validate_float_type(node_props.parity_prefactor)
             if temp_prefactor is not None:
-                if prefactor is None:
-                    prefactor = temp_prefactor
-                else:
-                    prefactor *= temp_prefactor
-            else:
-                prefactor = None
-                break
+                prefactor *= temp_prefactor
     return prefactor
 
 
@@ -567,23 +561,23 @@ class HelicityAmplitudeGenerator:
         self, graph: StateTransitionGraph[ParticleWithSpin]
     ) -> Optional[float]:
         prefactor = _get_prefactor(graph)
-        for node_id in graph.nodes:
-            raw_suffix = (
-                self.name_generator.generate_amplitude_coefficient_name(
-                    graph, node_id
+        if prefactor != 1.0:
+            for node_id in graph.nodes:
+                raw_suffix = (
+                    self.name_generator.generate_amplitude_coefficient_name(
+                        graph, node_id
+                    )
                 )
-            )
-            if (
-                raw_suffix
-                in self.name_generator.parity_partner_coefficient_mapping
-            ):
-                coefficient_suffix = (
-                    self.name_generator.parity_partner_coefficient_mapping[
-                        raw_suffix
-                    ]
-                )
-                if coefficient_suffix != raw_suffix:
-                    if prefactor != 1.0 and prefactor is not None:
+                if (
+                    raw_suffix
+                    in self.name_generator.parity_partner_coefficient_mapping
+                ):
+                    coefficient_suffix = (
+                        self.name_generator.parity_partner_coefficient_mapping[
+                            raw_suffix
+                        ]
+                    )
+                    if coefficient_suffix != raw_suffix:
                         return prefactor
         return None
 

--- a/tests/unit/amplitude/test_parity_prefactor.py
+++ b/tests/unit/amplitude/test_parity_prefactor.py
@@ -125,7 +125,7 @@ def extract_prefactor(node, coefficient_amplitude_name):
                 ["Lambda(1405)"],
                 [],
             ),
-            6,
+            5,
         ),
         (
             Input(
@@ -134,7 +134,7 @@ def extract_prefactor(node, coefficient_amplitude_name):
                 ["Delta(1232)++"],
                 [],
             ),
-            6,
+            5,
         ),
         (
             Input(
@@ -143,7 +143,7 @@ def extract_prefactor(node, coefficient_amplitude_name):
                 ["K*(892)0"],
                 [],
             ),
-            10,
+            9,
         ),
     ],
 )

--- a/tests/unit/amplitude/test_parity_prefactor.py
+++ b/tests/unit/amplitude/test_parity_prefactor.py
@@ -113,3 +113,52 @@ def extract_prefactor(node, coefficient_amplitude_name):
             if prefactor is not None:
                 return prefactor
     return None
+
+
+@pytest.mark.parametrize(
+    "test_input, parameter_count",
+    [
+        (
+            Input(
+                [("Lambda(c)+", [0.5])],
+                ["p", "K-", "pi+"],
+                ["Lambda(1405)"],
+                [],
+            ),
+            6,
+        ),
+        (
+            Input(
+                [("Lambda(c)+", [0.5])],
+                ["p", "K-", "pi+"],
+                ["Delta(1232)++"],
+                [],
+            ),
+            6,
+        ),
+        (
+            Input(
+                [("Lambda(c)+", [0.5])],
+                ["p", "K-", "pi+"],
+                ["K*(892)0"],
+                [],
+            ),
+            10,
+        ),
+    ],
+)
+def test_parity_amplitude_coupling(
+    test_input: Input,
+    parameter_count: int,
+) -> None:
+    stm = StateTransitionManager(
+        test_input.initial_state,
+        test_input.final_state,
+        allowed_intermediate_particles=test_input.intermediate_states,
+        number_of_threads=1,
+    )
+    problem_sets = stm.create_problem_sets()
+    result = stm.find_solutions(problem_sets)
+
+    amplitude_model = es.generate_amplitudes(result)
+    assert len(amplitude_model.parameters) == parameter_count


### PR DESCRIPTION
Decouple coefficients of amplitudes which are parity violating, by generating the correct coefficient names.

Closes #419 

- [x] Add test to verify decoupling for parity violating amplitudes