### PR TITLE
refactor!: use attr.asdict in io module

### DIFF
--- a/docs/usage/additional_particles.yml
+++ b/docs/usage/additional_particles.yml
@@ -1,4 +1,4 @@
-ParticleList:
+particles:
   - name: Sigma(1385)+
     pid: 32241385
     mass: 1.383

--- a/docs/usage/additional_particles.yml
+++ b/docs/usage/additional_particles.yml
@@ -1,34 +1,34 @@
 ParticleList:
-  Sigma(1385)+:
-    PID: 32241385
-    Mass: 1.383
-    Width: 0.036
-    QuantumNumbers:
-      Spin: 1.5
-      Charge: 1
-      Parity: 1
-      IsoSpin:
-        Value: 1
-        Projection: 1
-  Sigma(1660)+:
-    PID: 32241660
-    Mass: 1.66
-    Width: 0.1
-    QuantumNumbers:
-      Spin: 0.5
-      Charge: 1
-      Parity: 1
-      IsoSpin:
-        Projection: 1
-        Value: 1
-  Sigma(1750)+:
-    PID: 32241750
-    Mass: 1.75
-    Width: 0.09
-    QuantumNumbers:
-      Spin: 0.5
-      Charge: 1
-      Parity: -1
-      IsoSpin:
-        Projection: 1
-        Value: 1
+  - name: Sigma(1385)+
+    pid: 32241385
+    mass: 1.383
+    width: 0.036
+    spin: 1.5
+    charge: 1
+    parity:
+      value: 1
+    isospin:
+      magnitude: 1
+      projection: 1
+  - name: Sigma(1660)+
+    pid: 32241660
+    mass: 1.66
+    width: 0.1
+    spin: 0.5
+    charge: 1
+    parity:
+      value: 1
+    isospin:
+      magnitude: 1
+      projection: 1
+  - name: Sigma(1750)+
+    pid: 32241750
+    mass: 1.75
+    width: 0.09
+    spin: 0.5
+    charge: 1
+    parity:
+      value: -1
+    isospin:
+      magnitude: 1
+      projection: 1

--- a/src/expertsystem/additional_particle_definitions.yml
+++ b/src/expertsystem/additional_particle_definitions.yml
@@ -1,11 +1,13 @@
 ParticleList:
-  Y(4260):
-    PID: 11443
-    Mass: 4.300
-    Width: 9.29E-05
-    QuantumNumbers:
-      Spin: 1
-      Charge: 0
-      Parity: -1
-      CParity: -1
-      IsoSpin: 0
+  - name: Y(4260)
+    pid: 11443
+    mass: 4.300
+    width: 9.29E-05
+    spin: 1
+    parity:
+      value: -1
+    c_parity:
+      value: -1
+    isospin:
+      magnitude: 0
+      projection: 0

--- a/src/expertsystem/additional_particle_definitions.yml
+++ b/src/expertsystem/additional_particle_definitions.yml
@@ -1,4 +1,4 @@
-ParticleList:
+particles:
   - name: Y(4260)
     pid: 11443
     mass: 4.300

--- a/src/expertsystem/amplitude/helicity_decay.py
+++ b/src/expertsystem/amplitude/helicity_decay.py
@@ -586,7 +586,7 @@ class HelicityAmplitudeGenerator:
     ) -> FitParameter:
         if name in self.fit_parameters:
             return self.fit_parameters[name]
-        parameter = FitParameter(name=name, value=value, is_fixed=fix)
+        parameter = FitParameter(name=name, value=value, fix=fix)
         self.fit_parameters.add(parameter)
         return parameter
 

--- a/src/expertsystem/amplitude/model.py
+++ b/src/expertsystem/amplitude/model.py
@@ -34,7 +34,7 @@ class FitParameters(abc.Mapping):
     ) -> None:
         self.__parameters: Dict[str, FitParameter] = dict()
         if parameters is not None:
-            if not isinstance(parameters, (list, set, tuple)):
+            if not isinstance(parameters, abc.Iterable):
                 raise ValueError(
                     f"Cannot construct a {self.__class__.__name__} "
                     f"from a {parameters.__class__.__name__}"

--- a/src/expertsystem/amplitude/model.py
+++ b/src/expertsystem/amplitude/model.py
@@ -25,7 +25,7 @@ from expertsystem.particle import Particle, ParticleCollection
 class FitParameter:
     name: str = attr.ib()
     value: float = attr.ib()
-    is_fixed: bool = attr.ib(default=False)
+    fix: bool = attr.ib(default=False)
 
 
 class FitParameters(abc.Mapping):
@@ -193,7 +193,7 @@ class ParticleDynamics(abc.MutableMapping):
         meson_radius = FitParameter(
             name=f"MesonRadius_{particle_name}",
             value=1.0,
-            is_fixed=True,
+            fix=True,
         )
         self.__register_parameter(meson_radius)
         return BlattWeisskopf(meson_radius)

--- a/src/expertsystem/io/__init__.py
+++ b/src/expertsystem/io/__init__.py
@@ -140,9 +140,9 @@ def _determine_type(definition: dict) -> type:
         "Intensity",
         "Kinematics",
         "Parameters",
-        "ParticleList",
+        "particles",
     }:
         return AmplitudeModel
-    if keys == {"ParticleList"}:
+    if keys == {"particles"}:
         return ParticleCollection
     raise NotImplementedError(f"Could not determine type from keys {keys}")

