### PR TITLE
adr: reorganize ADR template

### DIFF
--- a/docs/adr.md
+++ b/docs/adr.md
@@ -13,7 +13,7 @@ maxdepth: 1
 adr/*
 ```
 
-For new ADRs, please use {download}`adr/template.md` as basis. More information
-on MADR is available at [adr.github.io/madr](https://adr.github.io/madr).
-General information about architectural decision records is available at
+For new ADRs, please use {download}`adr/template.md` as basis. This template
+was inspired by [MADR](https://adr.github.io/madr). General information about
+architectural decision records is available at
 [adr.github.io](https://adr.github.io).

--- a/docs/adr/001.md
+++ b/docs/adr/001.md
@@ -6,7 +6,7 @@
 - Status: **accepted**
 - Deciders: @redeboer @spflueger
 
-## Context and Problem Statement
+## Context and problem statement
 
 From the perspective of a PWA fitter package, the responsibility of the
 `expertsystem` is to construct an `AmplitudeModel` that serves as blueprint for
@@ -45,7 +45,7 @@ Requirements for the `AmplitudeModel`:
    for the calculation of fit fractions, or plotting individual parts of the
    intensity.
 
-## Decision Drivers
+## Decision drivers
 
 - [#382](https://github.com/ComPWA/expertsystem/issues/382): Coupling
   parameters in the `AmplitudeModel` is difficult (has to be done through the
@@ -65,9 +65,9 @@ Requirements for the `AmplitudeModel`:
   generators converting a mathematical expression into a function (using
   various back-ends) requires too much manpower.
 
-## Considered Options
+## Considered solutions
 
-### Current set-up
+### Customized Python classes
 
 Currently
 ([v0.6.8](https://pwa.readthedocs.io/projects/expertsystem/en/0.6.8)), the
@@ -101,7 +101,7 @@ maxdepth: 1
 001/operators
 ```
 
-## Decision Outcome
+## Decision outcome
 
 Use {doc}`001/sympy`. Initially, we leave the existing amplitude builders
 (modules

--- a/docs/adr/001.md
+++ b/docs/adr/001.md
@@ -3,8 +3,8 @@
 
 # [ADR-001] Amplitude model
 
-- Status: **accepted**
-- Deciders: @redeboer @spflueger
+- **Status**: accepted
+- **Deciders**: @redeboer @spflueger
 
 ## Context and problem statement
 
@@ -20,7 +20,29 @@ requirements:
 2. It should contain **parameters** that can be tweaked, so that they can be
    optimized with regard to a certain estimator.
 
-Requirements for the `AmplitudeModel`:
+### Technical story
+
+- [#382](https://github.com/ComPWA/expertsystem/issues/382): Coupling
+  parameters in the `AmplitudeModel` is difficult (has to be done through the
+  place where they are used in the `dynamics` or `intensity` section) and
+  counter-intuitive (cannot be done through the `parameters` section)
+- [#440](https://github.com/ComPWA/expertsystem/issues/440): when overwriting
+  existing dynamics, old parameters are not cleaned up from the `parameters`
+  section
+- [#441](https://github.com/ComPWA/expertsystem/issues/441): parameters contain
+  a name that can be changed, but that results in a mismatch between the key
+  that is used in the `parameters` section and the name of the parameter to
+  which that entry points.
+- [ComPWA#226](https://github.com/ComPWA/ComPWA/issues/226): Use a math
+  language for the blueprint of the function. This was also discussed early to
+  mid 2020, but dropped in favor of custom python code + `amplitf`. The
+  reasoning was that the effort of writing some new math language plus
+  generators converting a mathematical expression into a function (using
+  various back-ends) requires too much manpower.
+
+## Decision drivers
+
+### Solution requirements
 
 1. The `AmplitudeModel` has to be convertible to a function which can be
    **evaluated using various computation back-ends** (numpy, tensorflow,
@@ -44,26 +66,6 @@ Requirements for the `AmplitudeModel`:
    sub-parts of the complete mathematical expression. This is at least needed
    for the calculation of fit fractions, or plotting individual parts of the
    intensity.
-
-## Decision drivers
-
-- [#382](https://github.com/ComPWA/expertsystem/issues/382): Coupling
-  parameters in the `AmplitudeModel` is difficult (has to be done through the
-  place where they are used in the `dynamics` or `intensity` section) and
-  counter-intuitive (cannot be done through the `parameters` section)
-- [#440](https://github.com/ComPWA/expertsystem/issues/440): when overwriting
-  existing dynamics, old parameters are not cleaned up from the `parameters`
-  section
-- [#441](https://github.com/ComPWA/expertsystem/issues/441): parameters contain
-  a name that can be changed, but that results in a mismatch between the key
-  that is used in the `parameters` section and the name of the parameter to
-  which that entry points.
-- [ComPWA#226](https://github.com/ComPWA/ComPWA/issues/226): Use a math
-  language for the blueprint of the function. This was also discussed early to
-  mid 2020, but dropped in favor of custom python code + `amplitf`. The
-  reasoning was that the effort of writing some new math language plus
-  generators converting a mathematical expression into a function (using
-  various back-ends) requires too much manpower.
 
 ## Considered solutions
 
@@ -101,21 +103,24 @@ maxdepth: 1
 001/operators
 ```
 
-## Decision outcome
+## Evaluation
 
-Use {doc}`001/sympy`. Initially, we leave the existing amplitude builders
-(modules
-[`helicity_decay`](https://pwa.readthedocs.io/projects/expertsystem/en/0.6.8/api/expertsystem.amplitude.helicity_decay.html)
-and
-[`canonical_decay`](https://pwa.readthedocs.io/projects/expertsystem/en/0.6.8/api/expertsystem.amplitude.canonical_decay.html))
-alongside a SymPy implementation, so that it's possible to compare the results.
-Once it turns out the this set-up results in the same results and a comparable
-performance, we replace the old amplitude builders with the new SymPy
-implementation.
+### Pros and Cons
 
-## Pros and Cons of the Options
+#### Customized Python classes (current state)
 
-### {doc}`SymPy <001/sympy>`
+- **Positive**
+  - "Faster" implementation / prototyping possible compared to python operators
+  - No additional dependencies
+- **Negative**
+  - Not open-closed to new models
+  - Conversion to various back-ends not DRY
+  - Function replacement or extension feature becomes very difficult to handle.
+  - Model is not complete, since no complete mathematical description is used.
+    For example Breit-Wigner functions are referred to directly and their
+    implementations is not defined in the amplitude model.
+
+#### {doc}`SymPy <001/sympy>`
 
 - **Positive**
   - Easy to render amplitude model as LaTeX
@@ -136,7 +141,7 @@ implementation.
   - Need to keep track of components in the expression tree with symbol
     mappings
 
-### {doc}`Python's operator library <001/operators>`
+#### {doc}`Python's operator library <001/operators>`
 
 - **Positive**
   - More control over different components of in the expression tree
@@ -145,15 +150,14 @@ implementation.
 - **Negative**
   - Essentially re-inventing SymPy
 
-### Customized python code (current state)
+## Decision outcome
 
-- **Positive**
-  - "Faster" implementation / prototyping possible compared to python operators
-  - No additional dependencies
-- **Negative**
-  - Not open-closed to new models
-  - Conversion to various back-ends not DRY
-  - Function replacement or extension feature becomes very difficult to handle.
-  - Model is not complete, since no complete mathematical description is used.
-    For example Breit-Wigner functions are referred to directly and their
-    implementations is not defined in the amplitude model.
+Use {doc}`001/sympy`. Initially, we leave the existing amplitude builders
+(modules
+[`helicity_decay`](https://pwa.readthedocs.io/projects/expertsystem/en/0.6.8/api/expertsystem.amplitude.helicity_decay.html)
+and
+[`canonical_decay`](https://pwa.readthedocs.io/projects/expertsystem/en/0.6.8/api/expertsystem.amplitude.canonical_decay.html))
+alongside a SymPy implementation, so that it's possible to compare the results.
+Once it turns out the this set-up results in the same results and a comparable
+performance, we replace the old amplitude builders with the new SymPy
+implementation.

--- a/docs/adr/template.md
+++ b/docs/adr/template.md
@@ -9,9 +9,8 @@
   superseded by [ADR-xxx](./xxx.md)
   -->
 - **Deciders**: <!-- @github-user -->
-<!-- - Technical Story: [description | ticket/issue URL] -->
 
-## Context and Problem Statement
+## Context and problem statement
 
 <!--
 Describe the context and problem statement, e.g., in free form using two to
@@ -19,29 +18,81 @@ three sentences. You may want to articulate the problem in form of a question.
 -->
 
 <!--
-## Decision Drivers
+### Issues with existing set-up
 
-- [driver 1, e.g., a force, facing concern, …]
-- [driver 2, e.g., a force, facing concern, …]
+Summary of problems with the existing design, possibly with some snippets.
 -->
-
-## Considered Options
 
 <!--
-### [Option 1]
+### Technical story
 
-#### Pros
+If available, list and link related issues, PRs, or ADRs that led up to this
+ADR:
 
-#### Cons
-
-### [Option 2]
-
-#### Pros
-
-#### Cons
+- [#000](https://github.com/ComPWA/expertsystem/issues/000)
+- [#000](https://github.com/ComPWA/expertsystem/issues/000)
 -->
 
-## Decision Outcome
+### Solution requirements
+
+1. <!-- Requirement 1 -->
+2. <!-- Requirement 2 -->
+
+## Considered solutions
+
+<!--
+Solutions can be illustrated with Jupyter notebooks or MyST files in a
+subfolder. They should only factually illustrate design and implementation: the
+discussion should take place in the main document.
+
+To include documents in a sub-folder, use a toctree:
+
+```{toctree}
+xxx/option1
+xxx/option2
+```
+-->
+
+## Evaluation
+
+### Pros and Cons
+
+<!--
+List some advantages and disadvantages of each of the implementations, possibly
+with links (using e.g. {ref} or {doc}) to the proposed solutions.
+
+#### Option 1
+
+- **Positive**:
+  1.
+  2.
+- **Negative**:
+  1.
+  2.
+
+#### Option 2
+
+- **Positive**:
+  1.
+  2.
+- **Negative**:
+  1.
+  2.
+-->
+
+### Requirement evaluation
+
+See [requirements](#solution-requirements).
+
+<!--
+|          | 1   | 2   | 3   | ... |
+| -------- | --- | --- | --- | --- |
+| Option 1 |     |     |     |     |
+| Option 2 |     |     |     |     |
+| ...      |     |     |     |     |
+-->
+
+## Decision outcome
 
 <!--
 Chosen option: "[option 1]", because [justification. e.g., only option, which
@@ -50,13 +101,13 @@ out best (see below)].
 -->
 
 <!--
-### Positive Consequences
+### Positive consequences
 
 - [e.g., improvement of quality attribute satisfaction, follow-up decisions
   required, …]
 - …
 
-### Negative Consequences
+### Negative consequences
 
 - [e.g., compromising quality attribute, follow-up decisions required, …]
 - …

--- a/docs/adr/template.md
+++ b/docs/adr/template.md
@@ -35,10 +35,12 @@ ADR:
 
 ## Decision drivers
 
+<!--
 ### Solution requirements
 
-1. <!-- Requirement 1 -->
-2. <!-- Requirement 2 -->
+1. Requirement 1
+2. Requirement 2
+-->
 
 ## Considered solutions
 
@@ -82,11 +84,11 @@ with links (using e.g. {ref} or {doc}) to the proposed solutions.
   2.
 -->
 
+<!--
 ### Requirement evaluation
 
 See [requirements](#solution-requirements).
 
-<!--
 |          | 1   | 2   | 3   | ... |
 | -------- | --- | --- | --- | --- |
 | Option 1 |     |     |     |     |

--- a/docs/adr/template.md
+++ b/docs/adr/template.md
@@ -33,6 +33,8 @@ ADR:
 - [#000](https://github.com/ComPWA/expertsystem/issues/000)
 -->
 
+## Decision drivers
+
 ### Solution requirements
 
 1. <!-- Requirement 1 -->


### PR DESCRIPTION
The sections of the ADR template has been reorganized as to agree more with upcoming ADRs #458 #461 #467. The idea is that an ADR becomes a bit more like an analysis: state the problem, list requirements of a possible solution, propose some solution, evaluate, and decide which solution to follow.