### PR TITLE
docs: remove module visualization

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -78,7 +78,6 @@
         "mypy",
         "nishijima",
         "pycompwa",
-        "pydeps",
         "pydocstyle",
         "pydot",
         "pylint",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -228,24 +228,3 @@ thebe_config = {
     "repository_url": html_theme_options["repository_url"],
     "repository_branch": html_theme_options["repository_branch"],
 }
-
-# -- Visualize dependencies ---------------------------------------------------
-if jupyter_execute_notebooks != "off":
-    print("Generating module dependency tree...")
-    subprocess.call(
-        " ".join(
-            [
-                "HOME=.",  # in case of calling through tox
-                "pydeps",
-                f"../src/{package}",
-                "-o module_structure.svg",
-                "--exclude *._*",  # hide private modules
-                "--max-bacon=1",  # hide external dependencies
-                "--noshow",
-            ]
-        ),
-        shell=True,
-    )
-    if os.path.exists("module_structure.svg"):
-        with open(f"api/{package}.rst", "a") as stream:
-            stream.write("\n.. image:: /module_structure.svg")

--- a/reqs/3.6/requirements-doc.txt
+++ b/reqs/3.6/requirements-doc.txt
@@ -66,7 +66,6 @@ prompt-toolkit==3.0.10
 ptyprocess==0.7.0
 pycparser==2.20
 pydata-sphinx-theme==0.4.1
-pydeps==1.9.13
 pygments==2.7.4
 pyparsing==2.4.7
 pyrsistent==0.17.3
@@ -97,7 +96,6 @@ sphinxcontrib-qthelp==1.0.3
 sphinxcontrib-serializinghtml==1.1.4
 sphobjinv==2.0.1
 sqlalchemy==1.3.22
-stdlib-list==0.8.0
 terminado==0.9.2
 testpath==0.4.4
 tornado==6.1

--- a/reqs/3.7/requirements-doc.txt
+++ b/reqs/3.7/requirements-doc.txt
@@ -65,7 +65,6 @@ prompt-toolkit==3.0.10
 ptyprocess==0.7.0
 pycparser==2.20
 pydata-sphinx-theme==0.4.1
-pydeps==1.9.13
 pygments==2.7.4
 pyparsing==2.4.7
 pyrsistent==0.17.3
@@ -96,7 +95,6 @@ sphinxcontrib-qthelp==1.0.3
 sphinxcontrib-serializinghtml==1.1.4
 sphobjinv==2.0.1
 sqlalchemy==1.3.22
-stdlib-list==0.8.0
 terminado==0.9.2
 testpath==0.4.4
 tornado==6.1

--- a/reqs/3.8/requirements-doc.txt
+++ b/reqs/3.8/requirements-doc.txt
@@ -65,7 +65,6 @@ prompt-toolkit==3.0.10
 ptyprocess==0.7.0
 pycparser==2.20
 pydata-sphinx-theme==0.4.1
-pydeps==1.9.13
 pygments==2.7.4
 pyparsing==2.4.7
 pyrsistent==0.17.3
@@ -96,7 +95,6 @@ sphinxcontrib-qthelp==1.0.3
 sphinxcontrib-serializinghtml==1.1.4
 sphobjinv==2.0.1
 sqlalchemy==1.3.22
-stdlib-list==0.8.0
 terminado==0.9.2
 testpath==0.4.4
 tornado==6.1

--- a/reqs/3.9/requirements-doc.txt
+++ b/reqs/3.9/requirements-doc.txt
@@ -65,7 +65,6 @@ prompt-toolkit==3.0.10
 ptyprocess==0.7.0
 pycparser==2.20
 pydata-sphinx-theme==0.4.1
-pydeps==1.9.13
 pygments==2.7.4
 pyparsing==2.4.7
 pyrsistent==0.17.3
@@ -96,7 +95,6 @@ sphinxcontrib-qthelp==1.0.3
 sphinxcontrib-serializinghtml==1.1.4
 sphobjinv==2.0.1
 sqlalchemy==1.3.22
-stdlib-list==0.8.0
 terminado==0.9.2
 testpath==0.4.4
 tornado==6.1

--- a/reqs/requirements-dev.in
+++ b/reqs/requirements-dev.in
@@ -8,5 +8,6 @@ jupyterlab
 jupyterlab-code-formatter
 labels
 pip-tools
+pydeps
 sphinx-autobuild
 tox >= 1.9  # for skip_install, use_develop

--- a/reqs/requirements-doc.in
+++ b/reqs/requirements-doc.in
@@ -5,7 +5,6 @@ graphviz
 ipywidgets
 jupyter
 myst-nb < 0.11  # myst_admonition_enable
-pydeps
 Sphinx >= 3
 sphinx-book-theme
 sphinx-copybutton

--- a/tox.ini
+++ b/tox.ini
@@ -81,6 +81,20 @@ allowlist_externals =
 commands =
     make ignore-warnings=1 linkcheck  # for margin directive
 
+[testenv:pydeps]
+description =
+    Visualize module dependencies
+changedir = src
+setenv =
+    HOME = "."
+allowlist_externals = pydeps
+commands =
+    pydeps expertsystem \
+        -o module_structure.svg \
+        --exclude *._* \
+        --max-bacon=1 \
+        --noshow
+
 [testenv:sty]
 description =
     Perform all linting, formatting, and spelling checks


### PR DESCRIPTION
`pydeps` slows down RTD and the CI, especially when more dependencies are added. Compare:
- 1:43 min https://github.com/ComPWA/expertsystem/runs/1722740664 (58700db on master)
- 1:15 min https://github.com/ComPWA/expertsystem/runs/1722788674 (7e99d87 on this branch)