### PR TITLE
ci: add issue label for interface changes

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -4,13 +4,15 @@ tag-template: $NEXT_PATCH_VERSION
 categories:
   - title: 💡 New features
     label: 💡 Enhancement
+  - title: ⚠️ Interface
+    label: ⚠️ Enhancement
   - title: 🐛 Bug fixes
     label: Bug
-  - title: 🔨 Interface changes
+  - title: 🔨 Internal maintenance
     label: 🔨 Maintenance
   - title: 📝 Documentation
     label: 📝 Docs
-  - title: 🖱️ Internals
+  - title: 🖱️ Developer Experience
     label: 🖱️ DX
 
 change-template: "- $TITLE (#$NUMBER)"

--- a/.github/workflows/requirements-cron.yml
+++ b/.github/workflows/requirements-cron.yml
@@ -58,7 +58,6 @@ jobs:
           reviewers: ${{ github.actor }}
           labels: |
             🖱️ DX
-            🔨 Maintenance
           branch-suffix: timestamp
           delete-branch: true
           token: ${{ secrets.PAT }}

--- a/labels.toml
+++ b/labels.toml
@@ -8,6 +8,11 @@ color = "3E4B9E"
 name = "Epic"
 description = ""
 
+["⚠️ Interface"]
+color = "BFDADC"
+name = "⚠️ Interface"
+description = "Changes to the interface"
+
 ["⚪ Duplicate"]
 color = "cfd3d7"
 name = "⚪ Duplicate"
@@ -23,10 +28,10 @@ color = "88506B"
 name = "❔ Question"
 description = "Discuss this matter in the team"
 
-["💡 Enhancement"]
+["💡 Feature"]
 color = "c2e0c6"
-name = "💡 Enhancement"
-description = "New feature or improvement of existing code"
+name = "💡 Feature"
+description = "New feature added to the package"
 
 ["💫 Good first issue"]
 color = "F4EAEF"
@@ -41,7 +46,7 @@ description = "Improvements or additions to documentation"
 ["🔨 Maintenance"]
 color = "FFCD8F"
 name = "🔨 Maintenance"
-description = "Refactoring or redesign"
+description = "Refactoring that doesn't affect the interface"
 
 ["🖱️ DX"]
 color = "fef2c0"


### PR DESCRIPTION
Issue labels are used not only for the project board, but also used by the Release Drafter. The sections there are currently not clear enough, in particular a distinct section for interface changes was missing.