### PR TITLE
refactor: raise violated rules as exception

### DIFF
--- a/docs/usage/workflow.ipynb
+++ b/docs/usage/workflow.ipynb
@@ -202,7 +202,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The {meth}`~.StateTransitionManager.find_solutions` method returns a {class}`~.Result` object from which you can extract the {attr}`~.Result.solutions` and any {attr}`~.Result.violated_edge_rules` in case solutions were found. Now, you can use {meth}`~.Result.get_intermediate_particles` to print the names of the intermediate states that the {class}`~.StateTransitionManager` found:"
+    "The {meth}`~.StateTransitionManager.find_solutions` method returns a {class}`~.Result` object from which you can extract the {attr}`~.Result.solutions` and any {attr}`~.ExecutionInfo.violated_edge_rules` in case solutions were found. Now, you can use {meth}`~.Result.get_intermediate_particles` to print the names of the intermediate states that the {class}`~.StateTransitionManager` found:"
    ]
   },
   {

--- a/docs/usage/workflow.ipynb
+++ b/docs/usage/workflow.ipynb
@@ -202,7 +202,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The {meth}`~.StateTransitionManager.find_solutions` method returns a {class}`~.Result` object from which you can extract the {attr}`~.Result.solutions` and any {attr}`~.ExecutionInfo.violated_edge_rules` in case solutions were found. Now, you can use {meth}`~.Result.get_intermediate_particles` to print the names of the intermediate states that the {class}`~.StateTransitionManager` found:"
+    "The {meth}`~.StateTransitionManager.find_solutions` method returns a {class}`~.Result` object from which you can extract the {attr}`~.Result.solutions`. Now, you can use {meth}`~.Result.get_intermediate_particles` to print the names of the intermediate states that the {class}`~.StateTransitionManager` found:"
    ]
   },
   {

--- a/src/expertsystem/reaction/solving.py
+++ b/src/expertsystem/reaction/solving.py
@@ -189,7 +189,10 @@ class QNResult:
             self.violated_node_rules or self.violated_edge_rules
         ):
             raise ValueError(
-                "Invalid Result! Found solutions, but also violated rules."
+                f"Invalid {self.__class__.__name__}!"
+                f" Found {len(self.solutions)} solutions, but also violated rules.",
+                self.violated_node_rules,
+                self.violated_edge_rules,
             )
 
     def extend(self, other_result: "QNResult") -> None:


### PR DESCRIPTION
Violated rules are now raised as an exception. This simplifies the `Result` class: it only contains a formalism type and a list of `StateTransitionGraph`s.