### PR TITLE
ci: add GitHub Actions workflow dispatch

### DIFF
--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -7,6 +7,7 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
+  workflow_dispatch:
 
 jobs:
   check_links:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+  workflow_dispatch:
 
 jobs:
   update_release_draft:

--- a/.github/workflows/requirements-cron.yml
+++ b/.github/workflows/requirements-cron.yml
@@ -5,6 +5,7 @@ name: Requirements (scheduled)
 on:
   schedule:
     - cron: "0 2 * * 1"
+  workflow_dispatch:
 
 jobs:
   upgrade:


### PR DESCRIPTION
Allows to run linkcheck, the release drafter and the requirements updater manually, see [here](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow).