### PR TITLE
fix: avoid validating when building dict

### DIFF
--- a/src/expertsystem/io/_dict/dump.py
+++ b/src/expertsystem/io/_dict/dump.py
@@ -25,8 +25,6 @@ from expertsystem.amplitude.model import (
 )
 from expertsystem.particle import Parity, Particle, ParticleCollection, Spin
 
-from . import validate
-
 
 def from_amplitude_model(model: AmplitudeModel) -> dict:
     output_dict = {
@@ -36,14 +34,12 @@ def from_amplitude_model(model: AmplitudeModel) -> dict:
         **from_particle_collection(model.particles),
         "Dynamics": __dynamics_section_to_dict(model.dynamics),
     }
-    validate.amplitude_model(output_dict)
     return output_dict
 
 
 def from_particle_collection(particles: ParticleCollection) -> dict:
     output = {p.name: from_particle(p) for p in particles}
     output = {"ParticleList": output}
-    validate.particle_collection(output)
     return output
 
 

--- a/tests/unit/io/test_dict.py
+++ b/tests/unit/io/test_dict.py
@@ -38,8 +38,8 @@ def test_not_implemented_errors(
 def test_serialization(
     output_dir: str, particle_selection: ParticleCollection
 ):
-    assert len(particle_selection) == 181
     io.write(particle_selection, output_dir + "particle_selection.yml")
+    assert len(particle_selection) == 181
     asdict = io.asdict(particle_selection)
     imported_collection = io.fromdict(asdict)
     assert isinstance(imported_collection, ParticleCollection)
@@ -60,8 +60,8 @@ class TestHelicityFormalism:
     @pytest.fixture(scope="session")
     def imported_dict(self, output_dir: str, model: AmplitudeModel):
         output_filename = output_dir + "JPsiToGammaPi0Pi0_heli_recipe.yml"
-        asdict = io.asdict(model)
         io.write(model, output_filename)
+        asdict = io.asdict(model)
         return asdict
 
     @pytest.fixture(scope="session")
@@ -197,8 +197,8 @@ class TestCanonicalFormalism:
     @pytest.fixture(scope="session")
     def imported_dict(self, output_dir: str, model: AmplitudeModel):
         output_filename = output_dir + "JPsiToGammaPi0Pi0_cano_recipe.yml"
-        asdict = io.asdict(model)
         io.write(model, output_filename)
+        asdict = io.asdict(model)
         return asdict
 
     def test_not_implemented_writer(

--- a/tests/unit/test_io.py
+++ b/tests/unit/test_io.py
@@ -20,6 +20,8 @@ def test_serialization(
         exported = jpsi_to_gamma_pi_pi_canonical_amplitude_model
     else:
         raise NotImplementedError(formalism)
+    filename = output_dir + f"test_write_read_{formalism}.{file_extension}"
+    io.write(exported, filename)
     asdict = io.asdict(exported)
     imported = io.fromdict(asdict)
     assert isinstance(imported, AmplitudeModel)
@@ -30,5 +32,3 @@ def test_serialization(
     assert exported.intensity == imported.intensity
     assert exported == imported
     assert exported is not imported
-    filename = output_dir + f"test_write_read_{formalism}.{file_extension}"
-    io.write(exported, filename)


### PR DESCRIPTION
Tests should make sure that the framework dumps in the correct format. JSON validation is only relevant for input (e.g. a hand-written amplitude model or particle list).