### PR TITLE
ci: run mypy on src folder

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -91,7 +91,7 @@ allowlist_externals =
     mypy
     pre-commit
 commands =
-    mypy .  # run separately because of potential caching problems
+    mypy src .  # run separately because of potential caching problems
     pre-commit run {posargs} -a
     - bash -ec "cspell --no-progress $(git ls-files)"
 


### PR DESCRIPTION
Fixes a bug introduced by #356: the `src` folder does not contain an `__init__.py` file, so `mypy` ignores it if you run `mypy .`.