### PR TITLE
fix: add math-dollar and other myst extensions

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -223,7 +223,12 @@ if "EXECUTE_NB" in os.environ:
     jupyter_execute_notebooks = "force"
 
 # Settings for myst-parser
-myst_enable_extensions = ["colon_fence"]
+myst_enable_extensions = [
+    "amsmath",
+    "colon_fence",
+    "dollarmath",
+    "smartquotes",
+]
 myst_update_mathjax = False
 
 # Settings for Thebe cell output


### PR DESCRIPTION
Fixes a problem that was introduced by #463:
![image](https://user-images.githubusercontent.com/29308176/106291543-0ec8a880-624c-11eb-810c-bc6031b35236.png)

[`sphinx-math-dollar`](https://www.sympy.org/sphinx-math-dollar) has now been added as a MyST extension, as well as some others.