### PR TITLE
feat: freeze Topology class

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -161,6 +161,8 @@ nitpick_ignore = [
     ("py:class", "a set-like object providing a view on D's keys"),
     ("py:class", "an object providing a view on D's values"),
     ("py:class", "typing_extensions.Protocol"),
+    ("py:obj", "expertsystem.reaction.topology._K"),
+    ("py:obj", "expertsystem.reaction.topology._V"),
 ]
 
 # Intersphinx settings

--- a/src/expertsystem/amplitude/canonical_decay.py
+++ b/src/expertsystem/amplitude/canonical_decay.py
@@ -82,10 +82,11 @@ def _clebsch_gordan_decorator(
             raise ValueError(
                 f"{spin.__class__.__name__} is not of type {Spin.__name__}"
             )
+        topology = graph.topology
+        in_edge_ids = topology.get_edge_ids_ingoing_to_node(node_id)
+        out_edge_ids = topology.get_edge_ids_outgoing_from_node(node_id)
 
-        in_edge_ids = graph.get_edge_ids_ingoing_to_node(node_id)
         in_edge_id = next(iter(in_edge_ids))
-
         particle, spin_projection = graph.get_edge_props(in_edge_id)
         parent_spin = Spin(
             particle.spin,
@@ -93,8 +94,7 @@ def _clebsch_gordan_decorator(
         )
 
         daughter_spins: List[Spin] = []
-
-        for out_edge_id in graph.get_edge_ids_outgoing_from_node(node_id):
+        for out_edge_id in out_edge_ids:
             particle, spin_projection = graph.get_edge_props(out_edge_id)
             daughter_spin = Spin(
                 particle.spin,

--- a/src/expertsystem/amplitude/canonical_decay.py
+++ b/src/expertsystem/amplitude/canonical_decay.py
@@ -40,7 +40,7 @@ class _CanonicalAmplitudeNameGenerator(_HelicityAmplitudeNameGenerator):
         if isinstance(node_id, int):
             node_ids = frozenset({node_id})
         else:
-            node_ids = graph.nodes
+            node_ids = graph.topology.nodes
         for node in node_ids:
             name += (
                 super().generate_unique_amplitude_name(graph, node)[:-1]

--- a/src/expertsystem/amplitude/helicity_decay.py
+++ b/src/expertsystem/amplitude/helicity_decay.py
@@ -327,8 +327,9 @@ class _HelicityAmplitudeNameGenerator:
     def _retrieve_helicity_info(
         graph: StateTransitionGraph[ParticleWithSpin], node_id: int
     ) -> Tuple[List[Tuple[str, float]], List[Tuple[str, float]]]:
-        in_edges = graph.get_edge_ids_ingoing_to_node(node_id)
-        out_edges = graph.get_edge_ids_outgoing_from_node(node_id)
+        topology = graph.topology
+        in_edges = topology.get_edge_ids_ingoing_to_node(node_id)
+        out_edges = topology.get_edge_ids_outgoing_from_node(node_id)
 
         in_names_hel_list = _get_name_hel_list(graph, in_edges)
         out_names_hel_list = _get_name_hel_list(graph, out_edges)
@@ -485,11 +486,12 @@ class HelicityAmplitudeGenerator:
             return HelicityParticle(particle, spin_projection)
 
         decay_products: List[DecayProduct] = list()
-        for out_edge_id in graph.get_edge_ids_outgoing_from_node(node_id):
+        topology = graph.topology
+        for out_edge_id in topology.get_edge_ids_outgoing_from_node(node_id):
             edge_props = graph.get_edge_props(out_edge_id)
             helicity_particle = create_helicity_particle(edge_props)
             final_state_ids = _determine_attached_final_state(
-                graph.topology, out_edge_id
+                topology, out_edge_id
             )
             decay_products.append(
                 DecayProduct(
@@ -499,7 +501,7 @@ class HelicityAmplitudeGenerator:
                 )
             )
 
-        in_edge_ids = graph.get_edge_ids_ingoing_to_node(node_id)
+        in_edge_ids = topology.get_edge_ids_ingoing_to_node(node_id)
         if len(in_edge_ids) != 1:
             raise ValueError("This node does not represent a two body decay!")
         ingoing_edge_id = next(iter(in_edge_ids))
@@ -507,18 +509,18 @@ class HelicityAmplitudeGenerator:
         helicity_particle = create_helicity_particle(edge_props)
         helicity_decay = HelicityDecay(helicity_particle, decay_products)
 
-        recoil_edge_id = _get_recoil_edge(graph.topology, ingoing_edge_id)
+        recoil_edge_id = _get_recoil_edge(topology, ingoing_edge_id)
         if recoil_edge_id is not None:
             helicity_decay.recoil_system = RecoilSystem(
-                _determine_attached_final_state(graph.topology, recoil_edge_id)
+                _determine_attached_final_state(topology, recoil_edge_id)
             )
             parent_recoil_edge_id = _get_parent_recoil_edge(
-                graph.topology, ingoing_edge_id
+                topology, ingoing_edge_id
             )
             if parent_recoil_edge_id is not None:
                 helicity_decay.recoil_system.parent_recoil_final_state = (
                     _determine_attached_final_state(
-                        graph.topology, parent_recoil_edge_id
+                        topology, parent_recoil_edge_id
                     )
                 )
 

--- a/src/expertsystem/amplitude/helicity_decay.py
+++ b/src/expertsystem/amplitude/helicity_decay.py
@@ -158,7 +158,7 @@ def _get_prefactor(
 ) -> float:
     """Calculate the product of all prefactors defined in this graph."""
     prefactor = 1.0
-    for node_id in graph.nodes:
+    for node_id in graph.topology.nodes:
         node_props = graph.get_node_props(node_id)
         if node_props:
             temp_prefactor = __validate_float_type(node_props.parity_prefactor)
@@ -172,7 +172,7 @@ def _generate_particle_collection(
 ) -> ParticleCollection:
     particles = ParticleCollection()
     for graph in graphs:
-        for edge_props in map(graph.get_edge_props, graph.edges):
+        for edge_props in map(graph.get_edge_props, graph.topology.edges):
             particle, _ = edge_props
             if particle not in particles:
                 particles.add(particle)
@@ -254,7 +254,7 @@ class _HelicityAmplitudeNameGenerator:
     def register_amplitude_coefficient_name(
         self, graph: StateTransitionGraph[ParticleWithSpin]
     ) -> None:
-        for node_id in graph.nodes:
+        for node_id in graph.topology.nodes:
             (
                 coefficient_suffix,
                 parity_partner_coefficient_suffix,
@@ -309,7 +309,7 @@ class _HelicityAmplitudeNameGenerator:
         if isinstance(node_id, int):
             nodelist = frozenset({node_id})
         else:
-            nodelist = graph.nodes
+            nodelist = graph.topology.nodes
         for node in nodelist:
             (in_hel_info, out_hel_info) = self._retrieve_helicity_info(
                 graph, node
@@ -354,7 +354,7 @@ class _HelicityAmplitudeNameGenerator:
     ) -> str:
         """Generate unique suffix for a sequential amplitude graph."""
         output_suffix = ""
-        for node_id in graph.nodes:
+        for node_id in graph.topology.nodes:
             suffix = self.generate_amplitude_coefficient_name(graph, node_id)
             if suffix in self.parity_partner_coefficient_mapping:
                 suffix = self.parity_partner_coefficient_mapping[suffix]
@@ -457,7 +457,7 @@ class HelicityAmplitudeGenerator:
     ) -> AmplitudeNode:
         partial_decays: List[AmplitudeNode] = [
             self._generate_partial_decay(graph, node_id)
-            for node_id in graph.nodes
+            for node_id in graph.topology.nodes
         ]
         sequential_amplitudes = SequentialAmplitude(partial_decays)
 
@@ -551,7 +551,7 @@ class HelicityAmplitudeGenerator:
     ) -> Optional[float]:
         prefactor = _get_prefactor(graph)
         if prefactor != 1.0:
-            for node_id in graph.nodes:
+            for node_id in graph.topology.nodes:
                 raw_suffix = (
                     self.name_generator.generate_amplitude_coefficient_name(
                         graph, node_id

--- a/src/expertsystem/amplitude/helicity_decay.py
+++ b/src/expertsystem/amplitude/helicity_decay.py
@@ -45,8 +45,8 @@ def _group_graphs_same_initial_and_final(
         Tuple[tuple, tuple], List[StateTransitionGraph[ParticleWithSpin]]
     ] = dict()
     for graph in graphs:
-        ise = graph.get_final_state_edge_ids()
-        fse = graph.get_initial_state_edge_ids()
+        ise = graph.topology.outgoing_edge_ids
+        fse = graph.topology.incoming_edge_ids
         graph_group = (
             tuple(
                 sorted(
@@ -85,8 +85,8 @@ def _get_graph_group_unique_label(
     label = ""
     if graph_group:
         first_graph = next(iter(graph_group))
-        ise = first_graph.topology.get_initial_state_edge_ids()
-        fse = first_graph.topology.get_final_state_edge_ids()
+        ise = first_graph.topology.incoming_edge_ids
+        fse = first_graph.topology.outgoing_edge_ids
         is_names = _get_name_hel_list(first_graph, ise)
         fs_names = _get_name_hel_list(first_graph, fse)
         label += (
@@ -106,7 +106,7 @@ def _determine_attached_final_state(
     the root).
     """
     final_state_edge_ids = []
-    all_final_state_edges = topology.get_final_state_edge_ids()
+    all_final_state_edges = topology.outgoing_edge_ids
     current_edges = [edge_id]
     while current_edges:
         temp_current_edges = current_edges

--- a/src/expertsystem/amplitude/model.py
+++ b/src/expertsystem/amplitude/model.py
@@ -239,10 +239,10 @@ class Kinematics:
         kinematics_type: Optional[KinematicsType] = None,
     ) -> "Kinematics":
         initial_state = dict()
-        for state_id in graph.get_initial_state_edge_ids():
+        for state_id in graph.topology.incoming_edge_ids:
             initial_state[state_id] = graph.get_edge_props(state_id)[0]
         final_state = dict()
-        for state_id in graph.get_final_state_edge_ids():
+        for state_id in graph.topology.outgoing_edge_ids:
             final_state[state_id] = graph.get_edge_props(state_id)[0]
         return Kinematics(
             type=kinematics_type,

--- a/src/expertsystem/io/_dot.py
+++ b/src/expertsystem/io/_dot.py
@@ -63,7 +63,7 @@ def __graph_to_dot_content(
         )
     dot_source += __rank_string(top, prefix)
     dot_source += __rank_string(outs, prefix)
-    for i, edge in graph.edges.items():
+    for i, edge in topology.edges.items():
         j, k = edge.ending_node_id, edge.originating_node_id
         if j is None or k is None:
             dot_source += _DOT_DEFAULT_EDGE.format(

--- a/src/expertsystem/io/_dot.py
+++ b/src/expertsystem/io/_dot.py
@@ -3,7 +3,7 @@
 See :doc:`/usage/visualization` for more info.
 """
 
-from typing import Any, Callable, Iterable, List, Optional
+from typing import Any, Callable, Iterable, List, Optional, Union
 
 from expertsystem.particle import Particle, ParticleCollection
 from expertsystem.reaction.topology import StateTransitionGraph, Topology
@@ -46,12 +46,18 @@ def graph_to_dot(graph: StateTransitionGraph) -> str:
 
 
 def __graph_to_dot_content(
-    graph: StateTransitionGraph, prefix: str = ""
+    graph: Union[StateTransitionGraph, Topology], prefix: str = ""
 ) -> str:
     dot_source = ""
-    top = graph.get_initial_state_edge_ids()
-    outs = graph.get_final_state_edge_ids()
-    for edge_id in top + outs:
+    if isinstance(graph, StateTransitionGraph):
+        topology = graph.topology
+    elif isinstance(graph, Topology):
+        topology = graph
+    else:
+        raise NotImplementedError
+    top = topology.incoming_edge_ids
+    outs = topology.outgoing_edge_ids
+    for edge_id in top | outs:
         dot_source += _DOT_DEFAULT_NODE.format(
             prefix + __node_name(edge_id), __edge_label(graph, edge_id)
         )
@@ -84,7 +90,9 @@ def __rank_string(node_edge_ids: Iterable[int], prefix: str = "") -> str:
     return _DOT_RANK_SAME.format(name_string)
 
 
-def __edge_label(graph: StateTransitionGraph, edge_id: int) -> str:
+def __edge_label(
+    graph: Union[StateTransitionGraph, Topology], edge_id: int
+) -> str:
     if isinstance(graph, StateTransitionGraph):
         edge_prop = graph.get_edge_props(edge_id)
         if not edge_prop:

--- a/src/expertsystem/reaction/__init__.py
+++ b/src/expertsystem/reaction/__init__.py
@@ -237,7 +237,7 @@ class Result:
             ):
                 continue
             new_edge_props = dict()
-            for edge_id in graph.edges:
+            for edge_id in graph.topology.edges:
                 edge_props = graph.get_edge_props(edge_id)
                 if edge_props:
                     new_edge_props[edge_id] = edge_props[0]
@@ -247,7 +247,8 @@ class Result:
                     node_props={
                         i: node_props
                         for i, node_props in zip(
-                            graph.nodes, map(graph.get_node_props, graph.nodes)
+                            graph.topology.nodes,
+                            map(graph.get_node_props, graph.topology.nodes),
                         )
                         if node_props
                     },
@@ -277,7 +278,7 @@ class Result:
                 raise ValueError(
                     "Cannot merge graphs that don't have the same edge IDs"
                 )
-            for i in graph.edges:
+            for i in graph.topology.edges:
                 particle = graph.get_edge_props(i)
                 other_particles = merged_graph.get_edge_props(i)
                 if particle not in other_particles:
@@ -287,7 +288,7 @@ class Result:
             graph: StateTransitionGraph[Particle],
             merged_graph: StateTransitionGraph[ParticleCollection],
         ) -> bool:
-            if graph.edges != merged_graph.edges:
+            if graph.topology.edges != merged_graph.topology.edges:
                 return False
             for edge_id in (
                 graph.topology.incoming_edge_ids
@@ -315,13 +316,14 @@ class Result:
                     edge_id: ParticleCollection(
                         {graph.get_edge_props(edge_id)}
                     )
-                    for edge_id in graph.edges
+                    for edge_id in graph.topology.edges
                 }
                 inventory.append(
                     StateTransitionGraph[ParticleCollection](
                         topology=graph.topology,
                         node_props={
-                            i: graph.get_node_props(i) for i in graph.nodes
+                            i: graph.get_node_props(i)
+                            for i in graph.topology.nodes
                         },
                         edge_props=new_edge_props,
                     )

--- a/src/expertsystem/reaction/__init__.py
+++ b/src/expertsystem/reaction/__init__.py
@@ -242,9 +242,7 @@ class Result:
                     new_edge_props[edge_id] = edge_props[0]
             inventory.append(
                 StateTransitionGraph[Particle](
-                    topology=Topology(
-                        nodes=set(graph.nodes), edges=graph.edges
-                    ),
+                    topology=graph.topology,
                     node_props={
                         i: node_props
                         for i, node_props in zip(
@@ -320,9 +318,7 @@ class Result:
                 }
                 inventory.append(
                     StateTransitionGraph[ParticleCollection](
-                        topology=Topology(
-                            nodes=set(graph.nodes), edges=graph.edges
-                        ),
+                        topology=graph.topology,
                         node_props={
                             i: graph.get_node_props(i) for i in graph.nodes
                         },

--- a/src/expertsystem/reaction/__init__.py
+++ b/src/expertsystem/reaction/__init__.py
@@ -443,9 +443,9 @@ class StateTransitionManager:  # pylint: disable=too-many-instance-attributes
                 len(initial_state), len(final_state)
             )
         elif "n-body" in topology_building or "nbody" in topology_building:
-            self.__topologies = [
-                create_n_body_topology(len(initial_state), len(final_state))
-            ]
+            self.__topologies = frozenset(
+                {create_n_body_topology(len(initial_state), len(final_state))}
+            )
             use_nbody_topology = True
             # turn of mass conservation, in case more than one initial state
             # particle is present

--- a/src/expertsystem/reaction/_system_control.py
+++ b/src/expertsystem/reaction/_system_control.py
@@ -235,7 +235,7 @@ def _remove_qns_from_graph(  # pylint: disable=too-many-branches
     qn_list: Set[Type[NodeQuantumNumber]],
 ) -> StateTransitionGraph[ParticleWithSpin]:
     new_node_props = {}
-    for node_id in graph.nodes:
+    for node_id in graph.topology.nodes:
         node_props = graph.get_node_props(node_id)
         new_node_props[node_id] = attr.evolve(
             node_props, **{x.__name__: None for x in qn_list}

--- a/src/expertsystem/reaction/_system_control.py
+++ b/src/expertsystem/reaction/_system_control.py
@@ -375,11 +375,12 @@ def require_interaction_property(
 
 
 def _find_node_ids_with_ingoing_particle_name(
-    graph: StateTransitionGraph, ingoing_particle_name: str
+    graph: StateTransitionGraph[ParticleWithSpin], ingoing_particle_name: str
 ) -> List[int]:
+    topology = graph.topology
     found_node_ids = []
-    for node_id in graph.nodes:
-        for edge_id in graph.get_edge_ids_ingoing_to_node(node_id):
+    for node_id in topology.nodes:
+        for edge_id in topology.get_edge_ids_ingoing_to_node(node_id):
             edge_props = graph.get_edge_props(edge_id)
             edge_particle_name = edge_props[0].name
             if str(ingoing_particle_name) in str(edge_particle_name):

--- a/src/expertsystem/reaction/combinatorics.py
+++ b/src/expertsystem/reaction/combinatorics.py
@@ -287,10 +287,8 @@ def _generate_kinematic_permutations(
                 f"(len({state_definitions}) != len({edge_ids})"
             )
 
-    assert_number_of_states(
-        initial_state, topology.get_initial_state_edge_ids()
-    )
-    assert_number_of_states(final_state, topology.get_final_state_edge_ids())
+    assert_number_of_states(initial_state, topology.incoming_edge_ids)
+    assert_number_of_states(final_state, topology.outgoing_edge_ids)
 
     def is_allowed_grouping(
         kinematic_representation: _KinematicRepresentation,
@@ -368,8 +366,8 @@ def _generate_outer_edge_permutations(
     initial_state: Sequence[StateWithSpins],
     final_state: Sequence[StateWithSpins],
 ) -> Generator[Dict[int, StateWithSpins], None, None]:
-    initial_state_ids = topology.get_initial_state_edge_ids()
-    final_state_ids = topology.get_final_state_edge_ids()
+    initial_state_ids = list(topology.incoming_edge_ids)
+    final_state_ids = list(topology.outgoing_edge_ids)
     for initial_state_permutation in permutations(initial_state):
         for final_state_permutation in permutations(final_state):
             yield dict(
@@ -415,13 +413,13 @@ def _generate_spin_permutations(
 def __get_initial_state_edge_ids(
     graph: StateTransitionGraph[ParticleWithSpin],
 ) -> Iterable[int]:
-    return graph.get_initial_state_edge_ids()
+    return graph.topology.incoming_edge_ids
 
 
 def __get_final_state_edge_ids(
     graph: StateTransitionGraph[ParticleWithSpin],
 ) -> Iterable[int]:
-    return graph.get_final_state_edge_ids()
+    return graph.topology.outgoing_edge_ids
 
 
 def match_external_edges(

--- a/src/expertsystem/reaction/combinatorics.py
+++ b/src/expertsystem/reaction/combinatorics.py
@@ -30,7 +30,7 @@ import attr
 from expertsystem.particle import Particle, ParticleCollection
 
 from .quantum_numbers import InteractionProperties, ParticleWithSpin
-from .topology import StateTransitionGraph, Topology
+from .topology import StateTransitionGraph, Topology, get_originating_node_list
 
 StateWithSpins = Tuple[str, Sequence[float]]
 StateDefinition = Union[str, StateWithSpins]
@@ -527,7 +527,7 @@ def _external_edge_identical_particle_combinatorics(
         combinations = permutations(edge_group)
         graph_combinations = set()
         ext_edge_combinations = []
-        ref_node_origin = graph.get_originating_node_list(edge_group)
+        ref_node_origin = get_originating_node_list(graph.topology, edge_group)
         for comb in combinations:
             temp_edge_node_mapping = tuple(sorted(zip(comb, ref_node_origin)))
             if temp_edge_node_mapping not in graph_combinations:

--- a/src/expertsystem/reaction/solving.py
+++ b/src/expertsystem/reaction/solving.py
@@ -242,7 +242,7 @@ def _merge_particle_candidates_with_solutions(
     merged_solutions = []
 
     logging.debug("merging solutions with graph...")
-    intermediate_edges = topology.get_intermediate_state_edge_ids()
+    intermediate_edges = topology.intermediate_edge_ids
     for solution in solutions:
         current_new_solutions = [solution]
         for int_edge_id in intermediate_edges:

--- a/src/expertsystem/reaction/topology.py
+++ b/src/expertsystem/reaction/topology.py
@@ -383,7 +383,7 @@ class SimpleStateTransitionTopologyBuilder:
 
     def build(
         self, number_of_initial_edges: int, number_of_final_edges: int
-    ) -> List[Topology]:
+    ) -> FrozenSet[Topology]:
         number_of_initial_edges = int(number_of_initial_edges)
         number_of_final_edges = int(number_of_final_edges)
         if number_of_initial_edges < 1:
@@ -419,10 +419,10 @@ class SimpleStateTransitionTopologyBuilder:
 
         logging.info("finished building topology graphs...")
         # strip the current open end edges list from the result graph tuples
-        topologies = []
+        topologies: Set[Topology] = set()
         for graph_tuple in graph_tuple_list:
-            topologies.append(graph_tuple[0].freeze())
-        return topologies
+            topologies.add(graph_tuple[0].freeze())
+        return frozenset(topologies)
 
     def _extend_graph(
         self, pair: Tuple[_MutableTopology, Sequence[int]]
@@ -464,7 +464,7 @@ class SimpleStateTransitionTopologyBuilder:
 
 def create_isobar_topologies(
     number_of_initial_states: int, number_of_final_states: int
-) -> List[Topology]:
+) -> FrozenSet[Topology]:
     if number_of_initial_states != 1:
         raise ValueError(
             "Can only create an isobar decay if there's one initial state"
@@ -478,7 +478,7 @@ def create_isobar_topologies(
         number_of_initial_edges=number_of_initial_states,
         number_of_final_edges=number_of_final_states,
     )
-    return topologies
+    return frozenset(topologies)
 
 
 def create_n_body_topology(

--- a/src/expertsystem/reaction/topology.py
+++ b/src/expertsystem/reaction/topology.py
@@ -571,14 +571,6 @@ class StateTransitionGraph(Generic[EdgeType]):
         _assert_over_defined(self.topology.nodes, self.__node_props)
         _assert_over_defined(self.topology.edges, self.__edge_props)
 
-    @property
-    def nodes(self) -> FrozenSet[int]:
-        return frozenset(self.topology.nodes)
-
-    @property
-    def edges(self) -> FrozenDict[int, Edge]:
-        return self.topology.edges
-
     def get_node_props(self, node_id: int) -> InteractionProperties:
         return self.__node_props[node_id]
 
@@ -624,13 +616,13 @@ class StateTransitionGraph(Generic[EdgeType]):
         if self.topology != other.topology:
             return False
         if edge_comparator is not None:
-            for i in self.edges:
+            for i in self.topology.edges:
                 if not edge_comparator(
                     self.get_edge_props(i), other.get_edge_props(i)
                 ):
                     return False
         if node_comparator is not None:
-            for i in self.nodes:
+            for i in self.topology.nodes:
                 if not node_comparator(
                     self.get_node_props(i), other.get_node_props(i)
                 ):

--- a/src/expertsystem/reaction/topology.py
+++ b/src/expertsystem/reaction/topology.py
@@ -11,13 +11,17 @@ The main interface is the `.StateTransitionGraph`.
 import copy
 import itertools
 import logging
+from collections import abc
 from typing import (
     Callable,
     Collection,
     Dict,
     FrozenSet,
     Generic,
+    ItemsView,
     Iterable,
+    Iterator,
+    KeysView,
     List,
     Mapping,
     Optional,
@@ -25,14 +29,56 @@ from typing import (
     Set,
     Tuple,
     TypeVar,
+    ValuesView,
 )
 
 import attr
 
 from .quantum_numbers import InteractionProperties
 
+_K = TypeVar("_K")
+_V = TypeVar("_V")
 
-@attr.s
+
+class FrozenDict(  # pylint: disable=too-many-ancestors
+    Generic[_K, _V], abc.Hashable, abc.Mapping
+):
+    def __init__(self, mapping: Optional[Mapping] = None):
+        self.__mapping: Dict[_K, _V] = {}
+        if mapping is not None:
+            self.__mapping = dict(mapping)
+        self.__hash = hash(None)
+        if len(self.__mapping) != 0:
+            self.__hash = 0
+            for key_value_pair in self.items():
+                self.__hash ^= hash(key_value_pair)
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}({self.__mapping})"
+
+    def __iter__(self) -> Iterator[_K]:
+        return iter(self.__mapping)
+
+    def __len__(self) -> int:
+        return len(self.__mapping)
+
+    def __getitem__(self, key: _K) -> _V:
+        return self.__mapping[key]
+
+    def __hash__(self) -> int:
+        return self.__hash
+
+    def keys(self) -> KeysView[_K]:
+        return self.__mapping.keys()
+
+    def items(self) -> ItemsView[_K, _V]:
+        return self.__mapping.items()
+
+    def values(self) -> ValuesView[_V]:
+        return self.__mapping.values()
+
+
+@attr.s(frozen=True)
 class Edge:
     """Struct-like definition of an edge, used in `Topology`."""
 
@@ -45,6 +91,7 @@ class Edge:
         return connected_nodes  # type: ignore
 
 
+@attr.s(frozen=True)
 class Topology:
     """Directed Feynman-like graph without edge or node properties.
 
@@ -55,107 +102,21 @@ class Topology:
     because it allows open edges, like a Feynman-diagram.
     """
 
-    def __init__(
-        self,
-        nodes: Optional[Set[int]] = None,
-        edges: Optional[Mapping[int, Edge]] = None,
-    ) -> None:
-        self.__nodes: Set[int] = set()
-        self.__edges: Dict[int, Edge] = dict()
-        if nodes is not None:
-            self.__nodes = set(nodes)
-        if edges is not None:
-            self.__edges = dict(edges)
-        self.verify()
+    nodes: FrozenSet[int] = attr.ib(converter=frozenset)
+    edges: FrozenDict[int, Edge] = attr.ib(converter=FrozenDict)
 
-    @property
-    def nodes(self) -> Set[int]:
-        return self.__nodes
+    def __attrs_post_init__(self) -> None:
+        self.__verify()
 
-    @property
-    def edges(self) -> Dict[int, Edge]:
-        return self.__edges
-
-    def __repr__(self) -> str:
-        return f"{self.__class__.__name__}{(self.nodes, self.edges)}"
-
-    def __eq__(self, other: object) -> bool:
-        if isinstance(other, Topology):
-            return self.nodes == other.nodes and self.edges == other.edges
-        raise NotImplementedError
-
-    def add_node(self, node_id: int) -> None:
-        """Adds a node with id node_id.
-
-        Raises:
-            ValueError: if node_id already exists
-        """
-        if node_id in self.__nodes:
-            raise ValueError(f"Node with id {node_id} already exists!")
-        self.__nodes.add(node_id)
-
-    def add_edges(self, edge_ids: List[int]) -> None:
-        """Add edges with the ids in the edge_ids list."""
-        for edge_id in edge_ids:
-            if edge_id in self.__edges:
-                raise ValueError(f"Edge with id {edge_id} already exists!")
-            self.__edges[edge_id] = Edge()
-
-    def attach_edges_to_node_ingoing(
-        self, ingoing_edge_ids: Iterable[int], node_id: int
-    ) -> None:
-        """Attach existing edges to nodes.
-
-        So that the are ingoing to these nodes.
-
-        Args:
-            ingoing_edge_ids ([int]): list of edge ids, that will be attached
-            node_id (int): id of the node to which the edges will be attached
-
-        Raises:
-            ValueError: if an edge not doesn't exist.
-            ValueError: if an edge ID is already an ingoing node.
-        """
-        # first check if the ingoing edges are all available
-        for edge_id in ingoing_edge_ids:
-            if edge_id not in self.__edges:
-                raise ValueError(f"Edge with id {edge_id} does not exist!")
-            if self.__edges[edge_id].ending_node_id is not None:
-                raise ValueError(
-                    f"Edge with id {edge_id} is already ingoing to"
-                    f" node {self.__edges[edge_id].ending_node_id}"
-                )
-
-        # update the newly connected edges
-        for edge_id in ingoing_edge_ids:
-            self.__edges[edge_id].ending_node_id = node_id
-
-    def attach_edges_to_node_outgoing(
-        self, outgoing_edge_ids: Iterable[int], node_id: int
-    ) -> None:
-        # first check if the ingoing edges are all available
-        for edge_id in outgoing_edge_ids:
-            if edge_id not in self.__edges:
-                raise ValueError(f"Edge with id {edge_id} does not exist!")
-            if self.__edges[edge_id].originating_node_id is not None:
-                raise ValueError(
-                    f"Edge with id {edge_id} is already outgoing from"
-                    f" node {self.__edges[edge_id].originating_node_id}"
-                )
-
-        # update the edges
-        for edge_id in outgoing_edge_ids:
-            self.__edges[edge_id].originating_node_id = node_id
-
-    def verify(self) -> None:
+    def __verify(self) -> None:
         """Verify if there are no dangling edges or nodes."""
-        for edge_id, edge in self.__edges.items():
+        for edge_id, edge in self.edges.items():
             connected_nodes = edge.get_connected_nodes()
             if not connected_nodes:
                 raise ValueError(
                     f"Edge nr. {edge_id} is not connected to any node ({edge})"
                 )
-            if not connected_nodes <= self.__nodes:
+            if not connected_nodes <= self.nodes:
                 raise ValueError(
                     f"{edge} (ID: {edge_id}) has non-existing node IDs.\n"
                     f"Available node IDs: {self.nodes}"
@@ -195,7 +156,7 @@ class Topology:
         return sorted(
             [
                 edge_id
-                for edge_id, edge in self.__edges.items()
+                for edge_id, edge in self.edges.items()
                 if edge.originating_node_id is None
             ]
         )
@@ -204,7 +165,7 @@ class Topology:
         return sorted(
             [
                 edge_id
-                for edge_id, edge in self.__edges.items()
+                for edge_id, edge in self.edges.items()
                 if edge.ending_node_id is None
             ]
         )
@@ -213,7 +174,7 @@ class Topology:
         return sorted(
             [
                 edge_id
-                for edge_id, edge in self.__edges.items()
+                for edge_id, edge in self.edges.items()
                 if edge.ending_node_id is not None
                 and edge.originating_node_id is not None
             ]
@@ -271,11 +232,15 @@ class Topology:
             temp_edge_list = new_temp_edge_list
         return edge_list
 
-    def swap_edges(self, edge_id1: int, edge_id2: int) -> None:
-        popped_edge_id1 = self.__edges.pop(edge_id1)
-        popped_edge_id2 = self.__edges.pop(edge_id2)
-        self.__edges[edge_id2] = popped_edge_id1
-        self.__edges[edge_id1] = popped_edge_id2
+    def swap_edges(self, edge_id1: int, edge_id2: int) -> "Topology":
+        new_edges = dict(self.edges.items())
+        new_edges.update(
+            {
+                edge_id1: self.edges[edge_id2],
+                edge_id2: self.edges[edge_id1],
+            }
+        )
+        return attr.evolve(self, edges=FrozenDict(new_edges))
 
 
 def get_originating_node_list(
@@ -297,6 +262,89 @@ def get_originating_node_list(
     return [
         node_id for node_id in map(__get_originating_node, edge_ids) if node_id
     ]
+
+
+@attr.s(kw_only=True)
+class _MutableTopology:
+    edges: Dict[int, Edge] = attr.ib(factory=dict, converter=dict)
+    nodes: Set[int] = attr.ib(factory=set, converter=set)
+
+    def freeze(self) -> Topology:
+        return Topology(
+            edges=self.edges,
+            nodes=self.nodes,  # type: ignore
+        )
+
+    def add_node(self, node_id: int) -> None:
+        """Adds a node with id node_id.
+
+        Raises:
+            ValueError: if node_id already exists
+        """
+        if node_id in self.nodes:
+            raise ValueError(f"Node with id {node_id} already exists!")
+        self.nodes.add(node_id)
+
+    def add_edges(self, edge_ids: List[int]) -> None:
+        """Add edges with the ids in the edge_ids list."""
+        for edge_id in edge_ids:
+            if edge_id in self.edges:
+                raise ValueError(f"Edge with id {edge_id} already exists!")
+            self.edges[edge_id] = Edge()
+
+    def attach_edges_to_node_ingoing(
+        self, ingoing_edge_ids: Iterable[int], node_id: int
+    ) -> None:
+        """Attach existing edges to nodes.
+
+        So that the are ingoing to these nodes.
+
+        Args:
+            ingoing_edge_ids ([int]): list of edge ids, that will be attached
+            node_id (int): id of the node to which the edges will be attached
+
+        Raises:
+            ValueError: if an edge not doesn't exist.
+            ValueError: if an edge ID is already an ingoing node.
+        """
+        # first check if the ingoing edges are all available
+        for edge_id in ingoing_edge_ids:
+            if edge_id not in self.edges:
+                raise ValueError(f"Edge with id {edge_id} does not exist!")
+            if self.edges[edge_id].ending_node_id is not None:
+                raise ValueError(
+                    f"Edge with id {edge_id} is already ingoing to"
+                    f" node {self.edges[edge_id].ending_node_id}"
+                )
+
+        # update the newly connected edges
+        for edge_id in ingoing_edge_ids:
+            edge = self.edges[edge_id]
+            self.edges[edge_id] = Edge(
+                ending_node_id=node_id,
+                originating_node_id=edge.originating_node_id,
+            )
+
+    def attach_edges_to_node_outgoing(
+        self, outgoing_edge_ids: Iterable[int], node_id: int
+    ) -> None:
+        # first check if the ingoing edges are all available
+        for edge_id in outgoing_edge_ids:
+            if edge_id not in self.edges:
+                raise ValueError(f"Edge with id {edge_id} does not exist!")
+            if self.edges[edge_id].originating_node_id is not None:
+                raise ValueError(
+                    f"Edge with id {edge_id} is already outgoing from"
+                    f" node {self.edges[edge_id].originating_node_id}"
+                )
+
+        # update the edges
+        for edge_id in outgoing_edge_ids:
+            edge = self.edges[edge_id]
+            self.edges[edge_id] = Edge(
+                ending_node_id=edge.ending_node_id,
+                originating_node_id=node_id,
+            )
 
 
 @attr.s
@@ -346,12 +394,12 @@ class SimpleStateTransitionTopologyBuilder:
 
         logging.info("building topology graphs...")
         # result list
-        graph_tuple_list: List[Tuple[Topology, List[int]]] = []
+        graph_tuple_list: List[Tuple[_MutableTopology, List[int]]] = []
         # create seed graph
-        seed_graph = Topology()
+        seed_graph = _MutableTopology()
         current_open_end_edges = list(range(number_of_initial_edges))
         seed_graph.add_edges(current_open_end_edges)
-        extendable_graph_list: List[Tuple[Topology, List[int]]] = [
+        extendable_graph_list: List[Tuple[_MutableTopology, List[int]]] = [
             (seed_graph, current_open_end_edges)
         ]
 
@@ -364,23 +412,23 @@ class SimpleStateTransitionTopologyBuilder:
                     len(active_graph[1]) == number_of_final_edges
                     and len(active_graph[0].nodes) > 0
                 ):
-                    active_graph[0].verify()
+                    active_graph[0].freeze()  # verify
                     graph_tuple_list.append(active_graph)
                     continue
 
-                extendable_graph_list.extend(self.extend_graph(active_graph))
+                extendable_graph_list.extend(self._extend_graph(active_graph))
 
         logging.info("finished building topology graphs...")
         # strip the current open end edges list from the result graph tuples
-        result_graph_list = []
+        topologies = []
         for graph_tuple in graph_tuple_list:
-            result_graph_list.append(graph_tuple[0])
-        return result_graph_list
+            topologies.append(graph_tuple[0].freeze())
+        return topologies
 
-    def extend_graph(
-        self, pair: Tuple[Topology, Sequence[int]]
-    ) -> List[Tuple[Topology, List[int]]]:
-        extended_graph_list: List[Tuple[Topology, List[int]]] = []
+    def _extend_graph(
+        self, pair: Tuple[_MutableTopology, Sequence[int]]
+    ) -> List[Tuple[_MutableTopology, List[int]]]:
+        extended_graph_list: List[Tuple[_MutableTopology, List[int]]] = []
 
         topology, current_open_end_edges = pair
 
@@ -400,8 +448,10 @@ class SimpleStateTransitionTopologyBuilder:
                 # remove all combinations that originate from the same nodes
                 for comb1, comb2 in itertools.combinations(combis, 2):
                     if get_originating_node_list(
-                        topology, comb1
-                    ) == get_originating_node_list(topology, comb2):
+                        topology, comb1  # type: ignore
+                    ) == get_originating_node_list(
+                        topology, comb2  # type: ignore
+                    ):
                         combis.remove(comb2)
 
                 for combi in combis:
@@ -459,10 +509,10 @@ def create_n_body_topology(
 
 
 def _attach_node_to_edges(
-    graph: Tuple[Topology, Sequence[int]],
+    graph: Tuple[_MutableTopology, Sequence[int]],
     interaction_node: InteractionNode,
     ingoing_edge_ids: Iterable[int],
-) -> Tuple[Topology, List[int]]:
+) -> Tuple[_MutableTopology, List[int]]:
     temp_graph = copy.deepcopy(graph[0])
     new_open_end_lines = list(copy.deepcopy(graph[1]))
 
@@ -516,25 +566,18 @@ class StateTransitionGraph(Generic[EdgeType]):
         self.__edge_props = dict(edge_props)
         if not isinstance(topology, Topology):
             raise TypeError
-        self.__topology = Topology(
-            nodes=topology.nodes,
-            edges=topology.edges,
-        )
+        self.topology = topology
 
     def __post_init__(self) -> None:
         _assert_over_defined(self.topology.nodes, self.__node_props)
         _assert_over_defined(self.topology.edges, self.__edge_props)
 
     @property
-    def topology(self) -> Topology:
-        return self.__topology
-
-    @property
     def nodes(self) -> FrozenSet[int]:
         return frozenset(self.topology.nodes)
 
     @property
-    def edges(self) -> Dict[int, Edge]:
+    def edges(self) -> FrozenDict[int, Edge]:
         return self.topology.edges
 
     def get_initial_state_edge_ids(self) -> List[int]:
@@ -621,7 +664,7 @@ class StateTransitionGraph(Generic[EdgeType]):
         return True
 
     def swap_edges(self, edge_id1: int, edge_id2: int) -> None:
-        self.__topology.swap_edges(edge_id1, edge_id2)
+        self.topology = self.topology.swap_edges(edge_id1, edge_id2)
         value1: Optional[EdgeType] = None
         value2: Optional[EdgeType] = None
         if edge_id1 in self.__edge_props:

--- a/src/expertsystem/reaction/topology.py
+++ b/src/expertsystem/reaction/topology.py
@@ -181,57 +181,55 @@ class Topology:
         """
         raise NotImplementedError
 
-    def get_edge_ids_ingoing_to_node(self, node_id: int) -> List[int]:
-        return [
+    def get_edge_ids_ingoing_to_node(self, node_id: int) -> Set[int]:
+        return {
             edge_id
             for edge_id, edge in self.edges.items()
             if edge.ending_node_id == node_id
-        ]
+        }
 
-    def get_edge_ids_outgoing_from_node(self, node_id: int) -> List[int]:
-        return [
+    def get_edge_ids_outgoing_from_node(self, node_id: int) -> Set[int]:
+        return {
             edge_id
             for edge_id, edge in self.edges.items()
             if edge.originating_node_id == node_id
-        ]
+        }
 
-    def get_originating_final_state_edge_ids(self, node_id: int) -> List[int]:
+    def get_originating_final_state_edge_ids(self, node_id: int) -> Set[int]:
         fs_edges = self.outgoing_edge_ids
-        edge_list = []
+        edge_ids = set()
         temp_edge_list = self.get_edge_ids_outgoing_from_node(node_id)
         while temp_edge_list:
-            new_temp_edge_list = []
+            new_temp_edge_list = set()
             for edge_id in temp_edge_list:
                 if edge_id in fs_edges:
-                    edge_list.append(edge_id)
+                    edge_ids.add(edge_id)
                 else:
                     new_node_id = self.edges[edge_id].ending_node_id
                     if new_node_id is not None:
-                        new_temp_edge_list.extend(
+                        new_temp_edge_list.update(
                             self.get_edge_ids_outgoing_from_node(new_node_id)
                         )
             temp_edge_list = new_temp_edge_list
-        return edge_list
+        return edge_ids
 
-    def get_originating_initial_state_edge_ids(
-        self, node_id: int
-    ) -> List[int]:
+    def get_originating_initial_state_edge_ids(self, node_id: int) -> Set[int]:
         is_edges = self.incoming_edge_ids
-        edge_list = []
+        edge_ids: Set[int] = set()
         temp_edge_list = self.get_edge_ids_ingoing_to_node(node_id)
         while temp_edge_list:
-            new_temp_edge_list = []
+            new_temp_edge_list = set()
             for edge_id in temp_edge_list:
                 if edge_id in is_edges:
-                    edge_list.append(edge_id)
+                    edge_ids.add(edge_id)
                 else:
                     new_node_id = self.edges[edge_id].originating_node_id
                     if new_node_id is not None:
-                        new_temp_edge_list.extend(
+                        new_temp_edge_list.update(
                             self.get_edge_ids_ingoing_to_node(new_node_id)
                         )
             temp_edge_list = new_temp_edge_list
-        return edge_list
+        return edge_ids
 
     def swap_edges(self, edge_id1: int, edge_id2: int) -> "Topology":
         new_edges = dict(self.edges.items())
@@ -590,19 +588,19 @@ class StateTransitionGraph(Generic[EdgeType]):
     def get_intermediate_state_edge_ids(self) -> FrozenSet[int]:
         return self.topology.intermediate_edge_ids
 
-    def get_edge_ids_ingoing_to_node(self, node_id: int) -> List[int]:
-        return [
+    def get_edge_ids_ingoing_to_node(self, node_id: int) -> Set[int]:
+        return {
             edge_id
             for edge_id, edge in self.topology.edges.items()
             if edge.ending_node_id == node_id
-        ]
+        }
 
-    def get_edge_ids_outgoing_from_node(self, node_id: int) -> List[int]:
-        return [
+    def get_edge_ids_outgoing_from_node(self, node_id: int) -> Set[int]:
+        return {
             edge_id
             for edge_id, edge in self.topology.edges.items()
             if edge.originating_node_id == node_id
-        ]
+        }
 
     def get_node_props(self, node_id: int) -> InteractionProperties:
         return self.__node_props[node_id]

--- a/src/expertsystem/reaction/topology.py
+++ b/src/expertsystem/reaction/topology.py
@@ -191,26 +191,6 @@ class Topology:
         """
         raise NotImplementedError
 
-    def get_originating_node_list(self, edge_ids: Iterable[int]) -> List[int]:
-        """Get list of node ids from which the supplied edges originate from.
-
-        Args:
-            edge_ids ([int]): list of edge ids for which the origin node is
-                searched for
-
-        Returns:
-            [int]: a list of node ids
-        """
-
-        def __get_originating_node(edge_id: int) -> Optional[int]:
-            return self.__edges[edge_id].originating_node_id
-
-        return [
-            node_id
-            for node_id in map(__get_originating_node, edge_ids)
-            if node_id
-        ]
-
     def get_initial_state_edge_ids(self) -> List[int]:
         return sorted(
             [
@@ -296,6 +276,27 @@ class Topology:
         popped_edge_id2 = self.__edges.pop(edge_id2)
         self.__edges[edge_id2] = popped_edge_id1
         self.__edges[edge_id1] = popped_edge_id2
+
+
+def get_originating_node_list(
+    topology: Topology, edge_ids: Iterable[int]
+) -> List[int]:
+    """Get list of node ids from which the supplied edges originate from.
+
+    Args:
+        edge_ids ([int]): list of edge ids for which the origin node is
+            searched for
+
+    Returns:
+        [int]: a list of node ids
+    """
+
+    def __get_originating_node(edge_id: int) -> Optional[int]:
+        return topology.edges[edge_id].originating_node_id
+
+    return [
+        node_id for node_id in map(__get_originating_node, edge_ids) if node_id
+    ]
 
 
 @attr.s
@@ -398,9 +399,9 @@ class SimpleStateTransitionTopologyBuilder:
                 )
                 # remove all combinations that originate from the same nodes
                 for comb1, comb2 in itertools.combinations(combis, 2):
-                    if topology.get_originating_node_list(
-                        comb1
-                    ) == topology.get_originating_node_list(comb2):
+                    if get_originating_node_list(
+                        topology, comb1
+                    ) == get_originating_node_list(topology, comb2):
                         combis.remove(comb2)
 
                 for combi in combis:
@@ -558,9 +559,6 @@ class StateTransitionGraph(Generic[EdgeType]):
             for edge_id, edge in self.topology.edges.items()
             if edge.originating_node_id == node_id
         ]
-
-    def get_originating_node_list(self, edge_ids: Iterable[int]) -> List[int]:
-        return self.topology.get_originating_node_list(edge_ids)
 
     def get_node_props(self, node_id: int) -> InteractionProperties:
         return self.__node_props[node_id]

--- a/src/expertsystem/reaction/topology.py
+++ b/src/expertsystem/reaction/topology.py
@@ -579,21 +579,6 @@ class StateTransitionGraph(Generic[EdgeType]):
     def edges(self) -> FrozenDict[int, Edge]:
         return self.topology.edges
 
-    def get_initial_state_edge_ids(self) -> FrozenSet[int]:
-        return self.topology.incoming_edge_ids
-
-    def get_final_state_edge_ids(self) -> FrozenSet[int]:
-        return self.topology.outgoing_edge_ids
-
-    def get_intermediate_state_edge_ids(self) -> FrozenSet[int]:
-        return self.topology.intermediate_edge_ids
-
-    def get_edge_ids_ingoing_to_node(self, node_id: int) -> Set[int]:
-        return self.topology.get_edge_ids_ingoing_to_node(node_id)
-
-    def get_edge_ids_outgoing_from_node(self, node_id: int) -> Set[int]:
-        return self.topology.get_edge_ids_outgoing_from_node(node_id)
-
     def get_node_props(self, node_id: int) -> InteractionProperties:
         return self.__node_props[node_id]
 

--- a/src/expertsystem/reaction/topology.py
+++ b/src/expertsystem/reaction/topology.py
@@ -589,18 +589,10 @@ class StateTransitionGraph(Generic[EdgeType]):
         return self.topology.intermediate_edge_ids
 
     def get_edge_ids_ingoing_to_node(self, node_id: int) -> Set[int]:
-        return {
-            edge_id
-            for edge_id, edge in self.topology.edges.items()
-            if edge.ending_node_id == node_id
-        }
+        return self.topology.get_edge_ids_ingoing_to_node(node_id)
 
     def get_edge_ids_outgoing_from_node(self, node_id: int) -> Set[int]:
-        return {
-            edge_id
-            for edge_id, edge in self.topology.edges.items()
-            if edge.originating_node_id == node_id
-        }
+        return self.topology.get_edge_ids_outgoing_from_node(node_id)
 
     def get_node_props(self, node_id: int) -> InteractionProperties:
         return self.__node_props[node_id]
@@ -644,9 +636,7 @@ class StateTransitionGraph(Generic[EdgeType]):
             Callable[[InteractionProperties, InteractionProperties], bool]
         ] = None,
     ) -> bool:
-        if self.nodes != other.nodes:
-            return False
-        if self.edges != other.edges:
+        if self.topology != other.topology:
             return False
         if edge_comparator is not None:
             for i in self.edges:

--- a/tests/channels/test_jpsi_to_gamma_pi0_pi0.py
+++ b/tests/channels/test_jpsi_to_gamma_pi0_pi0.py
@@ -53,16 +53,18 @@ def test_id_to_particle_mappings(particle_database):
         number_of_threads=1,
     )
     assert len(result.solutions) == 4
+    iter_solutions = iter(result.solutions)
+    first_solution = next(iter_solutions)
     ref_mapping_fs = _create_edge_id_particle_mapping(
-        result.solutions[0], result.solutions[0].get_final_state_edge_ids()
+        first_solution, first_solution.topology.outgoing_edge_ids
     )
     ref_mapping_is = _create_edge_id_particle_mapping(
-        result.solutions[0], result.solutions[0].get_initial_state_edge_ids()
+        first_solution, first_solution.topology.incoming_edge_ids
     )
-    for solution in result.solutions[1:]:
+    for solution in iter_solutions:
         assert ref_mapping_fs == _create_edge_id_particle_mapping(
-            solution, solution.get_final_state_edge_ids()
+            solution, solution.topology.outgoing_edge_ids
         )
         assert ref_mapping_is == _create_edge_id_particle_mapping(
-            solution, solution.get_initial_state_edge_ids()
+            solution, solution.topology.incoming_edge_ids
         )

--- a/tests/unit/amplitude/test_parity_prefactor.py
+++ b/tests/unit/amplitude/test_parity_prefactor.py
@@ -68,11 +68,11 @@ def test_parity_prefactor(
     for solution in result.solutions:
         in_edge = [
             edge_id
-            for edge_id in solution.edges
+            for edge_id in solution.topology.edges
             if solution.get_edge_props(edge_id)[0].name == ingoing_state
         ]
         assert len(in_edge) == 1
-        node_id = solution.edges[in_edge[0]].ending_node_id
+        node_id = solution.topology.edges[in_edge[0]].ending_node_id
 
         assert isinstance(node_id, int)
 

--- a/tests/unit/io/test_dot.py
+++ b/tests/unit/io/test_dot.py
@@ -32,7 +32,7 @@ class TestWrite:
     def test_write_topology(output_dir):
         output_file = output_dir + "two_body_decay_topology.gv"
         topology = Topology(
-            nodes={0},
+            nodes={0},  # type: ignore
             edges={0: Edge(0, None), 1: Edge(None, 0), 2: Edge(None, 0)},
         )
         io.write(

--- a/tests/unit/reaction/test_solving.py
+++ b/tests/unit/reaction/test_solving.py
@@ -23,7 +23,7 @@ class TestResult:
         assert len(particle_graphs) == 2
         assert particle_graphs[0].get_edge_props(1) == pdg["f(0)(980)"]
         assert particle_graphs[1].get_edge_props(1) == pdg["f(0)(1500)"]
-        assert len(particle_graphs[0].edges) == 5
+        assert len(particle_graphs[0].topology.edges) == 5
         for edge_id in (0, 2, 3, 4):
             assert particle_graphs[0].get_edge_props(
                 edge_id

--- a/tests/unit/reaction/test_solving.py
+++ b/tests/unit/reaction/test_solving.py
@@ -41,7 +41,7 @@ class TestResult:
         collapsed_graphs = result.collapse_graphs()
         assert len(collapsed_graphs) == 1
         graph = next(iter(collapsed_graphs))
-        edge_id = next(iter(graph.get_intermediate_state_edge_ids()))
+        edge_id = next(iter(graph.topology.intermediate_edge_ids))
         f_resonances = pdg.filter(
             lambda p: p.name in ["f(0)(980)", "f(0)(1500)"]
         )

--- a/tests/unit/reaction/test_system_control.py
+++ b/tests/unit/reaction/test_system_control.py
@@ -376,7 +376,7 @@ def test_edge_swap(particle_database, initial_state, final_state):
 
     for graph in init_graphs:
         ref_mapping = _create_edge_id_particle_mapping(
-            graph, graph.get_final_state_edge_ids()
+            graph, graph.topology.outgoing_edge_ids
         )
         edge_keys = list(ref_mapping.keys())
         edge1 = edge_keys[0]
@@ -426,18 +426,18 @@ def test_match_external_edges(particle_database, initial_state, final_state):
     iter_graphs = iter(init_graphs)
     first_graph = next(iter_graphs)
     ref_mapping_fs = _create_edge_id_particle_mapping(
-        first_graph, first_graph.get_final_state_edge_ids()
+        first_graph, first_graph.topology.outgoing_edge_ids
     )
     ref_mapping_is = _create_edge_id_particle_mapping(
-        first_graph, first_graph.get_initial_state_edge_ids()
+        first_graph, first_graph.topology.incoming_edge_ids
     )
 
     for graph in iter_graphs:
         assert ref_mapping_fs == _create_edge_id_particle_mapping(
-            graph, graph.get_final_state_edge_ids()
+            graph, first_graph.topology.outgoing_edge_ids
         )
         assert ref_mapping_is == _create_edge_id_particle_mapping(
-            graph, graph.get_initial_state_edge_ids()
+            graph, first_graph.topology.incoming_edge_ids
         )
 
 
@@ -518,8 +518,8 @@ def test_external_edge_identical_particle_combinatorics(
 
     for group in comb_graphs[1:]:
         assert ref_mapping_fs == _create_edge_id_particle_mapping(
-            group, group.get_final_state_edge_ids()
+            group, group.topology.outgoing_edge_ids
         )
         assert ref_mapping_is == _create_edge_id_particle_mapping(
-            group, group.get_initial_state_edge_ids()
+            group, group.topology.incoming_edge_ids
         )

--- a/tests/unit/reaction/test_system_control.py
+++ b/tests/unit/reaction/test_system_control.py
@@ -208,7 +208,10 @@ def make_ls_test_graph(
     angular_momentum_magnitude, coupled_spin_magnitude, particle
 ):
     graph = StateTransitionGraph[ParticleWithSpin](
-        topology=Topology(nodes={0}, edges={0: Edge(None, 0)}),
+        topology=Topology(
+            nodes={0},  # type: ignore
+            edges={0: Edge(None, 0)},
+        ),
         node_props={
             0: InteractionProperties(
                 s_magnitude=coupled_spin_magnitude,
@@ -224,7 +227,10 @@ def make_ls_test_graph_scrambled(
     angular_momentum_magnitude, coupled_spin_magnitude, particle
 ):
     graph = StateTransitionGraph[ParticleWithSpin](
-        topology=Topology(nodes={0}, edges={0: Edge(None, 0)}),
+        topology=Topology(
+            nodes={0},  # type: ignore
+            edges={0: Edge(None, 0)},
+        ),
         node_props={
             0: InteractionProperties(
                 l_magnitude=angular_momentum_magnitude,

--- a/tests/unit/reaction/test_system_control.py
+++ b/tests/unit/reaction/test_system_control.py
@@ -380,14 +380,14 @@ def test_edge_swap(particle_database, initial_state, final_state):
         )
         edge_keys = list(ref_mapping.keys())
         edge1 = edge_keys[0]
-        edge1_val = graph.edges[edge1]
+        edge1_val = graph.topology.edges[edge1]
         edge1_props = deepcopy(graph.get_edge_props(edge1))
         edge2 = edge_keys[1]
-        edge2_val = graph.edges[edge2]
+        edge2_val = graph.topology.edges[edge2]
         edge2_props = deepcopy(graph.get_edge_props(edge2))
         graph.swap_edges(edge1, edge2)
-        assert graph.edges[edge1] == edge2_val
-        assert graph.edges[edge2] == edge1_val
+        assert graph.topology.edges[edge1] == edge2_val
+        assert graph.topology.edges[edge2] == edge1_val
         assert graph.get_edge_props(edge1) == edge2_props
         assert graph.get_edge_props(edge2) == edge1_props
 

--- a/tests/unit/reaction/test_system_control.py
+++ b/tests/unit/reaction/test_system_control.py
@@ -510,10 +510,10 @@ def test_external_edge_identical_particle_combinatorics(
     assert len(comb_graphs) == result_graph_count
 
     ref_mapping_fs = _create_edge_id_particle_mapping(
-        comb_graphs[0], comb_graphs[0].get_final_state_edge_ids()
+        comb_graphs[0], comb_graphs[0].topology.outgoing_edge_ids
     )
     ref_mapping_is = _create_edge_id_particle_mapping(
-        comb_graphs[0], comb_graphs[0].get_initial_state_edge_ids()
+        comb_graphs[0], comb_graphs[0].topology.incoming_edge_ids
     )
 
     for group in comb_graphs[1:]:

--- a/tests/unit/reaction/test_topology.py
+++ b/tests/unit/reaction/test_topology.py
@@ -190,9 +190,9 @@ class TestTopology:
         topology = two_to_three_decay  # shorter name
         assert get_originating_node_list(topology, edge_ids=[0]) == []
         assert get_originating_node_list(topology, edge_ids=[5, 6]) == [2, 2]
-        assert topology.get_initial_state_edge_ids() == [0, 1]
-        assert topology.get_final_state_edge_ids() == [4, 5, 6]
-        assert topology.get_intermediate_state_edge_ids() == [2, 3]
+        assert topology.incoming_edge_ids == {0, 1}
+        assert topology.outgoing_edge_ids == {4, 5, 6}
+        assert topology.intermediate_edge_ids == {2, 3}
 
     @staticmethod
     def test_swap_edges(two_to_three_decay: Topology):
@@ -237,12 +237,9 @@ def test_create_isobar_topologies(
         n_expected_nodes = n_final - 1
         n_intermediate_edges = n_final - 2
         for topology in topologies:
-            assert len(topology.get_initial_state_edge_ids()) == n_initial
-            assert len(topology.get_final_state_edge_ids()) == n_final
-            assert (
-                len(topology.get_intermediate_state_edge_ids())
-                == n_intermediate_edges
-            )
+            assert len(topology.incoming_edge_ids) == n_initial
+            assert len(topology.outgoing_edge_ids) == n_final
+            assert len(topology.intermediate_edge_ids) == n_intermediate_edges
             assert len(topology.nodes) == n_expected_nodes
 
 
@@ -266,7 +263,7 @@ def test_create_n_body_topology(n_initial: int, n_final: int, exception):
             create_n_body_topology(n_initial, n_final)
     else:
         topology = create_n_body_topology(n_initial, n_final)
-        assert len(topology.get_initial_state_edge_ids()) == n_initial
-        assert len(topology.get_final_state_edge_ids()) == n_final
-        assert len(topology.get_intermediate_state_edge_ids()) == 0
+        assert len(topology.incoming_edge_ids) == n_initial
+        assert len(topology.outgoing_edge_ids) == n_final
+        assert len(topology.intermediate_edge_ids) == 0
         assert len(topology.nodes) == 1

--- a/tests/unit/reaction/test_topology.py
+++ b/tests/unit/reaction/test_topology.py
@@ -1,6 +1,8 @@
 # flake8: noqa
 # pylint: disable=no-self-use, redefined-outer-name, too-many-arguments
 
+import typing
+
 import attr
 import pytest
 
@@ -55,6 +57,18 @@ class TestEdge:
         assert edge.get_connected_nodes() == {3}
         edge = Edge(ending_node_id=4)
         assert edge.get_connected_nodes() == {4}
+
+    @typing.no_type_check
+    def test_immutability(self):
+        edge = Edge(1, 2)
+        with pytest.raises(attr.exceptions.FrozenInstanceError):
+            edge.originating_node_id = None
+        with pytest.raises(attr.exceptions.FrozenInstanceError):
+            edge.originating_node_id += 1
+        with pytest.raises(attr.exceptions.FrozenInstanceError):
+            edge.ending_node_id = None
+        with pytest.raises(attr.exceptions.FrozenInstanceError):
+            edge.ending_node_id += 1
 
 
 class TestInteractionNode:
@@ -193,6 +207,23 @@ class TestTopology:
         assert topology.incoming_edge_ids == {0, 1}
         assert topology.outgoing_edge_ids == {4, 5, 6}
         assert topology.intermediate_edge_ids == {2, 3}
+
+    @staticmethod
+    @typing.no_type_check
+    def test_immutability(two_to_three_decay: Topology):
+        with pytest.raises(attr.exceptions.FrozenInstanceError):
+            two_to_three_decay.edges = {0: Edge(None, None)}
+        with pytest.raises(TypeError):
+            two_to_three_decay.edges[0] = Edge(None, None)
+        with pytest.raises(attr.exceptions.FrozenInstanceError):
+            two_to_three_decay.edges[0].ending_node_id = None
+        with pytest.raises(attr.exceptions.FrozenInstanceError):
+            two_to_three_decay.nodes = {0, 1}
+        with pytest.raises(AttributeError):
+            two_to_three_decay.nodes.add(2)
+        for node in two_to_three_decay.nodes:
+            node += 666
+        assert two_to_three_decay.nodes == {0, 1, 2}
 
     @staticmethod
     def test_swap_edges(two_to_three_decay: Topology):

--- a/tests/unit/reaction/test_topology.py
+++ b/tests/unit/reaction/test_topology.py
@@ -11,6 +11,7 @@ from expertsystem.reaction.topology import (
     Topology,
     create_isobar_topologies,
     create_n_body_topology,
+    get_originating_node_list,
 )
 
 
@@ -176,8 +177,8 @@ class TestTopology:
     @staticmethod
     def test_getters(two_to_three_decay: Topology):
         topology = two_to_three_decay  # shorter name
-        assert topology.get_originating_node_list([0]) == []
-        assert topology.get_originating_node_list([5, 6]) == [2, 2]
+        assert get_originating_node_list(topology, edge_ids=[0]) == []
+        assert get_originating_node_list(topology, edge_ids=[5, 6]) == [2, 2]
         assert topology.get_initial_state_edge_ids() == [0, 1]
         assert topology.get_final_state_edge_ids() == [4, 5, 6]
         assert topology.get_intermediate_state_edge_ids() == [2, 3]


### PR DESCRIPTION
The `StateTransitionGraph` is a mapping of properties onto an underlying topology structure. It therefore behaves like a collection of `dict`s, whether the keys are the edge and node IDs of the topology. Currently, the underlying `Topology` is, however, mutable and therefore does not serve well as a collection to map properties onto.

This results in subtle bugs. For instance, the `StateTransitionGraph` falsely protects its underlying `Topology` by dundering it and not exposing it as a `property`. I say falsely, because the `Topology.edges` are still exposed (example from the `stable` branch):

https://github.com/ComPWA/expertsystem/blob/1fb82ffabb1d384454b3790f7689e215ade12f73/src/expertsystem/reaction/topology.py#L369-L371

This allows one to modify the underlying topology as follows:

```python
# graph: StateTransitionGraph
graph.edges[666] = "gotcha!"
```

Another problem is that references to the same topology are being carried around by `ProblemSet` and `QNProblemSet`. There is no assurance that they change 'their' `topology` somewhere else in the code.

**Additional motivation**
Eventually, I would like to introduce a new class in addition to the `StateTransitionGraph`. This class (`StateTransition`) is an **immutable and hashable** mapping of `Particle` instances with a `float` spin projection to the edges of a topology. An overarching `StateTransitionCollection` (a `set` of `StateTransition`s) then provides a complete description of the allowed state transitions between some initial and final states.

The key difference between `StateTransitionGraph` and `StateTransition` is that the latter is immutable (and can therefore be made hashable). The `STG` is then only used within the `reaction` module (particularly `solving`), while `StateTransitionCollection` is the product that the `reaction` submodule produces. In that sense, we generally get:

- `expertsystem.particle` produces a `ParticleCollection`
- `expertsystem.reaction` produces a `StateTransitionCollection`
- `expertsystem.reaction` produces a `sympy.Expr` (see [ADR-001](https://pwa.readthedocs.io/projects/expertsystem/en/latest/adr/001.html))

At any rate, this is yet another class that maps onto an underlying topology. So I do not want to have this risk of carrying around a reference to some mutable topology as well as having to falsely hide it and then needing to yet again provide getter methods like `get_final_state_edge_ids`.

More thoughts at https://github.com/ComPWA/expertsystem/pull/470#issuecomment-772589710