--- a/src/expertsystem/io/__init__.py
+++ b/src/expertsystem/io/__init__.py
@@ -148,7 +148,7 @@ def _determine_type(definition: dict) -> type:
     keys = set(definition.keys())
     if keys == {
         "dynamics",
-        "Intensity",
+        "intensity",
         "Kinematics",
         "parameters",
         "particles",

--- a/src/expertsystem/io/__init__.py
+++ b/src/expertsystem/io/__init__.py
@@ -147,7 +147,7 @@ def _get_file_extension(filename: str) -> str:
 def _determine_type(definition: dict) -> type:
     keys = set(definition.keys())
     if keys == {
-        "Dynamics",
+        "dynamics",
         "Intensity",
         "Kinematics",
         "parameters",

--- a/src/expertsystem/io/__init__.py
+++ b/src/expertsystem/io/__init__.py
@@ -149,7 +149,7 @@ def _determine_type(definition: dict) -> type:
     if keys == {
         "dynamics",
         "intensity",
-        "Kinematics",
+        "kinematics",
         "parameters",
         "particles",
     }:

--- a/src/expertsystem/io/__init__.py
+++ b/src/expertsystem/io/__init__.py
@@ -11,7 +11,11 @@ from pathlib import Path
 
 import yaml
 
-from expertsystem.amplitude.model import AmplitudeModel
+from expertsystem.amplitude.model import (
+    AmplitudeModel,
+    FitParameter,
+    FitParameters,
+)
 from expertsystem.particle import Particle, ParticleCollection
 from expertsystem.reaction.topology import StateTransitionGraph, Topology
 
@@ -19,6 +23,10 @@ from . import _dict, _dot, _pdg
 
 
 def asdict(instance: object) -> dict:
+    if isinstance(instance, FitParameter):
+        return _dict.dump.from_fit_parameter(instance)
+    if isinstance(instance, FitParameters):
+        return _dict.dump.from_fit_parameters(instance)
     if isinstance(instance, Particle):
         return _dict.dump.from_particle(instance)
     if isinstance(instance, ParticleCollection):
@@ -34,6 +42,8 @@ def fromdict(definition: dict) -> object:
     type_defined = _determine_type(definition)
     if type_defined == AmplitudeModel:
         return _dict.build.build_amplitude_model(definition)
+    if type_defined == FitParameters:
+        return _dict.build.build_fit_parameters(definition)
     if type_defined == ParticleCollection:
         return _dict.build.build_particle_collection(definition)
     raise NotImplementedError
@@ -42,9 +52,10 @@ def fromdict(definition: dict) -> object:
 def validate(instance: dict) -> None:
     type_defined = _determine_type(instance)
     if type_defined == AmplitudeModel:
-        _dict.validate.amplitude_model(instance)
-    elif type_defined == ParticleCollection:
-        _dict.validate.particle_collection(instance)
+        return _dict.validate.amplitude_model(instance)
+    if type_defined == ParticleCollection:
+        return _dict.validate.particle_collection(instance)
+    raise NotImplementedError
 
 
 def load(filename: str) -> object:
@@ -139,10 +150,12 @@ def _determine_type(definition: dict) -> type:
         "Dynamics",
         "Intensity",
         "Kinematics",
-        "Parameters",
+        "parameters",
         "particles",
     }:
         return AmplitudeModel
+    if keys == {"parameters"}:
+        return FitParameters
     if keys == {"particles"}:
         return ParticleCollection
     raise NotImplementedError(f"Could not determine type from keys {keys}")

--- a/src/expertsystem/io/_dict/build.py
+++ b/src/expertsystem/io/_dict/build.py
@@ -59,11 +59,9 @@ def build_particle_collection(
 ) -> ParticleCollection:
     if do_validate:
         validate.particle_collection(definition)
-    definition = definition["ParticleList"]
-    particles = ParticleCollection()
-    for particle_def in definition:
-        particles.add(__build_particle(particle_def))
-    return particles
+    return ParticleCollection(
+        __build_particle(p) for p in definition["particles"]
+    )
 
 
 def __build_particle(definition: dict) -> Particle:

--- a/src/expertsystem/io/_dict/build.py
+++ b/src/expertsystem/io/_dict/build.py
@@ -115,20 +115,21 @@ def __build_particle_dynamics(
 
 
 def __build_dynamics(definition: dict, parameters: FitParameters) -> Dynamics:
-    dynamics_type = definition["Type"]
-    form_factor = definition.get("FormFactor")
+    dynamics_type = definition["type"]
+    form_factor = definition.get("form_factor")
     if form_factor is not None:
         form_factor = __build_form_factor(form_factor, parameters)
     if dynamics_type == "NonDynamic":
         return NonDynamic(form_factor)
     if dynamics_type == "RelativisticBreitWigner":
-        pole = definition["PoleParameters"]
-        pole_position = __safely_get_parameter(pole["Real"], parameters)
-        pole_width = __safely_get_parameter(pole["Imaginary"], parameters)
         return RelativisticBreitWigner(
             form_factor=form_factor,
-            pole_position=pole_position,
-            pole_width=pole_width,
+            pole_position=__safely_get_parameter(
+                definition["pole_position"], parameters
+            ),
+            pole_width=__safely_get_parameter(
+                definition["pole_width"], parameters
+            ),
         )
     raise ValueError(f'Dynamics type "{dynamics_type}" not defined')
 
@@ -136,9 +137,9 @@ def __build_dynamics(definition: dict, parameters: FitParameters) -> Dynamics:
 def __build_form_factor(
     definition: dict, parameters: FitParameters
 ) -> FormFactor:
-    form_factor_type = definition["Type"]
+    form_factor_type = definition["type"]
     if form_factor_type == "BlattWeisskopf":
-        par_name = definition["MesonRadius"]
+        par_name = definition["meson_radius"]
         meson_radius = __safely_get_parameter(par_name, parameters)
         return BlattWeisskopf(meson_radius)
     raise NotImplementedError(

--- a/src/expertsystem/io/_dict/build.py
+++ b/src/expertsystem/io/_dict/build.py
@@ -1,6 +1,6 @@
 """Read recipe objects from a YAML file."""
 
-from typing import List, Optional, Union
+from typing import List, Optional
 
 from expertsystem.amplitude.model import (
     AmplitudeModel,
@@ -61,54 +61,20 @@ def build_particle_collection(
         validate.particle_collection(definition)
     definition = definition["ParticleList"]
     particles = ParticleCollection()
-    for name, particle_def in definition.items():
-        particles.add(build_particle(name, particle_def))
+    for particle_def in definition:
+        particles.add(__build_particle(particle_def))
     return particles
 
 
-def build_particle(name: str, definition: dict) -> Particle:
-    qn_def = definition["QuantumNumbers"]
-    return Particle(
-        name=name,
-        pid=int(definition["PID"]),
-        mass=float(definition["Mass"]),
-        width=float(definition.get("Width", 0.0)),
-        charge=int(qn_def["Charge"]),
-        spin=float(qn_def["Spin"]),
-        strangeness=int(qn_def.get("Strangeness", 0)),
-        charmness=int(qn_def.get("Charmness", 0)),
-        bottomness=int(qn_def.get("Bottomness", 0)),
-        topness=int(qn_def.get("Topness", 0)),
-        baryon_number=int(qn_def.get("BaryonNumber", 0)),
-        electron_lepton_number=int(qn_def.get("ElectronLN", 0)),
-        muon_lepton_number=int(qn_def.get("MuonLN", 0)),
-        tau_lepton_number=int(qn_def.get("TauLN", 0)),
-        isospin=__yaml_to_isospin(qn_def.get("IsoSpin", None)),
-        parity=__yaml_to_parity(qn_def.get("Parity", None)),
-        c_parity=__yaml_to_parity(qn_def.get("CParity", None)),
-        g_parity=__yaml_to_parity(qn_def.get("GParity", None)),
-    )
-
-
-def build_spin(definition: Union[dict, float, int, str]) -> Spin:
-    def check_missing_projection(magnitude: float) -> None:
-        if magnitude != 0.0:
-            raise ValueError(
-                "Can only have a spin without projection if magnitude = 0"
-            )
-
-    if isinstance(definition, (float, int)):
-        magnitude = float(definition)
-        check_missing_projection(magnitude)
-        projection = 0.0
-    elif not isinstance(definition, dict):
-        raise ValueError(f"Cannot create Spin from definition {definition}")
-    else:
-        magnitude = float(definition["Value"])
-        if "Projection" not in definition:
-            check_missing_projection(magnitude)
-        projection = definition.get("Projection", 0.0)
-    return Spin(magnitude, projection)
+def __build_particle(definition: dict) -> Particle:
+    isospin_def = definition.get("isospin", None)
+    if isospin_def is not None:
+        definition["isospin"] = Spin(**isospin_def)
+    for parity in ["parity", "c_parity", "g_parity"]:
+        parity_def = definition.get(parity, None)
+        if parity_def is not None:
+            definition[parity] = Parity(**parity_def)
+    return Particle(**definition)
 
 
 def __build_fit_parameters(definition: List[dict]) -> FitParameters:
@@ -322,19 +288,3 @@ def __build_amplitude(  # pylint: disable=too-many-locals
     raise SyntaxError(
         f"No conversion defined for amplitude type {amplitude_type}"
     )
-
-
-def __yaml_to_parity(
-    definition: Optional[Union[float, int, str]]
-) -> Optional[Parity]:
-    if definition is None:
-        return None
-    return Parity(definition)
-
-
-def __yaml_to_isospin(
-    definition: Optional[Union[dict, float, int, str]]
-) -> Optional[Spin]:
-    if definition is None:
-        return None
-    return build_spin(definition)

--- a/src/expertsystem/io/_dict/build.py
+++ b/src/expertsystem/io/_dict/build.py
@@ -40,7 +40,7 @@ def build_amplitude_model(definition: dict) -> AmplitudeModel:
     parameters = build_fit_parameters(definition)
     kinematics = __build_kinematics(definition["Kinematics"], particles)
     dynamics = __build_particle_dynamics(
-        definition["Dynamics"], particles, parameters
+        definition["dynamics"], particles, parameters
     )
     intensity = __build_intensity(
         definition["Intensity"], particles, parameters

--- a/src/expertsystem/io/_dict/build.py
+++ b/src/expertsystem/io/_dict/build.py
@@ -1,6 +1,6 @@
 """Read recipe objects from a YAML file."""
 
-from typing import List, Optional
+from typing import Optional
 
 from expertsystem.amplitude.model import (
     AmplitudeModel,
@@ -37,7 +37,7 @@ from . import validate
 def build_amplitude_model(definition: dict) -> AmplitudeModel:
     validate.amplitude_model(definition)
     particles = build_particle_collection(definition, do_validate=False)
-    parameters = __build_fit_parameters(definition["Parameters"])
+    parameters = build_fit_parameters(definition)
     kinematics = __build_kinematics(definition["Kinematics"], particles)
     dynamics = __build_particle_dynamics(
         definition["Dynamics"], particles, parameters
@@ -75,12 +75,8 @@ def __build_particle(definition: dict) -> Particle:
     return Particle(**definition)
 
 
-def __build_fit_parameters(definition: List[dict]) -> FitParameters:
-    parameters = FitParameters()
-    for parameter_def in definition:
-        parameter = FitParameter(**parameter_def)
-        parameters.add(parameter)
-    return parameters
+def build_fit_parameters(definition: dict) -> FitParameters:
+    return FitParameters(FitParameter(**p) for p in definition["parameters"])
 
 
 def __build_kinematics(

--- a/src/expertsystem/io/_dict/build.py
+++ b/src/expertsystem/io/_dict/build.py
@@ -81,19 +81,16 @@ def build_fit_parameters(definition: dict) -> FitParameters:
 def __build_kinematics(
     definition: dict, particles: ParticleCollection
 ) -> Kinematics:
-    str_to_kinematics_type = {"Helicity": KinematicsType.Helicity}
-    kinematics_type = str_to_kinematics_type[definition["Type"]]
+    kinematics_type = eval(  # pylint: disable=eval-used
+        f'{KinematicsType.__name__}.{definition["type"]}'
+    )
     kinematics = Kinematics(
         kinematics_type=kinematics_type,
         particles=particles,
     )
-    for item in definition["InitialState"]:
-        state_id = int(item["ID"])
-        particle_name = str(item["Particle"])
+    for state_id, particle_name in definition["initial_state"].items():
         kinematics.add_initial_state(state_id, particle_name)
-    for item in definition["FinalState"]:
-        state_id = int(item["ID"])
-        particle_name = str(item["Particle"])
+    for state_id, particle_name in definition["final_state"].items():
         kinematics.add_final_state(state_id, particle_name)
     return kinematics
 

--- a/src/expertsystem/io/_dict/build.py
+++ b/src/expertsystem/io/_dict/build.py
@@ -37,7 +37,7 @@ def build_amplitude_model(definition: dict) -> AmplitudeModel:
     validate.amplitude_model(definition)
     particles = build_particle_collection(definition, do_validate=False)
     parameters = build_fit_parameters(definition)
-    kinematics = __build_kinematics(definition["Kinematics"], particles)
+    kinematics = __build_kinematics(definition["kinematics"], particles)
     dynamics = __build_particle_dynamics(
         definition["dynamics"], particles, parameters
     )

--- a/src/expertsystem/io/_dict/build.py
+++ b/src/expertsystem/io/_dict/build.py
@@ -78,17 +78,9 @@ def __build_particle(definition: dict) -> Particle:
 def __build_fit_parameters(definition: List[dict]) -> FitParameters:
     parameters = FitParameters()
     for parameter_def in definition:
-        parameter = __build_fit_parameter(parameter_def)
+        parameter = FitParameter(**parameter_def)
         parameters.add(parameter)
     return parameters
-
-
-def __build_fit_parameter(definition: dict) -> FitParameter:
-    return FitParameter(
-        name=str(definition["Name"]),
-        value=float(definition.get("Value", 0.0)),
-        is_fixed=bool(definition.get("Fix", False)),
-    )
 
 
 def __build_kinematics(

--- a/src/expertsystem/io/_dict/build.py
+++ b/src/expertsystem/io/_dict/build.py
@@ -43,7 +43,7 @@ def build_amplitude_model(definition: dict) -> AmplitudeModel:
         definition["dynamics"], particles, parameters
     )
     intensity = __build_intensity(
-        definition["Intensity"], particles, parameters
+        definition["intensity"], particles, parameters
     )
     return AmplitudeModel(
         particles=particles,

--- a/src/expertsystem/io/_dict/build.py
+++ b/src/expertsystem/io/_dict/build.py
@@ -160,7 +160,7 @@ def __safely_get_parameter(
 def __build_intensity(
     definition: dict, particles: ParticleCollection, parameters: FitParameters
 ) -> IntensityNode:
-    intensity_type = definition["Class"]
+    intensity_type = definition["type"]
     if intensity_type == "StrengthIntensity":
         strength = parameters[definition["Strength"]]
         component = str(definition["Component"])
@@ -202,7 +202,7 @@ def __build_intensity(
 def __build_amplitude(  # pylint: disable=too-many-locals
     definition: dict, particles: ParticleCollection, parameters: FitParameters
 ) -> AmplitudeNode:
-    amplitude_type = definition["Class"]
+    amplitude_type = definition["type"]
     if amplitude_type == "CoefficientAmplitude":
         component = definition["Component"]
         magnitude = parameters[definition["Magnitude"]]

--- a/src/expertsystem/io/_dict/dump.py
+++ b/src/expertsystem/io/_dict/dump.py
@@ -29,7 +29,7 @@ def from_amplitude_model(model: AmplitudeModel) -> dict:
     output_dict = {
         "Kinematics": __kinematics_to_dict(model.kinematics),
         **from_fit_parameters(model.parameters),
-        "Intensity": __intensity_to_dict(model.intensity),
+        "intensity": __intensity_to_dict(model.intensity),
         **from_particle_collection(model.particles),
         "dynamics": __dynamics_section_to_dict(model.dynamics),
     }

--- a/src/expertsystem/io/_dict/dump.py
+++ b/src/expertsystem/io/_dict/dump.py
@@ -57,7 +57,11 @@ def from_fit_parameters(parameters: FitParameters) -> dict:
 
 
 def from_fit_parameter(parameter: FitParameter) -> dict:
-    return attr.asdict(parameter, recurse=True)
+    return attr.asdict(
+        parameter,
+        recurse=True,
+        filter=lambda attr, value: attr.default != value,
+    )
 
 
 def __kinematics_to_dict(kin: Kinematics) -> dict:

--- a/src/expertsystem/io/_dict/dump.py
+++ b/src/expertsystem/io/_dict/dump.py
@@ -10,7 +10,6 @@ from expertsystem.amplitude.model import (
     CoefficientAmplitude,
     CoherentIntensity,
     Dynamics,
-    FitParameter,
     FitParameters,
     FormFactor,
     HelicityDecay,
@@ -53,17 +52,7 @@ def from_particle(particle: Particle) -> dict:
 
 
 def __parameters_to_dict(parameters: FitParameters) -> List[dict]:
-    return [__parameter_to_dict(par) for par in parameters.values()]
-
-
-def __parameter_to_dict(parameter: FitParameter) -> dict:
-    output_dict = {
-        "Name": parameter.name,
-        "Value": parameter.value,
-    }
-    if parameter.is_fixed:
-        output_dict["Fix"] = True
-    return output_dict
+    return [attr.asdict(par, recurse=True) for par in parameters.values()]
 
 
 def __kinematics_to_dict(kin: Kinematics) -> dict:

--- a/src/expertsystem/io/_dict/dump.py
+++ b/src/expertsystem/io/_dict/dump.py
@@ -101,19 +101,19 @@ def __intensity_to_dict(  # pylint: disable=too-many-return-statements
 ) -> dict:
     if isinstance(node, StrengthIntensity):
         return {
-            "Class": "StrengthIntensity",
+            "type": "StrengthIntensity",
             "Component": node.component,
             "Strength": node.strength.name,
             "Intensity": __intensity_to_dict(node.intensity),
         }
     if isinstance(node, NormalizedIntensity):
         return {
-            "Class": "NormalizedIntensity",
+            "type": "NormalizedIntensity",
             "Intensity": __intensity_to_dict(node.intensity),
         }
     if isinstance(node, IncoherentIntensity):
         return {
-            "Class": "IncoherentIntensity",
+            "type": "IncoherentIntensity",
             "Intensities": [
                 __intensity_to_dict(intensity)
                 for intensity in node.intensities
@@ -121,7 +121,7 @@ def __intensity_to_dict(  # pylint: disable=too-many-return-statements
         }
     if isinstance(node, CoherentIntensity):
         return {
-            "Class": "CoherentIntensity",
+            "type": "CoherentIntensity",
             "Component": node.component,
             "Amplitudes": [
                 __intensity_to_dict(intensity) for intensity in node.amplitudes
@@ -129,7 +129,7 @@ def __intensity_to_dict(  # pylint: disable=too-many-return-statements
         }
     if isinstance(node, CoefficientAmplitude):
         output_dict: dict = {
-            "Class": "CoefficientAmplitude",
+            "type": "CoefficientAmplitude",
             "Component": node.component,
         }
         if node.prefactor is not None:
@@ -140,14 +140,14 @@ def __intensity_to_dict(  # pylint: disable=too-many-return-statements
         return output_dict
     if isinstance(node, SequentialAmplitude):
         return {
-            "Class": "SequentialAmplitude",
+            "type": "SequentialAmplitude",
             "Amplitudes": [
                 __intensity_to_dict(intensity) for intensity in node.amplitudes
             ],
         }
     if isinstance(node, (HelicityDecay, CanonicalDecay)):
         output_dict = {
-            "Class": "HelicityDecay",
+            "type": "HelicityDecay",
             "DecayParticle": {
                 "Name": node.decaying_particle.particle.name,
                 "Helicity": node.decaying_particle.helicity,

--- a/src/expertsystem/io/_dict/dump.py
+++ b/src/expertsystem/io/_dict/dump.py
@@ -31,7 +31,7 @@ def from_amplitude_model(model: AmplitudeModel) -> dict:
         **from_fit_parameters(model.parameters),
         "Intensity": __intensity_to_dict(model.intensity),
         **from_particle_collection(model.particles),
-        "Dynamics": __dynamics_section_to_dict(model.dynamics),
+        "dynamics": __dynamics_section_to_dict(model.dynamics),
     }
     return output_dict
 

--- a/src/expertsystem/io/_dict/dump.py
+++ b/src/expertsystem/io/_dict/dump.py
@@ -1,5 +1,5 @@
 """Dump recipe objects to `dict` instances for a YAML file."""
-from typing import Any, List, Optional
+from typing import Any, Optional
 
 import attr
 
@@ -10,6 +10,7 @@ from expertsystem.amplitude.model import (
     CoefficientAmplitude,
     CoherentIntensity,
     Dynamics,
+    FitParameter,
     FitParameters,
     FormFactor,
     HelicityDecay,
@@ -30,7 +31,7 @@ from expertsystem.particle import Parity, Particle, ParticleCollection, Spin
 def from_amplitude_model(model: AmplitudeModel) -> dict:
     output_dict = {
         "Kinematics": __kinematics_to_dict(model.kinematics),
-        "Parameters": __parameters_to_dict(model.parameters),
+        **from_fit_parameters(model.parameters),
         "Intensity": __intensity_to_dict(model.intensity),
         **from_particle_collection(model.particles),
         "Dynamics": __dynamics_section_to_dict(model.dynamics),
@@ -51,8 +52,12 @@ def from_particle(particle: Particle) -> dict:
     )
 
 
-def __parameters_to_dict(parameters: FitParameters) -> List[dict]:
-    return [attr.asdict(par, recurse=True) for par in parameters.values()]
+def from_fit_parameters(parameters: FitParameters) -> dict:
+    return {"parameters": [from_fit_parameter(p) for p in parameters.values()]}
+
+
+def from_fit_parameter(parameter: FitParameter) -> dict:
+    return attr.asdict(parameter, recurse=True)
 
 
 def __kinematics_to_dict(kin: Kinematics) -> dict:

--- a/src/expertsystem/io/_dict/dump.py
+++ b/src/expertsystem/io/_dict/dump.py
@@ -25,7 +25,7 @@ from expertsystem.particle import Parity, Particle, ParticleCollection, Spin
 
 def from_amplitude_model(model: AmplitudeModel) -> dict:
     output_dict = {
-        "Kinematics": __kinematics_to_dict(model.kinematics),
+        "kinematics": __kinematics_to_dict(model.kinematics),
         **from_fit_parameters(model.parameters),
         "intensity": __intensity_to_dict(model.intensity),
         **from_particle_collection(model.particles),

--- a/src/expertsystem/io/_dict/dump.py
+++ b/src/expertsystem/io/_dict/dump.py
@@ -40,8 +40,7 @@ def from_amplitude_model(model: AmplitudeModel) -> dict:
 
 
 def from_particle_collection(particles: ParticleCollection) -> dict:
-    output = {"ParticleList": [from_particle(p) for p in particles]}
-    return output
+    return {"particles": [from_particle(p) for p in particles]}
 
 
 def from_particle(particle: Particle) -> dict:

--- a/src/expertsystem/io/_dict/dump.py
+++ b/src/expertsystem/io/_dict/dump.py
@@ -44,11 +44,7 @@ def from_fit_parameters(parameters: FitParameters) -> dict:
 
 
 def from_fit_parameter(parameter: FitParameter) -> dict:
-    return attr.asdict(
-        parameter,
-        recurse=True,
-        filter=lambda attr, value: attr.default != value,
-    )
+    return attr.asdict(parameter, recurse=True)
 
 
 def __kinematics_to_dict(kin: Kinematics) -> dict:

--- a/src/expertsystem/io/_dict/dump.py
+++ b/src/expertsystem/io/_dict/dump.py
@@ -10,7 +10,6 @@ from expertsystem.amplitude.model import (
     FitParameters,
     FormFactor,
     Kinematics,
-    KinematicsType,
     Node,
     ParticleDynamics,
 )
@@ -53,18 +52,10 @@ def from_fit_parameter(parameter: FitParameter) -> dict:
 
 
 def __kinematics_to_dict(kin: Kinematics) -> dict:
-    if kin.kinematics_type == KinematicsType.Helicity:
-        kinematics_type = "Helicity"
-    else:
-        raise NotImplementedError("No conversion for", kin.kinematics_type)
     return {
-        "Type": kinematics_type,
-        "InitialState": [
-            {"Particle": p.name, "ID": i} for i, p in kin.initial_state.items()
-        ],
-        "FinalState": [
-            {"Particle": p.name, "ID": i} for i, p in kin.final_state.items()
-        ],
+        "type": kin.kinematics_type.name,
+        "initial_state": {i: p.name for i, p in kin.initial_state.items()},
+        "final_state": {i: p.name for i, p in kin.final_state.items()},
     }
 
 

--- a/src/expertsystem/io/_dict/validate.py
+++ b/src/expertsystem/io/_dict/validate.py
@@ -1,3 +1,5 @@
+# cspell:ignore stringyfied
+
 """JSON validation schema for a YAML recipe file."""
 
 import json
@@ -26,9 +28,9 @@ def amplitude_model(instance: dict) -> None:
         f"file://{_EXPERTSYSTEM_PATH}/schemas/",
         "amplitude-model.json",
     )
-
+    stringyfied_instance = json.loads(json.dumps(instance))
     jsonschema.validate(
-        instance=instance,
+        instance=stringyfied_instance,
         schema=_SCHEMA_AMPLITUDE,
         resolver=resolver,
     )

--- a/src/expertsystem/schemas/amplitude-model.json
+++ b/src/expertsystem/schemas/amplitude-model.json
@@ -83,19 +83,17 @@
       "patternProperties": {
         "^.*$": {
           "type": "object",
-          "required": ["Type"],
+          "required": ["type"],
           "additionalProperties": true,
           "properties": {
-            "Type": {
-              "enum": ["NonDynamic", "Flatté", "RelativisticBreitWigner"]
-            },
-            "FormFactor": {
+            "type": { "object": "string" },
+            "form_factor": {
               "type": "object",
-              "required": ["Type", "MesonRadius"],
+              "required": ["type", "meson_radius"],
               "additionalProperties": false,
               "properties": {
-                "Type": { "const": "BlattWeisskopf" },
-                "MesonRadius": { "type": "string" }
+                "type": { "object": "string" },
+                "meson_radius": { "type": "string" }
               }
             }
           }

--- a/src/expertsystem/schemas/amplitude-model.json
+++ b/src/expertsystem/schemas/amplitude-model.json
@@ -14,35 +14,25 @@
     "kinematics": {
       "title": "Kinematical description of the particle reaction",
       "type": "object",
-      "required": ["Type", "InitialState", "FinalState"],
+      "required": ["type", "initial_state", "final_state"],
       "additionalProperties": false,
       "properties": {
-        "Type": {
+        "type": {
           "enum": ["Helicity"],
           "title": "Formalism with which the reaction is studied"
         },
-        "InitialState": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "required": ["Particle", "ID"],
-            "additionalProperties": false,
-            "properties": {
-              "Particle": { "type": "string" },
-              "ID": { "$ref": "#/definitions/StateID" }
-            }
+        "initial_state": {
+          "type": "object",
+          "additionalProperties": false,
+          "patternProperties": {
+            "^[0-9]+$": { "type": "string" }
           }
         },
-        "FinalState": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "required": ["Particle", "ID"],
-            "additionalProperties": false,
-            "properties": {
-              "Particle": { "type": "string" },
-              "ID": { "$ref": "#/definitions/StateID" }
-            }
+        "final_state": {
+          "type": "object",
+          "additionalProperties": false,
+          "patternProperties": {
+            "^[0-9]+$": { "type": "string" }
           }
         }
       }

--- a/src/expertsystem/schemas/amplitude-model.json
+++ b/src/expertsystem/schemas/amplitude-model.json
@@ -6,7 +6,7 @@
     "Kinematics",
     "parameters",
     "dynamics",
-    "Intensity",
+    "intensity",
     "particles"
   ],
   "additionalProperties": false,
@@ -100,7 +100,7 @@
         }
       }
     },
-    "Intensity": { "$ref": "#/definitions/Intensity/_recursion" },
+    "intensity": { "$ref": "#/definitions/Intensity/_recursion" },
     "particles": { "$ref": "particle-list.json#/definitions/particles" }
   },
   "definitions": {

--- a/src/expertsystem/schemas/amplitude-model.json
+++ b/src/expertsystem/schemas/amplitude-model.json
@@ -117,23 +117,23 @@
       "_recursion": {
         "type": "object",
         "properties": {
-          "Class": { "$ref": "#/definitions/Intensity/_types" }
+          "type": { "$ref": "#/definitions/Intensity/_types" }
         },
-        "if": { "properties": { "Class": { "const": "StrengthIntensity" } } },
+        "if": { "properties": { "type": { "const": "StrengthIntensity" } } },
         "then": { "$ref": "#/definitions/Intensity/Strength" },
         "else": {
           "if": {
-            "properties": { "Class": { "const": "NormalizedIntensity" } }
+            "properties": { "type": { "const": "NormalizedIntensity" } }
           },
           "then": { "$ref": "#/definitions/Intensity/Normalized" },
           "else": {
             "if": {
-              "properties": { "Class": { "const": "IncoherentIntensity" } }
+              "properties": { "type": { "const": "IncoherentIntensity" } }
             },
             "then": { "$ref": "#/definitions/Intensity/Incoherent" },
             "else": {
               "if": {
-                "properties": { "Class": { "const": "CoherentIntensity" } }
+                "properties": { "type": { "const": "CoherentIntensity" } }
               },
               "then": { "$ref": "#/definitions/Intensity/Coherent" }
             }
@@ -142,10 +142,10 @@
       },
       "Strength": {
         "type": "object",
-        "required": ["Class", "Intensity", "Strength"],
+        "required": ["type", "Intensity", "Strength"],
         "additionalProperties": false,
         "properties": {
-          "Class": { "$ref": "#/definitions/Intensity/_types" },
+          "type": { "$ref": "#/definitions/Intensity/_types" },
           "Component": { "type": "string" },
           "Strength": {
             "type": "string",
@@ -160,10 +160,10 @@
       },
       "Normalized": {
         "type": "object",
-        "required": ["Class", "Intensity"],
+        "required": ["type", "Intensity"],
         "additionalProperties": false,
         "properties": {
-          "Class": { "$ref": "#/definitions/Intensity/_types" },
+          "type": { "$ref": "#/definitions/Intensity/_types" },
           "Intensity": {
             "$ref": "#/definitions/Intensity/_recursion",
             "title": "The intensity with which to multiply the (optional) strength coefficient"
@@ -172,10 +172,10 @@
       },
       "Incoherent": {
         "type": "object",
-        "required": ["Class", "Intensities"],
+        "required": ["type", "Intensities"],
         "additionalProperties": false,
         "properties": {
-          "Class": { "$ref": "#/definitions/Intensity/_types" },
+          "type": { "$ref": "#/definitions/Intensity/_types" },
           "Intensities": {
             "type": "array",
             "title": "List of intensities that will be added up incoherently",
@@ -185,10 +185,10 @@
       },
       "Coherent": {
         "type": "object",
-        "required": ["Class", "Amplitudes"],
+        "required": ["type", "Amplitudes"],
         "additionalProperties": false,
         "properties": {
-          "Class": { "$ref": "#/definitions/Intensity/_types" },
+          "type": { "$ref": "#/definitions/Intensity/_types" },
           "Component": { "type": "string" },
           "Amplitudes": {
             "type": "array",
@@ -209,29 +209,29 @@
       "_recursion": {
         "type": "object",
         "properties": {
-          "Class": { "$ref": "#/definitions/Amplitude/_types" }
+          "type": { "$ref": "#/definitions/Amplitude/_types" }
         },
         "if": {
-          "properties": { "Class": { "const": "CoefficientAmplitude" } }
+          "properties": { "type": { "const": "CoefficientAmplitude" } }
         },
         "then": { "$ref": "#/definitions/Amplitude/Coefficient" },
         "else": {
           "if": {
-            "properties": { "Class": { "const": "SequentialAmplitude" } }
+            "properties": { "type": { "const": "SequentialAmplitude" } }
           },
           "then": { "$ref": "#/definitions/Amplitude/Sequential" },
           "else": {
-            "if": { "properties": { "Class": { "const": "HelicityDecay" } } },
+            "if": { "properties": { "type": { "const": "HelicityDecay" } } },
             "then": { "$ref": "#/definitions/Amplitude/HelicityDecay" }
           }
         }
       },
       "Coefficient": {
         "type": "object",
-        "required": ["Class", "Magnitude", "Phase", "Amplitude"],
+        "required": ["type", "Magnitude", "Phase", "Amplitude"],
         "additionalProperties": false,
         "properties": {
-          "Class": { "$ref": "#/definitions/Amplitude/_types" },
+          "type": { "$ref": "#/definitions/Amplitude/_types" },
           "Component": { "type": "string" },
           "PreFactor": { "type": "number" },
           "Magnitude": { "type": "string" },
@@ -241,10 +241,10 @@
       },
       "Sequential": {
         "type": "object",
-        "required": ["Class", "Amplitudes"],
+        "required": ["type", "Amplitudes"],
         "additionalProperties": false,
         "properties": {
-          "Class": { "$ref": "#/definitions/Amplitude/_types" },
+          "type": { "$ref": "#/definitions/Amplitude/_types" },
           "Amplitudes": {
             "type": "array",
             "items": { "$ref": "#/definitions/Amplitude/_recursion" }
@@ -253,10 +253,10 @@
       },
       "HelicityDecay": {
         "type": "object",
-        "required": ["Class", "DecayParticle", "DecayProducts"],
+        "required": ["type", "DecayParticle", "DecayProducts"],
         "additionalProperties": false,
         "properties": {
-          "Class": { "$ref": "#/definitions/Amplitude/_types" },
+          "type": { "$ref": "#/definitions/Amplitude/_types" },
           "DecayParticle": {
             "type": "object",
             "required": ["Name", "Helicity"],

--- a/src/expertsystem/schemas/amplitude-model.json
+++ b/src/expertsystem/schemas/amplitude-model.json
@@ -53,24 +53,24 @@
       "type": "array",
       "items": {
         "type": "object",
-        "required": ["Name", "Value"],
+        "required": ["name", "value"],
         "additionalProperties": false,
         "properties": {
-          "Name": {
+          "name": {
             "type": "string",
             "title": "Parameter name",
             "description": "Has to be a unique string that is used to identify where the parameter is used in the rest of the model"
           },
-          "Value": {
+          "value": {
             "type": "number",
             "title": "Starting value of the fit parameter"
           },
-          "Fix": { "type": "boolean" },
-          "Min": {
+          "is_fixed": { "type": "boolean" },
+          "min": {
             "type": "number",
             "title": "Lower boundary of the fit range"
           },
-          "Max": {
+          "max": {
             "type": "number",
             "title": "Upper boundary of the fit range"
           }

--- a/src/expertsystem/schemas/amplitude-model.json
+++ b/src/expertsystem/schemas/amplitude-model.json
@@ -7,7 +7,7 @@
     "Parameters",
     "Dynamics",
     "Intensity",
-    "ParticleList"
+    "particles"
   ],
   "additionalProperties": false,
   "properties": {
@@ -103,7 +103,7 @@
       }
     },
     "Intensity": { "$ref": "#/definitions/Intensity/_recursion" },
-    "ParticleList": { "$ref": "particle-list.json#/definitions/ParticleList" }
+    "particles": { "$ref": "particle-list.json#/definitions/particles" }
   },
   "definitions": {
     "Intensity": {

--- a/src/expertsystem/schemas/amplitude-model.json
+++ b/src/expertsystem/schemas/amplitude-model.json
@@ -234,7 +234,7 @@
         "properties": {
           "type": { "$ref": "#/definitions/Amplitude/_types" },
           "component": { "type": "string" },
-          "PreFactor": { "type": "number" },
+          "prefactor": { "type": "number" },
           "magnitude": { "type": "string" },
           "phase": { "type": "string" },
           "amplitude": { "$ref": "#/definitions/Amplitude/_recursion" }

--- a/src/expertsystem/schemas/amplitude-model.json
+++ b/src/expertsystem/schemas/amplitude-model.json
@@ -4,7 +4,7 @@
   "type": "object",
   "required": [
     "Kinematics",
-    "Parameters",
+    "parameters",
     "Dynamics",
     "Intensity",
     "particles"
@@ -47,7 +47,7 @@
         }
       }
     },
-    "Parameters": {
+    "parameters": {
       "title": "Parameter list",
       "description": "An array of parameters used throughout the amplitude model",
       "type": "array",

--- a/src/expertsystem/schemas/amplitude-model.json
+++ b/src/expertsystem/schemas/amplitude-model.json
@@ -5,7 +5,7 @@
   "required": [
     "Kinematics",
     "parameters",
-    "Dynamics",
+    "dynamics",
     "Intensity",
     "particles"
   ],
@@ -77,7 +77,7 @@
         }
       }
     },
-    "Dynamics": {
+    "dynamics": {
       "type": "object",
       "additionalProperties": false,
       "patternProperties": {

--- a/src/expertsystem/schemas/amplitude-model.json
+++ b/src/expertsystem/schemas/amplitude-model.json
@@ -142,17 +142,17 @@
       },
       "Strength": {
         "type": "object",
-        "required": ["type", "Intensity", "Strength"],
+        "required": ["type", "intensity", "strength"],
         "additionalProperties": false,
         "properties": {
           "type": { "$ref": "#/definitions/Intensity/_types" },
-          "Component": { "type": "string" },
-          "Strength": {
+          "component": { "type": "string" },
+          "strength": {
             "type": "string",
             "title": "Coefficient when working with multiple terms",
             "description": "Should be the unique name of a parameter that is further specified in the Parameter section"
           },
-          "Intensity": {
+          "intensity": {
             "$ref": "#/definitions/Intensity/_recursion",
             "title": "The intensity with which to multiply the (optional) strength coefficient"
           }
@@ -160,11 +160,11 @@
       },
       "Normalized": {
         "type": "object",
-        "required": ["type", "Intensity"],
+        "required": ["type", "intensity"],
         "additionalProperties": false,
         "properties": {
           "type": { "$ref": "#/definitions/Intensity/_types" },
-          "Intensity": {
+          "intensity": {
             "$ref": "#/definitions/Intensity/_recursion",
             "title": "The intensity with which to multiply the (optional) strength coefficient"
           }
@@ -172,11 +172,11 @@
       },
       "Incoherent": {
         "type": "object",
-        "required": ["type", "Intensities"],
+        "required": ["type", "intensities"],
         "additionalProperties": false,
         "properties": {
           "type": { "$ref": "#/definitions/Intensity/_types" },
-          "Intensities": {
+          "intensities": {
             "type": "array",
             "title": "List of intensities that will be added up incoherently",
             "items": { "$ref": "#/definitions/Intensity/_recursion" }
@@ -185,12 +185,12 @@
       },
       "Coherent": {
         "type": "object",
-        "required": ["type", "Amplitudes"],
+        "required": ["type", "amplitudes"],
         "additionalProperties": false,
         "properties": {
           "type": { "$ref": "#/definitions/Intensity/_types" },
-          "Component": { "type": "string" },
-          "Amplitudes": {
+          "component": { "type": "string" },
+          "amplitudes": {
             "type": "array",
             "items": { "$ref": "#/definitions/Amplitude/_recursion" }
           }
@@ -203,7 +203,8 @@
         "enum": [
           "CoefficientAmplitude",
           "SequentialAmplitude",
-          "HelicityDecay"
+          "HelicityDecay",
+          "CanonicalDecay"
         ]
       },
       "_recursion": {
@@ -228,100 +229,30 @@
       },
       "Coefficient": {
         "type": "object",
-        "required": ["type", "Magnitude", "Phase", "Amplitude"],
+        "required": ["type", "magnitude", "phase", "amplitude"],
         "additionalProperties": false,
         "properties": {
           "type": { "$ref": "#/definitions/Amplitude/_types" },
-          "Component": { "type": "string" },
+          "component": { "type": "string" },
           "PreFactor": { "type": "number" },
-          "Magnitude": { "type": "string" },
-          "Phase": { "type": "string" },
-          "Amplitude": { "$ref": "#/definitions/Amplitude/_recursion" }
+          "magnitude": { "type": "string" },
+          "phase": { "type": "string" },
+          "amplitude": { "$ref": "#/definitions/Amplitude/_recursion" }
         }
       },
       "Sequential": {
         "type": "object",
-        "required": ["type", "Amplitudes"],
+        "required": ["type", "amplitudes"],
         "additionalProperties": false,
         "properties": {
           "type": { "$ref": "#/definitions/Amplitude/_types" },
-          "Amplitudes": {
+          "amplitudes": {
             "type": "array",
             "items": { "$ref": "#/definitions/Amplitude/_recursion" }
           }
         }
       },
-      "HelicityDecay": {
-        "type": "object",
-        "required": ["type", "DecayParticle", "DecayProducts"],
-        "additionalProperties": false,
-        "properties": {
-          "type": { "$ref": "#/definitions/Amplitude/_types" },
-          "DecayParticle": {
-            "type": "object",
-            "required": ["Name", "Helicity"],
-            "additionalProperties": false,
-            "properties": {
-              "Name": { "type": "string" },
-              "Helicity": { "type": "number" }
-            }
-          },
-          "DecayProducts": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "required": ["Name", "FinalState", "Helicity"],
-              "additionalProperties": false,
-              "properties": {
-                "Name": { "type": "string" },
-                "Helicity": { "type": "number" },
-                "FinalState": {
-                  "type": "array",
-                  "items": { "$ref": "#/definitions/StateID" }
-                }
-              }
-            }
-          },
-          "RecoilSystem": {
-            "type": "object",
-            "required": ["RecoilFinalState"],
-            "additionalProperties": false,
-            "properties": {
-              "RecoilFinalState": {
-                "type": "array",
-                "items": { "$ref": "#/definitions/StateID" }
-              },
-              "ParentRecoilFinalState": {
-                "type": "array",
-                "items": { "$ref": "#/definitions/StateID" }
-              }
-            }
-          },
-          "Canonical": {
-            "type": "object",
-            "required": ["LS", "s2s3"],
-            "additionalProperties": false,
-            "properties": {
-              "LS": {
-                "type": "object",
-                "required": ["ClebschGordan"],
-                "additionalProperties": false,
-                "properties": {
-                  "ClebschGordan": { "$ref": "#/definitions/ClebschGordan" }
-                }
-              },
-              "s2s3": {
-                "type": "object",
-                "required": ["ClebschGordan"],
-                "additionalProperties": false,
-                "properties": {
-                  "ClebschGordan": { "$ref": "#/definitions/ClebschGordan" }
-                }
-              }
-            }
-          }
-        }
-      }
+      "HelicityDecay": { "$ref": "#/definitions/HelicityDecay" }
     },
     "ClebschGordan": {
       "type": "object",
@@ -334,6 +265,56 @@
         "m1": { "type": "number" },
         "j2": { "type": "number" },
         "m2": { "type": "number" }
+      }
+    },
+    "HelicityDecay": {
+      "type": "object",
+      "required": ["type", "decaying_particle", "decay_products"],
+      "additionalProperties": false,
+      "properties": {
+        "type": { "$ref": "#/definitions/Amplitude/_types" },
+        "decaying_particle": {
+          "type": "object",
+          "required": ["particle", "helicity"],
+          "additionalProperties": false,
+          "properties": {
+            "particle": { "type": "string" },
+            "helicity": { "type": "number" }
+          }
+        },
+        "decay_products": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["particle", "final_state_ids", "helicity"],
+            "additionalProperties": false,
+            "properties": {
+              "particle": { "type": "string" },
+              "helicity": { "type": "number" },
+              "final_state_ids": {
+                "type": "array",
+                "items": { "$ref": "#/definitions/StateID" }
+              }
+            }
+          }
+        },
+        "recoil_system": {
+          "type": "object",
+          "required": ["recoil_final_state"],
+          "additionalProperties": false,
+          "properties": {
+            "recoil_final_state": {
+              "type": "array",
+              "items": { "$ref": "#/definitions/StateID" }
+            },
+            "parent_recoil_final_state": {
+              "type": "array",
+              "items": { "$ref": "#/definitions/StateID" }
+            }
+          }
+        },
+        "l_s": { "$ref": "#/definitions/ClebschGordan" },
+        "s2s3": { "$ref": "#/definitions/ClebschGordan" }
       }
     },
     "StateID": {

--- a/src/expertsystem/schemas/amplitude-model.json
+++ b/src/expertsystem/schemas/amplitude-model.json
@@ -3,7 +3,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "required": [
-    "Kinematics",
+    "kinematics",
     "parameters",
     "dynamics",
     "intensity",
@@ -11,7 +11,7 @@
   ],
   "additionalProperties": false,
   "properties": {
-    "Kinematics": {
+    "kinematics": {
       "title": "Kinematical description of the particle reaction",
       "type": "object",
       "required": ["Type", "InitialState", "FinalState"],

--- a/src/expertsystem/schemas/amplitude-model.json
+++ b/src/expertsystem/schemas/amplitude-model.json
@@ -65,7 +65,7 @@
             "type": "number",
             "title": "Starting value of the fit parameter"
           },
-          "is_fixed": { "type": "boolean" },
+          "fix": { "type": "boolean" },
           "min": {
             "type": "number",
             "title": "Lower boundary of the fit range"

--- a/src/expertsystem/schemas/particle-list.json
+++ b/src/expertsystem/schemas/particle-list.json
@@ -2,9 +2,9 @@
   "$id": "particle-list.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
-  "required": ["ParticleList"],
+  "required": ["particles"],
   "additionalProperties": false,
-  "properties": { "ParticleList": { "$ref": "#/definitions/ParticleList" } },
+  "properties": { "particles": { "$ref": "#/definitions/particles" } },
   "definitions": {
     "Parity": {
       "type": "object",
@@ -47,7 +47,7 @@
       },
       "additionalProperties": false
     },
-    "ParticleList": {
+    "particles": {
       "type": "array",
       "items": { "$ref": "#/definitions/Particle" }
     }

--- a/src/expertsystem/schemas/particle-list.json
+++ b/src/expertsystem/schemas/particle-list.json
@@ -6,64 +6,50 @@
   "additionalProperties": false,
   "properties": { "ParticleList": { "$ref": "#/definitions/ParticleList" } },
   "definitions": {
+    "Parity": {
+      "type": "object",
+      "required": ["value"],
+      "properties": {
+        "value": { "enum": [-1, 1] },
+        "additionalProperties": false
+      }
+    },
     "Particle": {
       "type": "object",
-      "required": ["PID", "Mass", "QuantumNumbers"],
+      "required": ["name", "pid", "mass", "spin"],
       "properties": {
-        "PID": { "type": "integer" },
-        "Mass": { "type": "number" },
-        "Width": { "type": "number" },
-        "QuantumNumbers": { "$ref": "#/definitions/QuantumNumbers" }
+        "name": { "type": "string" },
+        "pid": { "type": "integer" },
+        "mass": { "type": "number" },
+        "width": { "type": "number" },
+        "charge": { "type": "integer" },
+        "spin": { "type": "number", "multipleOf": 0.5 },
+        "parity": { "$ref": "#/definitions/Parity" },
+        "c_parity": { "$ref": "#/definitions/Parity" },
+        "g_parity": { "$ref": "#/definitions/Parity" },
+        "strangeness": { "type": "integer" },
+        "charmness": { "type": "integer" },
+        "bottomness": { "type": "integer" },
+        "topness": { "type": "integer" },
+        "baryon_number": { "type": "integer" },
+        "electron_lepton_number": { "type": "integer" },
+        "muon_lepton_number": { "type": "integer" },
+        "tau_lepton_number": { "type": "integer" },
+        "isospin": {
+          "type": "object",
+          "required": ["magnitude", "projection"],
+          "properties": {
+            "magnitude": { "type": "number" },
+            "projection": { "type": "number" }
+          },
+          "additionalProperties": false
+        }
       },
       "additionalProperties": false
     },
     "ParticleList": {
-      "type": "object",
-      "patternProperties": { "^.*$": { "$ref": "#/definitions/Particle" } },
-      "additionalProperties": false
-    },
-    "QuantumNumbers": {
-      "type": "object",
-      "required": ["Charge", "Spin"],
-      "properties": {
-        "Charge": { "type": "integer" },
-        "Spin": { "type": "number", "multipleOf": 0.5 },
-        "Parity": { "enum": [-1, 1] },
-        "CParity": { "enum": [-1, 1] },
-        "GParity": { "enum": [-1, 1] },
-        "Strangeness": { "type": "integer" },
-        "Charmness": { "type": "integer" },
-        "Bottomness": { "type": "integer" },
-        "Topness": { "type": "integer" },
-        "BaryonNumber": { "type": "integer" },
-        "ElectronLN": { "type": "integer" },
-        "MuonLN": { "type": "integer" },
-        "TauLN": { "type": "integer" },
-        "IsoSpin": {
-          "anyOf": [
-            { "type": "number", "minimum": 0, "maximum": 0 },
-            {
-              "type": "object",
-              "required": ["Value"],
-              "properties": {
-                "Value": { "type": "number" },
-                "Projection": { "type": "number" }
-              },
-              "additionalProperties": false
-            }
-          ]
-        }
-      },
-      "additionalProperties": false
-    },
-    "Scalar": {
-      "anyOf": [
-        { "type": "number" },
-        {
-          "type": "string",
-          "regex": "[-+]?(\\.[0-9]+|[0-9]+(\\.[0-9]*)?)([eE][-+]?[0-9]+)?"
-        }
-      ]
+      "type": "array",
+      "items": { "$ref": "#/definitions/Particle" }
     }
   }
 }

--- a/tests/unit/amplitude/test_model.py
+++ b/tests/unit/amplitude/test_model.py
@@ -103,7 +103,7 @@ class TestParticleDynamics:
         gamma_width = pars[f"Width_{gamma}"]
         assert gamma_mass.value == pdg[gamma].mass
         assert gamma_width.value == pdg[gamma].width
-        assert list(pars.filter(lambda p: not p.is_fixed).values()) == [
+        assert list(pars.filter(lambda p: not p.fix).values()) == [
             gamma_mass,
             gamma_width,
         ]

--- a/tests/unit/io/expected_recipe.yml
+++ b/tests/unit/io/expected_recipe.yml
@@ -10,26 +10,34 @@ kinematics:
 parameters:
   - name: &par1 Magnitude_J/psi(1S)_to_f(0)(980)_0+gamma_1;f(0)(980)_to_pi0_0+pi0_0;
     value: 1.0
+    fix: false
   - name: &par2 Phase_J/psi(1S)_to_f(0)(980)_0+gamma_1;f(0)(980)_to_pi0_0+pi0_0;
     value: 0.0
+    fix: false
   - name: &par3 Magnitude_J/psi(1S)_to_f(0)(1500)_0+gamma_1;f(0)(1500)_to_pi0_0+pi0_0;
     value: 1.0
+    fix: false
   - name: &par4 Phase_J/psi(1S)_to_f(0)(1500)_0+gamma_1;f(0)(1500)_to_pi0_0+pi0_0;
     value: 0.0
+    fix: false
   - name: &par5 MesonRadius_J/psi(1S)
     value: 1.0
     fix: true
   - name: &par6 Position_f(0)(980)
     value: 0.99
+    fix: false
   - name: &par7 Width_f(0)(980)
     value: 0.06
+    fix: false
   - name: &par8 MesonRadius_f(0)(980)
     value: 1.0
     fix: true
   - name: &par9 Position_f(0)(1500)
     value: 1.506
+    fix: false
   - name: &par10 Width_f(0)(1500)
     value: 0.112
+    fix: false
   - name: &par11 MesonRadius_f(0)(1500)
     value: 1.0
     fix: true

--- a/tests/unit/io/expected_recipe.yml
+++ b/tests/unit/io/expected_recipe.yml
@@ -422,7 +422,7 @@ particles:
       magnitude: 0.0
       projection: 0.0
 
-Dynamics:
+dynamics:
   J/psi(1S):
     type: NonDynamic
     form_factor:

--- a/tests/unit/io/expected_recipe.yml
+++ b/tests/unit/io/expected_recipe.yml
@@ -356,7 +356,7 @@ Intensity:
                       RecoilFinalState:
                         - 2
 
-ParticleList:
+particles:
   - name: J/psi(1S)
     pid: 443
     mass: 3.0969

--- a/tests/unit/io/expected_recipe.yml
+++ b/tests/unit/io/expected_recipe.yml
@@ -39,25 +39,25 @@ parameters:
     fix: true
 
 intensity:
-  Class: StrengthIntensity
+  type: StrengthIntensity
   Component: incoherent_with_strength
   Strength: strength_incoherent
   Intensity:
-    Class: NormalizedIntensity
+    type: NormalizedIntensity
     Intensity:
-      Class: IncoherentIntensity
+      type: IncoherentIntensity
       Intensities:
-        - Class: CoherentIntensity
+        - type: CoherentIntensity
           Component: coherent_J/psi(1S)_-1_to_gamma_-1+pi0_0+pi0_0
           Amplitudes:
-            - Class: CoefficientAmplitude
+            - type: CoefficientAmplitude
               Component: J/psi(1S)_-1_to_f(0)(980)_0+gamma_-1;f(0)(980)_0_to_pi0_0+pi0_0;
               Magnitude: *par1
               Phase: *par2
               Amplitude:
-                Class: SequentialAmplitude
+                type: SequentialAmplitude
                 Amplitudes:
-                  - Class: HelicityDecay
+                  - type: HelicityDecay
                     DecayParticle:
                       Name: J/psi(1S)
                       Helicity: -1.0
@@ -71,7 +71,7 @@ intensity:
                         FinalState:
                           - 2
                         Helicity: -1.0
-                  - Class: HelicityDecay
+                  - type: HelicityDecay
                     DecayParticle:
                       Name: f(0)(980)
                       Helicity: 0.0
@@ -87,14 +87,14 @@ intensity:
                     RecoilSystem:
                       RecoilFinalState:
                         - 2
-            - Class: CoefficientAmplitude
+            - type: CoefficientAmplitude
               Component: J/psi(1S)_-1_to_f(0)(1500)_0+gamma_-1;f(0)(1500)_0_to_pi0_0+pi0_0;
               Magnitude: *par3
               Phase: *par4
               Amplitude:
-                Class: SequentialAmplitude
+                type: SequentialAmplitude
                 Amplitudes:
-                  - Class: HelicityDecay
+                  - type: HelicityDecay
                     DecayParticle:
                       Name: J/psi(1S)
                       Helicity: -1.0
@@ -108,7 +108,7 @@ intensity:
                         FinalState:
                           - 2
                         Helicity: -1.0
-                  - Class: HelicityDecay
+                  - type: HelicityDecay
                     DecayParticle:
                       Name: f(0)(1500)
                       Helicity: 0.0
@@ -124,17 +124,17 @@ intensity:
                     RecoilSystem:
                       RecoilFinalState:
                         - 2
-        - Class: CoherentIntensity
+        - type: CoherentIntensity
           Component: coherent_J/psi(1S)_1_to_gamma_-1+pi0_0+pi0_0
           Amplitudes:
-            - Class: CoefficientAmplitude
+            - type: CoefficientAmplitude
               Component: J/psi(1S)_1_to_f(0)(980)_0+gamma_-1;f(0)(980)_0_to_pi0_0+pi0_0;
               Magnitude: *par1
               Phase: *par2
               Amplitude:
-                Class: SequentialAmplitude
+                type: SequentialAmplitude
                 Amplitudes:
-                  - Class: HelicityDecay
+                  - type: HelicityDecay
                     DecayParticle:
                       Name: J/psi(1S)
                       Helicity: 1.0
@@ -148,7 +148,7 @@ intensity:
                         FinalState:
                           - 2
                         Helicity: -1.0
-                  - Class: HelicityDecay
+                  - type: HelicityDecay
                     DecayParticle:
                       Name: f(0)(980)
                       Helicity: 0.0
@@ -164,14 +164,14 @@ intensity:
                     RecoilSystem:
                       RecoilFinalState:
                         - 2
-            - Class: CoefficientAmplitude
+            - type: CoefficientAmplitude
               Component: J/psi(1S)_1_to_f(0)(1500)_0+gamma_-1;f(0)(1500)_0_to_pi0_0+pi0_0;
               Magnitude: *par3
               Phase: *par4
               Amplitude:
-                Class: SequentialAmplitude
+                type: SequentialAmplitude
                 Amplitudes:
-                  - Class: HelicityDecay
+                  - type: HelicityDecay
                     DecayParticle:
                       Name: J/psi(1S)
                       Helicity: 1.0
@@ -185,7 +185,7 @@ intensity:
                         FinalState:
                           - 2
                         Helicity: -1.0
-                  - Class: HelicityDecay
+                  - type: HelicityDecay
                     DecayParticle:
                       Name: f(0)(1500)
                       Helicity: 0.0
@@ -201,17 +201,17 @@ intensity:
                     RecoilSystem:
                       RecoilFinalState:
                         - 2
-        - Class: CoherentIntensity
+        - type: CoherentIntensity
           Component: coherent_J/psi(1S)_-1_to_gamma_1+pi0_0+pi0_0
           Amplitudes:
-            - Class: CoefficientAmplitude
+            - type: CoefficientAmplitude
               Component: J/psi(1S)_-1_to_f(0)(980)_0+gamma_1;f(0)(980)_0_to_pi0_0+pi0_0;
               Magnitude: *par1
               Phase: *par2
               Amplitude:
-                Class: SequentialAmplitude
+                type: SequentialAmplitude
                 Amplitudes:
-                  - Class: HelicityDecay
+                  - type: HelicityDecay
                     DecayParticle:
                       Name: J/psi(1S)
                       Helicity: -1.0
@@ -225,7 +225,7 @@ intensity:
                         FinalState:
                           - 2
                         Helicity: 1.0
-                  - Class: HelicityDecay
+                  - type: HelicityDecay
                     DecayParticle:
                       Name: f(0)(980)
                       Helicity: 0.0
@@ -241,14 +241,14 @@ intensity:
                     RecoilSystem:
                       RecoilFinalState:
                         - 2
-            - Class: CoefficientAmplitude
+            - type: CoefficientAmplitude
               Component: J/psi(1S)_-1_to_f(0)(1500)_0+gamma_1;f(0)(1500)_0_to_pi0_0+pi0_0;
               Magnitude: *par3
               Phase: *par4
               Amplitude:
-                Class: SequentialAmplitude
+                type: SequentialAmplitude
                 Amplitudes:
-                  - Class: HelicityDecay
+                  - type: HelicityDecay
                     DecayParticle:
                       Name: J/psi(1S)
                       Helicity: -1.0
@@ -262,7 +262,7 @@ intensity:
                         FinalState:
                           - 2
                         Helicity: 1.0
-                  - Class: HelicityDecay
+                  - type: HelicityDecay
                     DecayParticle:
                       Name: f(0)(1500)
                       Helicity: 0.0
@@ -278,17 +278,17 @@ intensity:
                     RecoilSystem:
                       RecoilFinalState:
                         - 2
-        - Class: CoherentIntensity
+        - type: CoherentIntensity
           Component: coherent_J/psi(1S)_1_to_gamma_1+pi0_0+pi0_0
           Amplitudes:
-            - Class: CoefficientAmplitude
+            - type: CoefficientAmplitude
               Component: J/psi(1S)_1_to_f(0)(980)_0+gamma_1;f(0)(980)_0_to_pi0_0+pi0_0;
               Magnitude: *par1
               Phase: *par2
               Amplitude:
-                Class: SequentialAmplitude
+                type: SequentialAmplitude
                 Amplitudes:
-                  - Class: HelicityDecay
+                  - type: HelicityDecay
                     DecayParticle:
                       Name: J/psi(1S)
                       Helicity: 1.0
@@ -302,7 +302,7 @@ intensity:
                         FinalState:
                           - 2
                         Helicity: 1.0
-                  - Class: HelicityDecay
+                  - type: HelicityDecay
                     DecayParticle:
                       Name: f(0)(980)
                       Helicity: 0.0
@@ -318,14 +318,14 @@ intensity:
                     RecoilSystem:
                       RecoilFinalState:
                         - 2
-            - Class: CoefficientAmplitude
+            - type: CoefficientAmplitude
               Component: J/psi(1S)_1_to_f(0)(1500)_0+gamma_1;f(0)(1500)_0_to_pi0_0+pi0_0;
               Magnitude: *par3
               Phase: *par4
               Amplitude:
-                Class: SequentialAmplitude
+                type: SequentialAmplitude
                 Amplitudes:
-                  - Class: HelicityDecay
+                  - type: HelicityDecay
                     DecayParticle:
                       Name: J/psi(1S)
                       Helicity: 1.0
@@ -339,7 +339,7 @@ intensity:
                         FinalState:
                           - 2
                         Helicity: 1.0
-                  - Class: HelicityDecay
+                  - type: HelicityDecay
                     DecayParticle:
                       Name: f(0)(1500)
                       Helicity: 0.0

--- a/tests/unit/io/expected_recipe.yml
+++ b/tests/unit/io/expected_recipe.yml
@@ -1,4 +1,4 @@
-Kinematics:
+kinematics:
   Type: Helicity
   InitialState:
     - Particle: J/psi(1S)

--- a/tests/unit/io/expected_recipe.yml
+++ b/tests/unit/io/expected_recipe.yml
@@ -11,7 +11,7 @@ Kinematics:
     - Particle: pi0
       ID: 4
 
-Parameters:
+parameters:
   - name: &par1 Magnitude_J/psi(1S)_to_f(0)(980)_0+gamma_1;f(0)(980)_to_pi0_0+pi0_0;
     value: 1.0
     is_fixed: false

--- a/tests/unit/io/expected_recipe.yml
+++ b/tests/unit/io/expected_recipe.yml
@@ -22,21 +22,21 @@ parameters:
     value: 0.0
   - name: &par5 MesonRadius_J/psi(1S)
     value: 1.0
-    is_fixed: true
+    fix: true
   - name: &par6 Position_f(0)(980)
     value: 0.99
   - name: &par7 Width_f(0)(980)
     value: 0.06
   - name: &par8 MesonRadius_f(0)(980)
     value: 1.0
-    is_fixed: true
+    fix: true
   - name: &par9 Position_f(0)(1500)
     value: 1.506
   - name: &par10 Width_f(0)(1500)
     value: 0.112
   - name: &par11 MesonRadius_f(0)(1500)
     value: 1.0
-    is_fixed: true
+    fix: true
 
 Intensity:
   Class: StrengthIntensity

--- a/tests/unit/io/expected_recipe.yml
+++ b/tests/unit/io/expected_recipe.yml
@@ -14,34 +14,26 @@ Kinematics:
 parameters:
   - name: &par1 Magnitude_J/psi(1S)_to_f(0)(980)_0+gamma_1;f(0)(980)_to_pi0_0+pi0_0;
     value: 1.0
-    is_fixed: false
   - name: &par2 Phase_J/psi(1S)_to_f(0)(980)_0+gamma_1;f(0)(980)_to_pi0_0+pi0_0;
     value: 0.0
-    is_fixed: false
   - name: &par3 Magnitude_J/psi(1S)_to_f(0)(1500)_0+gamma_1;f(0)(1500)_to_pi0_0+pi0_0;
     value: 1.0
-    is_fixed: false
   - name: &par4 Phase_J/psi(1S)_to_f(0)(1500)_0+gamma_1;f(0)(1500)_to_pi0_0+pi0_0;
     value: 0.0
-    is_fixed: false
   - name: &par5 MesonRadius_J/psi(1S)
     value: 1.0
     is_fixed: true
   - name: &par6 Position_f(0)(980)
     value: 0.99
-    is_fixed: false
   - name: &par7 Width_f(0)(980)
     value: 0.06
-    is_fixed: false
   - name: &par8 MesonRadius_f(0)(980)
     value: 1.0
     is_fixed: true
   - name: &par9 Position_f(0)(1500)
     value: 1.506
-    is_fixed: false
   - name: &par10 Width_f(0)(1500)
     value: 0.112
-    is_fixed: false
   - name: &par11 MesonRadius_f(0)(1500)
     value: 1.0
     is_fixed: true

--- a/tests/unit/io/expected_recipe.yml
+++ b/tests/unit/io/expected_recipe.yml
@@ -357,60 +357,70 @@ Intensity:
                         - 2
 
 ParticleList:
-  J/psi(1S):
-    PID: 443
-    Mass: 3.0969
-    Width: 9.29e-05
-    QuantumNumbers:
-      Spin: 1
-      Charge: 0
-      Parity: -1
-      CParity: -1
-      GParity: -1
-      IsoSpin: 0
-  gamma:
-    PID: 22
-    Mass: 0.0
-    QuantumNumbers:
-      Spin: 1
-      Charge: 0
-      Parity: -1
-      CParity: -1
-  pi0:
-    PID: 111
-    Mass: 0.1349768
-    Width: 7.73e-09
-    QuantumNumbers:
-      Spin: 0
-      Charge: 0
-      Parity: -1
-      CParity: 1
-      GParity: -1
-      IsoSpin:
-        Value: 1
-        Projection: 0
-  f(0)(980):
-    PID: 9010221
-    Mass: 0.99
-    Width: 0.06
-    QuantumNumbers:
-      Spin: 0
-      Charge: 0
-      Parity: 1
-      CParity: 1
-      GParity: 1
-      IsoSpin: 0
-  f(0)(1500):
-    PID: 9030221
-    Mass: 1.506
-    Width: 0.112
-    QuantumNumbers:
-      Spin: 0
-      Charge: 0
-      Parity: 1
-      CParity: 1
-      GParity: 1
-      IsoSpin: 0
+  - name: J/psi(1S)
+    pid: 443
+    mass: 3.0969
+    width: 9.29e-05
+    spin: 1.0
+    parity:
+      value: -1
+    c_parity:
+      value: -1
+    g_parity:
+      value: -1
+    isospin:
+      magnitude: 0.0
+      projection: 0.0
+  - name: gamma
+    pid: 22
+    mass: 0.0
+    spin: 1.0
+    parity:
+      value: -1
+    c_parity:
+      value: -1
+  - name: pi0
+    pid: 111
+    mass: 0.1349768
+    width: 7.73e-09
+    spin: 0.0
+    parity:
+      value: -1
+    c_parity:
+      value: 1
+    g_parity:
+      value: -1
+    isospin:
+      magnitude: 1.0
+      projection: 0.0
+  - name: f(0)(980)
+    pid: 9010221
+    mass: 0.99
+    width: 0.06
+    spin: 0.0
+    parity:
+      value: 1
+    c_parity:
+      value: 1
+    g_parity:
+      value: 1
+    isospin:
+      magnitude: 0.0
+      projection: 0.0
+  - name: f(0)(1500)
+    pid: 9030221
+    mass: 1.506
+    width: 0.112
+    spin: 0.0
+    parity:
+      value: 1
+    c_parity:
+      value: 1
+    g_parity:
+      value: 1
+    isospin:
+      magnitude: 0.0
+      projection: 0.0
 
 Dynamics:
   J/psi(1S):

--- a/tests/unit/io/expected_recipe.yml
+++ b/tests/unit/io/expected_recipe.yml
@@ -38,7 +38,7 @@ parameters:
     value: 1.0
     fix: true
 
-Intensity:
+intensity:
   Class: StrengthIntensity
   Component: incoherent_with_strength
   Strength: strength_incoherent

--- a/tests/unit/io/expected_recipe.yml
+++ b/tests/unit/io/expected_recipe.yml
@@ -12,31 +12,39 @@ Kinematics:
       ID: 4
 
 Parameters:
-  - Name: &par1 Magnitude_J/psi(1S)_to_f(0)(980)_0+gamma_1;f(0)(980)_to_pi0_0+pi0_0;
-    Value: 1.0
-  - Name: &par2 Phase_J/psi(1S)_to_f(0)(980)_0+gamma_1;f(0)(980)_to_pi0_0+pi0_0;
-    Value: 0.0
-  - Name: &par3 Magnitude_J/psi(1S)_to_f(0)(1500)_0+gamma_1;f(0)(1500)_to_pi0_0+pi0_0;
-    Value: 1.0
-  - Name: &par4 Phase_J/psi(1S)_to_f(0)(1500)_0+gamma_1;f(0)(1500)_to_pi0_0+pi0_0;
-    Value: 0.0
-  - Name: &par5 MesonRadius_J/psi(1S)
-    Value: 1.0
-    Fix: true
-  - Name: &par6 Position_f(0)(980)
-    Value: 0.99
-  - Name: &par7 Width_f(0)(980)
-    Value: 0.06
-  - Name: &par8 MesonRadius_f(0)(980)
-    Value: 1.0
-    Fix: true
-  - Name: &par9 Position_f(0)(1500)
-    Value: 1.506
-  - Name: &par10 Width_f(0)(1500)
-    Value: 0.112
-  - Name: &par11 MesonRadius_f(0)(1500)
-    Value: 1.0
-    Fix: true
+  - name: &par1 Magnitude_J/psi(1S)_to_f(0)(980)_0+gamma_1;f(0)(980)_to_pi0_0+pi0_0;
+    value: 1.0
+    is_fixed: false
+  - name: &par2 Phase_J/psi(1S)_to_f(0)(980)_0+gamma_1;f(0)(980)_to_pi0_0+pi0_0;
+    value: 0.0
+    is_fixed: false
+  - name: &par3 Magnitude_J/psi(1S)_to_f(0)(1500)_0+gamma_1;f(0)(1500)_to_pi0_0+pi0_0;
+    value: 1.0
+    is_fixed: false
+  - name: &par4 Phase_J/psi(1S)_to_f(0)(1500)_0+gamma_1;f(0)(1500)_to_pi0_0+pi0_0;
+    value: 0.0
+    is_fixed: false
+  - name: &par5 MesonRadius_J/psi(1S)
+    value: 1.0
+    is_fixed: true
+  - name: &par6 Position_f(0)(980)
+    value: 0.99
+    is_fixed: false
+  - name: &par7 Width_f(0)(980)
+    value: 0.06
+    is_fixed: false
+  - name: &par8 MesonRadius_f(0)(980)
+    value: 1.0
+    is_fixed: true
+  - name: &par9 Position_f(0)(1500)
+    value: 1.506
+    is_fixed: false
+  - name: &par10 Width_f(0)(1500)
+    value: 0.112
+    is_fixed: false
+  - name: &par11 MesonRadius_f(0)(1500)
+    value: 1.0
+    is_fixed: true
 
 Intensity:
   Class: StrengthIntensity

--- a/tests/unit/io/expected_recipe.yml
+++ b/tests/unit/io/expected_recipe.yml
@@ -424,23 +424,21 @@ particles:
 
 Dynamics:
   J/psi(1S):
-    Type: NonDynamic
-    FormFactor:
-      Type: BlattWeisskopf
-      MesonRadius: *par5
+    type: NonDynamic
+    form_factor:
+      type: BlattWeisskopf
+      meson_radius: *par5
   f(0)(980):
-    Type: RelativisticBreitWigner
-    PoleParameters:
-      Real: *par6
-      Imaginary: *par7
-    FormFactor:
-      Type: BlattWeisskopf
-      MesonRadius: *par8
+    type: RelativisticBreitWigner
+    pole_position: *par6
+    pole_width: *par7
+    form_factor:
+      type: BlattWeisskopf
+      meson_radius: *par8
   f(0)(1500):
-    Type: RelativisticBreitWigner
-    PoleParameters:
-      Real: *par9
-      Imaginary: *par10
-    FormFactor:
-      Type: BlattWeisskopf
-      MesonRadius: *par11
+    type: RelativisticBreitWigner
+    pole_position: *par9
+    pole_width: *par10
+    form_factor:
+      type: BlattWeisskopf
+      meson_radius: *par11

--- a/tests/unit/io/expected_recipe.yml
+++ b/tests/unit/io/expected_recipe.yml
@@ -40,320 +40,320 @@ parameters:
 
 intensity:
   type: StrengthIntensity
-  Component: incoherent_with_strength
-  Strength: strength_incoherent
-  Intensity:
+  component: incoherent_with_strength
+  strength: strength_incoherent
+  intensity:
     type: NormalizedIntensity
-    Intensity:
+    intensity:
       type: IncoherentIntensity
-      Intensities:
+      intensities:
         - type: CoherentIntensity
-          Component: coherent_J/psi(1S)_-1_to_gamma_-1+pi0_0+pi0_0
-          Amplitudes:
+          component: coherent_J/psi(1S)_-1_to_gamma_-1+pi0_0+pi0_0
+          amplitudes:
             - type: CoefficientAmplitude
-              Component: J/psi(1S)_-1_to_f(0)(980)_0+gamma_-1;f(0)(980)_0_to_pi0_0+pi0_0;
-              Magnitude: *par1
-              Phase: *par2
-              Amplitude:
+              component: J/psi(1S)_-1_to_f(0)(980)_0+gamma_-1;f(0)(980)_0_to_pi0_0+pi0_0;
+              magnitude: *par1
+              phase: *par2
+              amplitude:
                 type: SequentialAmplitude
-                Amplitudes:
+                amplitudes:
                   - type: HelicityDecay
-                    DecayParticle:
-                      Name: J/psi(1S)
-                      Helicity: -1.0
-                    DecayProducts:
-                      - Name: f(0)(980)
-                        FinalState:
+                    decaying_particle:
+                      particle: J/psi(1S)
+                      helicity: -1.0
+                    decay_products:
+                      - particle: f(0)(980)
+                        final_state_ids:
                           - 3
                           - 4
-                        Helicity: 0.0
-                      - Name: gamma
-                        FinalState:
+                        helicity: 0.0
+                      - particle: gamma
+                        final_state_ids:
                           - 2
-                        Helicity: -1.0
+                        helicity: -1.0
                   - type: HelicityDecay
-                    DecayParticle:
-                      Name: f(0)(980)
-                      Helicity: 0.0
-                    DecayProducts:
-                      - Name: pi0
-                        FinalState:
+                    decaying_particle:
+                      particle: f(0)(980)
+                      helicity: 0.0
+                    decay_products:
+                      - particle: pi0
+                        final_state_ids:
                           - 3
-                        Helicity: -0.0
-                      - Name: pi0
-                        FinalState:
+                        helicity: -0.0
+                      - particle: pi0
+                        final_state_ids:
                           - 4
-                        Helicity: -0.0
-                    RecoilSystem:
-                      RecoilFinalState:
+                        helicity: -0.0
+                    recoil_system:
+                      recoil_final_state:
                         - 2
             - type: CoefficientAmplitude
-              Component: J/psi(1S)_-1_to_f(0)(1500)_0+gamma_-1;f(0)(1500)_0_to_pi0_0+pi0_0;
-              Magnitude: *par3
-              Phase: *par4
-              Amplitude:
+              component: J/psi(1S)_-1_to_f(0)(1500)_0+gamma_-1;f(0)(1500)_0_to_pi0_0+pi0_0;
+              magnitude: *par3
+              phase: *par4
+              amplitude:
                 type: SequentialAmplitude
-                Amplitudes:
+                amplitudes:
                   - type: HelicityDecay
-                    DecayParticle:
-                      Name: J/psi(1S)
-                      Helicity: -1.0
-                    DecayProducts:
-                      - Name: f(0)(1500)
-                        FinalState:
+                    decaying_particle:
+                      particle: J/psi(1S)
+                      helicity: -1.0
+                    decay_products:
+                      - particle: f(0)(1500)
+                        final_state_ids:
                           - 3
                           - 4
-                        Helicity: 0.0
-                      - Name: gamma
-                        FinalState:
+                        helicity: 0.0
+                      - particle: gamma
+                        final_state_ids:
                           - 2
-                        Helicity: -1.0
+                        helicity: -1.0
                   - type: HelicityDecay
-                    DecayParticle:
-                      Name: f(0)(1500)
-                      Helicity: 0.0
-                    DecayProducts:
-                      - Name: pi0
-                        FinalState:
+                    decaying_particle:
+                      particle: f(0)(1500)
+                      helicity: 0.0
+                    decay_products:
+                      - particle: pi0
+                        final_state_ids:
                           - 3
-                        Helicity: -0.0
-                      - Name: pi0
-                        FinalState:
+                        helicity: -0.0
+                      - particle: pi0
+                        final_state_ids:
                           - 4
-                        Helicity: -0.0
-                    RecoilSystem:
-                      RecoilFinalState:
-                        - 2
-        - type: CoherentIntensity
-          Component: coherent_J/psi(1S)_1_to_gamma_-1+pi0_0+pi0_0
-          Amplitudes:
-            - type: CoefficientAmplitude
-              Component: J/psi(1S)_1_to_f(0)(980)_0+gamma_-1;f(0)(980)_0_to_pi0_0+pi0_0;
-              Magnitude: *par1
-              Phase: *par2
-              Amplitude:
-                type: SequentialAmplitude
-                Amplitudes:
-                  - type: HelicityDecay
-                    DecayParticle:
-                      Name: J/psi(1S)
-                      Helicity: 1.0
-                    DecayProducts:
-                      - Name: f(0)(980)
-                        FinalState:
-                          - 3
-                          - 4
-                        Helicity: 0.0
-                      - Name: gamma
-                        FinalState:
-                          - 2
-                        Helicity: -1.0
-                  - type: HelicityDecay
-                    DecayParticle:
-                      Name: f(0)(980)
-                      Helicity: 0.0
-                    DecayProducts:
-                      - Name: pi0
-                        FinalState:
-                          - 3
-                        Helicity: -0.0
-                      - Name: pi0
-                        FinalState:
-                          - 4
-                        Helicity: -0.0
-                    RecoilSystem:
-                      RecoilFinalState:
-                        - 2
-            - type: CoefficientAmplitude
-              Component: J/psi(1S)_1_to_f(0)(1500)_0+gamma_-1;f(0)(1500)_0_to_pi0_0+pi0_0;
-              Magnitude: *par3
-              Phase: *par4
-              Amplitude:
-                type: SequentialAmplitude
-                Amplitudes:
-                  - type: HelicityDecay
-                    DecayParticle:
-                      Name: J/psi(1S)
-                      Helicity: 1.0
-                    DecayProducts:
-                      - Name: f(0)(1500)
-                        FinalState:
-                          - 3
-                          - 4
-                        Helicity: 0.0
-                      - Name: gamma
-                        FinalState:
-                          - 2
-                        Helicity: -1.0
-                  - type: HelicityDecay
-                    DecayParticle:
-                      Name: f(0)(1500)
-                      Helicity: 0.0
-                    DecayProducts:
-                      - Name: pi0
-                        FinalState:
-                          - 3
-                        Helicity: -0.0
-                      - Name: pi0
-                        FinalState:
-                          - 4
-                        Helicity: -0.0
-                    RecoilSystem:
-                      RecoilFinalState:
+                        helicity: -0.0
+                    recoil_system:
+                      recoil_final_state:
                         - 2
         - type: CoherentIntensity
-          Component: coherent_J/psi(1S)_-1_to_gamma_1+pi0_0+pi0_0
-          Amplitudes:
+          component: coherent_J/psi(1S)_1_to_gamma_-1+pi0_0+pi0_0
+          amplitudes:
             - type: CoefficientAmplitude
-              Component: J/psi(1S)_-1_to_f(0)(980)_0+gamma_1;f(0)(980)_0_to_pi0_0+pi0_0;
-              Magnitude: *par1
-              Phase: *par2
-              Amplitude:
+              component: J/psi(1S)_1_to_f(0)(980)_0+gamma_-1;f(0)(980)_0_to_pi0_0+pi0_0;
+              magnitude: *par1
+              phase: *par2
+              amplitude:
                 type: SequentialAmplitude
-                Amplitudes:
+                amplitudes:
                   - type: HelicityDecay
-                    DecayParticle:
-                      Name: J/psi(1S)
-                      Helicity: -1.0
-                    DecayProducts:
-                      - Name: f(0)(980)
-                        FinalState:
+                    decaying_particle:
+                      particle: J/psi(1S)
+                      helicity: 1.0
+                    decay_products:
+                      - particle: f(0)(980)
+                        final_state_ids:
                           - 3
                           - 4
-                        Helicity: 0.0
-                      - Name: gamma
-                        FinalState:
+                        helicity: 0.0
+                      - particle: gamma
+                        final_state_ids:
                           - 2
-                        Helicity: 1.0
+                        helicity: -1.0
                   - type: HelicityDecay
-                    DecayParticle:
-                      Name: f(0)(980)
-                      Helicity: 0.0
-                    DecayProducts:
-                      - Name: pi0
-                        FinalState:
+                    decaying_particle:
+                      particle: f(0)(980)
+                      helicity: 0.0
+                    decay_products:
+                      - particle: pi0
+                        final_state_ids:
                           - 3
-                        Helicity: -0.0
-                      - Name: pi0
-                        FinalState:
+                        helicity: -0.0
+                      - particle: pi0
+                        final_state_ids:
                           - 4
-                        Helicity: -0.0
-                    RecoilSystem:
-                      RecoilFinalState:
+                        helicity: -0.0
+                    recoil_system:
+                      recoil_final_state:
                         - 2
             - type: CoefficientAmplitude
-              Component: J/psi(1S)_-1_to_f(0)(1500)_0+gamma_1;f(0)(1500)_0_to_pi0_0+pi0_0;
-              Magnitude: *par3
-              Phase: *par4
-              Amplitude:
+              component: J/psi(1S)_1_to_f(0)(1500)_0+gamma_-1;f(0)(1500)_0_to_pi0_0+pi0_0;
+              magnitude: *par3
+              phase: *par4
+              amplitude:
                 type: SequentialAmplitude
-                Amplitudes:
+                amplitudes:
                   - type: HelicityDecay
-                    DecayParticle:
-                      Name: J/psi(1S)
-                      Helicity: -1.0
-                    DecayProducts:
-                      - Name: f(0)(1500)
-                        FinalState:
+                    decaying_particle:
+                      particle: J/psi(1S)
+                      helicity: 1.0
+                    decay_products:
+                      - particle: f(0)(1500)
+                        final_state_ids:
                           - 3
                           - 4
-                        Helicity: 0.0
-                      - Name: gamma
-                        FinalState:
+                        helicity: 0.0
+                      - particle: gamma
+                        final_state_ids:
                           - 2
-                        Helicity: 1.0
+                        helicity: -1.0
                   - type: HelicityDecay
-                    DecayParticle:
-                      Name: f(0)(1500)
-                      Helicity: 0.0
-                    DecayProducts:
-                      - Name: pi0
-                        FinalState:
+                    decaying_particle:
+                      particle: f(0)(1500)
+                      helicity: 0.0
+                    decay_products:
+                      - particle: pi0
+                        final_state_ids:
                           - 3
-                        Helicity: -0.0
-                      - Name: pi0
-                        FinalState:
+                        helicity: -0.0
+                      - particle: pi0
+                        final_state_ids:
                           - 4
-                        Helicity: -0.0
-                    RecoilSystem:
-                      RecoilFinalState:
+                        helicity: -0.0
+                    recoil_system:
+                      recoil_final_state:
                         - 2
         - type: CoherentIntensity
-          Component: coherent_J/psi(1S)_1_to_gamma_1+pi0_0+pi0_0
-          Amplitudes:
+          component: coherent_J/psi(1S)_-1_to_gamma_1+pi0_0+pi0_0
+          amplitudes:
             - type: CoefficientAmplitude
-              Component: J/psi(1S)_1_to_f(0)(980)_0+gamma_1;f(0)(980)_0_to_pi0_0+pi0_0;
-              Magnitude: *par1
-              Phase: *par2
-              Amplitude:
+              component: J/psi(1S)_-1_to_f(0)(980)_0+gamma_1;f(0)(980)_0_to_pi0_0+pi0_0;
+              magnitude: *par1
+              phase: *par2
+              amplitude:
                 type: SequentialAmplitude
-                Amplitudes:
+                amplitudes:
                   - type: HelicityDecay
-                    DecayParticle:
-                      Name: J/psi(1S)
-                      Helicity: 1.0
-                    DecayProducts:
-                      - Name: f(0)(980)
-                        FinalState:
+                    decaying_particle:
+                      particle: J/psi(1S)
+                      helicity: -1.0
+                    decay_products:
+                      - particle: f(0)(980)
+                        final_state_ids:
                           - 3
                           - 4
-                        Helicity: 0.0
-                      - Name: gamma
-                        FinalState:
+                        helicity: 0.0
+                      - particle: gamma
+                        final_state_ids:
                           - 2
-                        Helicity: 1.0
+                        helicity: 1.0
                   - type: HelicityDecay
-                    DecayParticle:
-                      Name: f(0)(980)
-                      Helicity: 0.0
-                    DecayProducts:
-                      - Name: pi0
-                        FinalState:
+                    decaying_particle:
+                      particle: f(0)(980)
+                      helicity: 0.0
+                    decay_products:
+                      - particle: pi0
+                        final_state_ids:
                           - 3
-                        Helicity: -0.0
-                      - Name: pi0
-                        FinalState:
+                        helicity: -0.0
+                      - particle: pi0
+                        final_state_ids:
                           - 4
-                        Helicity: -0.0
-                    RecoilSystem:
-                      RecoilFinalState:
+                        helicity: -0.0
+                    recoil_system:
+                      recoil_final_state:
                         - 2
             - type: CoefficientAmplitude
-              Component: J/psi(1S)_1_to_f(0)(1500)_0+gamma_1;f(0)(1500)_0_to_pi0_0+pi0_0;
-              Magnitude: *par3
-              Phase: *par4
-              Amplitude:
+              component: J/psi(1S)_-1_to_f(0)(1500)_0+gamma_1;f(0)(1500)_0_to_pi0_0+pi0_0;
+              magnitude: *par3
+              phase: *par4
+              amplitude:
                 type: SequentialAmplitude
-                Amplitudes:
+                amplitudes:
                   - type: HelicityDecay
-                    DecayParticle:
-                      Name: J/psi(1S)
-                      Helicity: 1.0
-                    DecayProducts:
-                      - Name: f(0)(1500)
-                        FinalState:
+                    decaying_particle:
+                      particle: J/psi(1S)
+                      helicity: -1.0
+                    decay_products:
+                      - particle: f(0)(1500)
+                        final_state_ids:
                           - 3
                           - 4
-                        Helicity: 0.0
-                      - Name: gamma
-                        FinalState:
+                        helicity: 0.0
+                      - particle: gamma
+                        final_state_ids:
                           - 2
-                        Helicity: 1.0
+                        helicity: 1.0
                   - type: HelicityDecay
-                    DecayParticle:
-                      Name: f(0)(1500)
-                      Helicity: 0.0
-                    DecayProducts:
-                      - Name: pi0
-                        FinalState:
+                    decaying_particle:
+                      particle: f(0)(1500)
+                      helicity: 0.0
+                    decay_products:
+                      - particle: pi0
+                        final_state_ids:
                           - 3
-                        Helicity: -0.0
-                      - Name: pi0
-                        FinalState:
+                        helicity: -0.0
+                      - particle: pi0
+                        final_state_ids:
                           - 4
-                        Helicity: -0.0
-                    RecoilSystem:
-                      RecoilFinalState:
+                        helicity: -0.0
+                    recoil_system:
+                      recoil_final_state:
+                        - 2
+        - type: CoherentIntensity
+          component: coherent_J/psi(1S)_1_to_gamma_1+pi0_0+pi0_0
+          amplitudes:
+            - type: CoefficientAmplitude
+              component: J/psi(1S)_1_to_f(0)(980)_0+gamma_1;f(0)(980)_0_to_pi0_0+pi0_0;
+              magnitude: *par1
+              phase: *par2
+              amplitude:
+                type: SequentialAmplitude
+                amplitudes:
+                  - type: HelicityDecay
+                    decaying_particle:
+                      particle: J/psi(1S)
+                      helicity: 1.0
+                    decay_products:
+                      - particle: f(0)(980)
+                        final_state_ids:
+                          - 3
+                          - 4
+                        helicity: 0.0
+                      - particle: gamma
+                        final_state_ids:
+                          - 2
+                        helicity: 1.0
+                  - type: HelicityDecay
+                    decaying_particle:
+                      particle: f(0)(980)
+                      helicity: 0.0
+                    decay_products:
+                      - particle: pi0
+                        final_state_ids:
+                          - 3
+                        helicity: -0.0
+                      - particle: pi0
+                        final_state_ids:
+                          - 4
+                        helicity: -0.0
+                    recoil_system:
+                      recoil_final_state:
+                        - 2
+            - type: CoefficientAmplitude
+              component: J/psi(1S)_1_to_f(0)(1500)_0+gamma_1;f(0)(1500)_0_to_pi0_0+pi0_0;
+              magnitude: *par3
+              phase: *par4
+              amplitude:
+                type: SequentialAmplitude
+                amplitudes:
+                  - type: HelicityDecay
+                    decaying_particle:
+                      particle: J/psi(1S)
+                      helicity: 1.0
+                    decay_products:
+                      - particle: f(0)(1500)
+                        final_state_ids:
+                          - 3
+                          - 4
+                        helicity: 0.0
+                      - particle: gamma
+                        final_state_ids:
+                          - 2
+                        helicity: 1.0
+                  - type: HelicityDecay
+                    decaying_particle:
+                      particle: f(0)(1500)
+                      helicity: 0.0
+                    decay_products:
+                      - particle: pi0
+                        final_state_ids:
+                          - 3
+                        helicity: -0.0
+                      - particle: pi0
+                        final_state_ids:
+                          - 4
+                        helicity: -0.0
+                    recoil_system:
+                      recoil_final_state:
                         - 2
 
 particles:

--- a/tests/unit/io/expected_recipe.yml
+++ b/tests/unit/io/expected_recipe.yml
@@ -1,15 +1,11 @@
 kinematics:
-  Type: Helicity
-  InitialState:
-    - Particle: J/psi(1S)
-      ID: 0
-  FinalState:
-    - Particle: gamma
-      ID: 2
-    - Particle: pi0
-      ID: 3
-    - Particle: pi0
-      ID: 4
+  type: Helicity
+  initial_state:
+    0: J/psi(1S)
+  final_state:
+    2: gamma
+    3: pi0
+    4: pi0
 
 parameters:
   - name: &par1 Magnitude_J/psi(1S)_to_f(0)(980)_0+gamma_1;f(0)(980)_to_pi0_0+pi0_0;

--- a/tests/unit/io/test_dict.py
+++ b/tests/unit/io/test_dict.py
@@ -113,11 +113,11 @@ class TestHelicityFormalism:
 
     def test_kinematics_section(self, imported_dict):
         kinematics = imported_dict["kinematics"]
-        initial_state = kinematics["InitialState"]
-        final_state = kinematics["FinalState"]
-        assert kinematics["Type"] == "Helicity"
+        initial_state = kinematics["initial_state"]
+        final_state = kinematics["final_state"]
+        assert kinematics["type"] == "Helicity"
         assert len(initial_state) == 1
-        assert initial_state[0]["Particle"] == "J/psi(1S)"
+        assert initial_state[0] == "J/psi(1S)"
         assert len(final_state) == 3
 
     def test_parameter_section(self, imported_dict):

--- a/tests/unit/io/test_dict.py
+++ b/tests/unit/io/test_dict.py
@@ -138,7 +138,7 @@ class TestHelicityFormalism:
                     return par
             raise LookupError(f'Could not find parameter  "{parameter_name}"')
 
-        dynamics = imported_dict["Dynamics"]
+        dynamics = imported_dict["dynamics"]
         assert len(dynamics) == 3
 
         j_psi = dynamics["J/psi(1S)"]
@@ -168,7 +168,7 @@ class TestHelicityFormalism:
 
     @pytest.mark.parametrize(
         "section",
-        ["Dynamics", "Kinematics", "parameters", "particles"],
+        ["dynamics", "Kinematics", "parameters", "particles"],
     )
     def test_expected_recipe_shape(
         self, imported_dict, expected_dict, section

--- a/tests/unit/io/test_dict.py
+++ b/tests/unit/io/test_dict.py
@@ -162,7 +162,7 @@ class TestHelicityFormalism:
             )
 
     def test_intensity_section(self, imported_dict):
-        intensity = imported_dict["Intensity"]
+        intensity = imported_dict["intensity"]
         assert intensity["Class"] == "IncoherentIntensity"
         assert len(intensity["Intensities"]) == 4
 
@@ -231,7 +231,7 @@ class TestCanonicalFormalism:
             assert "value" in parameter
 
     def test_clebsch_gordan(self, imported_dict):
-        incoherent_intensity = imported_dict["Intensity"]
+        incoherent_intensity = imported_dict["intensity"]
         coherent_intensity = incoherent_intensity["Intensities"][0]
         coefficient_amplitude = coherent_intensity["Amplitudes"][0]
         sequential_amplitude = coefficient_amplitude["Amplitude"]

--- a/tests/unit/io/test_dict.py
+++ b/tests/unit/io/test_dict.py
@@ -142,21 +142,22 @@ class TestHelicityFormalism:
         assert len(dynamics) == 3
 
         j_psi = dynamics["J/psi(1S)"]
-        assert j_psi["Type"] == "NonDynamic"
-        assert j_psi["FormFactor"]["Type"] == "BlattWeisskopf"
+        assert j_psi["type"] == "NonDynamic"
+        assert j_psi["form_factor"]["type"] == "BlattWeisskopf"
         assert (
-            get_parameter(j_psi["FormFactor"]["MesonRadius"])["value"] == 1.0
+            get_parameter(j_psi["form_factor"]["meson_radius"])["value"] == 1.0
         )
 
         f0_980 = dynamics.get("f(0)(980)", None)
         if f0_980:
-            assert f0_980["Type"] == "RelativisticBreitWigner"
-            assert f0_980["FormFactor"]["Type"] == "BlattWeisskopf"
+            assert f0_980["type"] == "RelativisticBreitWigner"
+            assert f0_980["form_factor"]["type"] == "BlattWeisskopf"
             assert (
-                f0_980["FormFactor"]["MesonRadius"] == "MesonRadius_f(0)(980)"
+                f0_980["form_factor"]["meson_radius"]
+                == "MesonRadius_f(0)(980)"
             )
             assert (
-                get_parameter(f0_980["FormFactor"]["MesonRadius"])["value"]
+                get_parameter(f0_980["form_factor"]["meson_radius"])["value"]
                 == 1.0
             )
 

--- a/tests/unit/io/test_dict.py
+++ b/tests/unit/io/test_dict.py
@@ -124,16 +124,16 @@ class TestHelicityFormalism:
         parameter_list = imported_dict["Parameters"]
         assert len(parameter_list) == 11
         for parameter in parameter_list:
-            assert "Name" in parameter
-            assert "Value" in parameter
-            assert parameter.get("Fix", True)
+            assert "name" in parameter
+            assert "value" in parameter
+            assert parameter.get("fix", True)
 
     def test_dynamics_section(self, imported_dict):
         parameter_list: list = imported_dict["Parameters"]
 
         def get_parameter(parameter_name: str) -> dict:
             for par in parameter_list:
-                name = par["Name"]
+                name = par["name"]
                 if name == parameter_name:
                     return par
             raise LookupError(f'Could not find parameter  "{parameter_name}"')
@@ -145,7 +145,7 @@ class TestHelicityFormalism:
         assert j_psi["Type"] == "NonDynamic"
         assert j_psi["FormFactor"]["Type"] == "BlattWeisskopf"
         assert (
-            get_parameter(j_psi["FormFactor"]["MesonRadius"])["Value"] == 1.0
+            get_parameter(j_psi["FormFactor"]["MesonRadius"])["value"] == 1.0
         )
 
         f0_980 = dynamics.get("f(0)(980)", None)
@@ -156,7 +156,7 @@ class TestHelicityFormalism:
                 f0_980["FormFactor"]["MesonRadius"] == "MesonRadius_f(0)(980)"
             )
             assert (
-                get_parameter(f0_980["FormFactor"]["MesonRadius"])["Value"]
+                get_parameter(f0_980["FormFactor"]["MesonRadius"])["value"]
                 == 1.0
             )
 
@@ -172,9 +172,6 @@ class TestHelicityFormalism:
     def test_expected_recipe_shape(
         self, imported_dict, expected_dict, section
     ):
-        name_tag = "Name"
-        if section == "particles":
-            name_tag = "name"
         expected_section = equalize_dict(expected_dict[section])
         imported_section = equalize_dict(imported_dict[section])
         if isinstance(expected_section, dict):
@@ -182,12 +179,8 @@ class TestHelicityFormalism:
             imported_items = list(imported_section.values())
             expected_items = list(expected_section.values())
         else:
-            expected_items = sorted(
-                expected_section, key=lambda p: p[name_tag]
-            )
-            imported_items = sorted(
-                imported_section, key=lambda p: p[name_tag]
-            )
+            expected_items = sorted(expected_section, key=lambda p: p["name"])
+            imported_items = sorted(imported_section, key=lambda p: p["name"])
         assert len(imported_items) == len(expected_items)
         for imported, expected in zip(imported_items, expected_items):
             assert imported == expected
@@ -233,8 +226,8 @@ class TestCanonicalFormalism:
         parameter_list = imported_dict["Parameters"]
         assert len(parameter_list) == 11
         for parameter in parameter_list:
-            assert "Name" in parameter
-            assert "Value" in parameter
+            assert "name" in parameter
+            assert "value" in parameter
 
     def test_clebsch_gordan(self, imported_dict):
         incoherent_intensity = imported_dict["Intensity"]

--- a/tests/unit/io/test_dict.py
+++ b/tests/unit/io/test_dict.py
@@ -164,7 +164,7 @@ class TestHelicityFormalism:
     def test_intensity_section(self, imported_dict):
         intensity = imported_dict["intensity"]
         assert intensity["type"] == "IncoherentIntensity"
-        assert len(intensity["Intensities"]) == 4
+        assert len(intensity["intensities"]) == 4
 
     @pytest.mark.parametrize(
         "section",
@@ -232,14 +232,12 @@ class TestCanonicalFormalism:
 
     def test_clebsch_gordan(self, imported_dict):
         incoherent_intensity = imported_dict["intensity"]
-        coherent_intensity = incoherent_intensity["Intensities"][0]
-        coefficient_amplitude = coherent_intensity["Amplitudes"][0]
-        sequential_amplitude = coefficient_amplitude["Amplitude"]
-        helicity_decay = sequential_amplitude["Amplitudes"][0]
-        canonical_sum = helicity_decay["Canonical"]
-        assert list(canonical_sum) == ["LS", "s2s3"]
-        s2s3 = canonical_sum["s2s3"]["ClebschGordan"]
-        assert list(s2s3) == ["J", "M", "j1", "m1", "j2", "m2"]
+        coherent_intensity = incoherent_intensity["intensities"][0]
+        coefficient_amplitude = coherent_intensity["amplitudes"][0]
+        sequential_amplitude = coefficient_amplitude["amplitude"]
+        canonical_decay = sequential_amplitude["amplitudes"][0]
+        s2s3 = canonical_decay["s2s3"]
+        assert list(s2s3) == ["J", "M", "j_1", "m_1", "j_2", "m_2"]
         assert s2s3["J"] == 1.0
 
 

--- a/tests/unit/io/test_dict.py
+++ b/tests/unit/io/test_dict.py
@@ -121,7 +121,7 @@ class TestHelicityFormalism:
         assert len(final_state) == 3
 
     def test_parameter_section(self, imported_dict):
-        parameter_list = imported_dict["Parameters"]
+        parameter_list = imported_dict["parameters"]
         assert len(parameter_list) == 11
         for parameter in parameter_list:
             assert "name" in parameter
@@ -129,7 +129,7 @@ class TestHelicityFormalism:
             assert parameter.get("fix", True)
 
     def test_dynamics_section(self, imported_dict):
-        parameter_list: list = imported_dict["Parameters"]
+        parameter_list: list = imported_dict["parameters"]
 
         def get_parameter(parameter_name: str) -> dict:
             for par in parameter_list:
@@ -167,7 +167,7 @@ class TestHelicityFormalism:
 
     @pytest.mark.parametrize(
         "section",
-        ["Dynamics", "Kinematics", "Parameters", "particles"],
+        ["Dynamics", "Kinematics", "parameters", "particles"],
     )
     def test_expected_recipe_shape(
         self, imported_dict, expected_dict, section
@@ -223,7 +223,7 @@ class TestCanonicalFormalism:
         assert pi0["isospin"]["magnitude"] == 1
 
     def test_parameter_section(self, imported_dict):
-        parameter_list = imported_dict["Parameters"]
+        parameter_list = imported_dict["parameters"]
         assert len(parameter_list) == 11
         for parameter in parameter_list:
             assert "name" in parameter

--- a/tests/unit/io/test_dict.py
+++ b/tests/unit/io/test_dict.py
@@ -112,7 +112,7 @@ class TestHelicityFormalism:
         assert pi0["isospin"]["projection"] == 0
 
     def test_kinematics_section(self, imported_dict):
-        kinematics = imported_dict["Kinematics"]
+        kinematics = imported_dict["kinematics"]
         initial_state = kinematics["InitialState"]
         final_state = kinematics["FinalState"]
         assert kinematics["Type"] == "Helicity"
@@ -168,7 +168,7 @@ class TestHelicityFormalism:
 
     @pytest.mark.parametrize(
         "section",
-        ["dynamics", "Kinematics", "parameters", "particles"],
+        ["dynamics", "kinematics", "parameters", "particles"],
     )
     def test_expected_recipe_shape(
         self, imported_dict, expected_dict, section

--- a/tests/unit/io/test_dict.py
+++ b/tests/unit/io/test_dict.py
@@ -163,7 +163,7 @@ class TestHelicityFormalism:
 
     def test_intensity_section(self, imported_dict):
         intensity = imported_dict["intensity"]
-        assert intensity["Class"] == "IncoherentIntensity"
+        assert intensity["type"] == "IncoherentIntensity"
         assert len(intensity["Intensities"]) == 4
 
     @pytest.mark.parametrize(

--- a/tests/unit/io/test_dict.py
+++ b/tests/unit/io/test_dict.py
@@ -96,7 +96,7 @@ class TestHelicityFormalism:
         assert len(jpsi_to_gamma_pi_pi_helicity_amplitude_model.dynamics) == 3
 
     def test_particle_section(self, imported_dict):
-        particle_list = imported_dict.get("ParticleList", imported_dict)
+        particle_list = imported_dict.get("particles", imported_dict)
         gamma = next(p for p in particle_list if p["name"] == "gamma")
         assert gamma["pid"] == 22
         assert gamma["mass"] == 0.0
@@ -167,13 +167,13 @@ class TestHelicityFormalism:
 
     @pytest.mark.parametrize(
         "section",
-        ["Dynamics", "Kinematics", "Parameters", "ParticleList"],
+        ["Dynamics", "Kinematics", "Parameters", "particles"],
     )
     def test_expected_recipe_shape(
         self, imported_dict, expected_dict, section
     ):
         name_tag = "Name"
-        if section == "ParticleList":
+        if section == "particles":
             name_tag = "name"
         expected_section = equalize_dict(expected_dict[section])
         imported_section = equalize_dict(imported_dict[section])
@@ -219,7 +219,7 @@ class TestCanonicalFormalism:
             )
 
     def test_particle_section(self, imported_dict):
-        particle_list = imported_dict["ParticleList"]
+        particle_list = imported_dict["particles"]
         gamma = next(p for p in particle_list if p["name"] == "gamma")
         assert gamma["pid"] == 22
         assert gamma["mass"] == 0.0

--- a/tests/unit/io/test_dict.py
+++ b/tests/unit/io/test_dict.py
@@ -97,21 +97,19 @@ class TestHelicityFormalism:
 
     def test_particle_section(self, imported_dict):
         particle_list = imported_dict.get("ParticleList", imported_dict)
-        gamma = particle_list["gamma"]
-        assert gamma["PID"] == 22
-        assert gamma["Mass"] == 0.0
-        gamma_qns = gamma["QuantumNumbers"]
-        assert gamma_qns["Spin"] == 1
-        assert gamma_qns["Charge"] == 0
-        assert gamma_qns["Parity"] == -1
-        assert gamma_qns["CParity"] == -1
+        gamma = next(p for p in particle_list if p["name"] == "gamma")
+        assert gamma["pid"] == 22
+        assert gamma["mass"] == 0.0
+        assert gamma["spin"] == 1.0
+        assert gamma["parity"]["value"] == -1
+        assert gamma["c_parity"]["value"] == -1
 
-        f0_980 = particle_list["f(0)(980)"]
-        assert f0_980["Width"] == 0.06
+        f0_980 = next(p for p in particle_list if p["name"] == "f(0)(980)")
+        assert f0_980["width"] == 0.06
 
-        pi0_qns = particle_list["pi0"]["QuantumNumbers"]
-        assert pi0_qns["IsoSpin"]["Value"] == 1
-        assert pi0_qns["IsoSpin"]["Projection"] == 0
+        pi0 = next(p for p in particle_list if p["name"] == "pi0")
+        assert pi0["isospin"]["magnitude"] == 1
+        assert pi0["isospin"]["projection"] == 0
 
     def test_kinematics_section(self, imported_dict):
         kinematics = imported_dict["Kinematics"]
@@ -174,6 +172,9 @@ class TestHelicityFormalism:
     def test_expected_recipe_shape(
         self, imported_dict, expected_dict, section
     ):
+        name_tag = "Name"
+        if section == "ParticleList":
+            name_tag = "name"
         expected_section = equalize_dict(expected_dict[section])
         imported_section = equalize_dict(imported_dict[section])
         if isinstance(expected_section, dict):
@@ -181,8 +182,12 @@ class TestHelicityFormalism:
             imported_items = list(imported_section.values())
             expected_items = list(expected_section.values())
         else:
-            expected_items = sorted(expected_section, key=lambda p: p["Name"])
-            imported_items = sorted(imported_section, key=lambda p: p["Name"])
+            expected_items = sorted(
+                expected_section, key=lambda p: p[name_tag]
+            )
+            imported_items = sorted(
+                imported_section, key=lambda p: p[name_tag]
+            )
         assert len(imported_items) == len(expected_items)
         for imported, expected in zip(imported_items, expected_items):
             assert imported == expected
@@ -215,15 +220,14 @@ class TestCanonicalFormalism:
 
     def test_particle_section(self, imported_dict):
         particle_list = imported_dict["ParticleList"]
-        gamma = particle_list["gamma"]
-        assert gamma["PID"] == 22
-        assert gamma["Mass"] == 0.0
-        gamma_qns = gamma["QuantumNumbers"]
-        assert gamma_qns["CParity"] == -1
-        f0_980 = particle_list["f(0)(980)"]
-        assert f0_980["Width"] == 0.06
-        pi0_qns = particle_list["pi0"]["QuantumNumbers"]
-        assert pi0_qns["IsoSpin"]["Value"] == 1
+        gamma = next(p for p in particle_list if p["name"] == "gamma")
+        assert gamma["pid"] == 22
+        assert gamma["mass"] == 0.0
+        assert gamma["c_parity"]["value"] == -1
+        f0_980 = next(p for p in particle_list if p["name"] == "f(0)(980)")
+        assert f0_980["width"] == 0.06
+        pi0 = next(p for p in particle_list if p["name"] == "pi0")
+        assert pi0["isospin"]["magnitude"] == 1
 
     def test_parameter_section(self, imported_dict):
         parameter_list = imported_dict["Parameters"]

--- a/tests/unit/io/test_dict.py
+++ b/tests/unit/io/test_dict.py
@@ -126,7 +126,7 @@ class TestHelicityFormalism:
         for parameter in parameter_list:
             assert "name" in parameter
             assert "value" in parameter
-            assert parameter.get("fix", True)
+            assert isinstance(parameter["fix"], bool)
 
     def test_dynamics_section(self, imported_dict):
         parameter_list: list = imported_dict["parameters"]

--- a/tests/unit/test_io.py
+++ b/tests/unit/test_io.py
@@ -24,6 +24,10 @@ def test_serialization(
     io.write(exported, filename)
     asdict = io.asdict(exported)
     imported = io.fromdict(asdict)
+    io.write(
+        imported,
+        output_dir + f"test_write_read_{formalism}.imported.{file_extension}",
+    )
     assert isinstance(imported, AmplitudeModel)
     assert exported.particles == imported.particles
     assert exported.parameters == imported.parameters

--- a/tests/unit/test_io.py
+++ b/tests/unit/test_io.py
@@ -24,10 +24,6 @@ def test_serialization(
     io.write(exported, filename)
     asdict = io.asdict(exported)
     imported = io.fromdict(asdict)
-    io.write(
-        imported,
-        output_dir + f"test_write_read_{formalism}.imported.{file_extension}",
-    )
     assert isinstance(imported, AmplitudeModel)
     assert exported.particles == imported.particles
     assert exported.parameters == imported.parameters


### PR DESCRIPTION
The `io` module now uses `attr.asdict` where possible. This has a few consequences:
1. classes that are constructed with `attr.s` can be refactored without having to worry about the `io` module.
2. the amplitude model file changes along with the structure of the data classes
3. the code of the `io` module becomes simpler. This is a step towards removing this module (see e.g. #400)

## To-do list

- [x] `ParticleCollection`
- [x] `FitParameters`
- [x] `Dynamics`
- [x] `IntensityNode`
- [x] `Kinematics` (not an `attr.s` class)