### PR TITLE
ci: pin Pyright to version 1.1.99

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,8 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r reqs/3.7/requirements-sty.txt
           pip install .
-          sudo npm install -g cspell pyright
+          sudo npm install -g cspell pyright@1.1.99
+        # https://github.com/ComPWA/expertsystem/issues/437
       - name: Perform style checks
         run: pre-commit run -a
       - name: Check spelling


### PR DESCRIPTION
Pyright seems to [result in false-positives](https://github.com/ComPWA/expertsystem/runs/1680505840), so we have to temporarily pin `pyright` to 1.1.99. Keep an eye on the Pyright [issues](https://github.com/microsoft/pyright/issues) and [releases](https://github.com/microsoft/pyright/releases).