### PR TITLE
fix: narrow down type hints

### DIFF
--- a/src/expertsystem/reaction/topology.py
+++ b/src/expertsystem/reaction/topology.py
@@ -322,7 +322,9 @@ class StateTransitionGraph(Generic[EdgeType]):
     topology: Topology = attr.ib(converter=_copy_topology)
     node_props: Dict[int, InteractionProperties] = attr.ib(factory=dict)
     edge_props: Dict[int, EdgeType] = attr.ib(factory=dict)
-    graph_node_properties_comparator: Optional[Callable] = attr.ib(
+    graph_node_properties_comparator: Optional[
+        Callable[[InteractionProperties, InteractionProperties], bool]
+    ] = attr.ib(
         default=None,
         validator=attr.validators.optional(attr.validators.is_callable()),
         on_setattr=attr.setters.NO_OP,

--- a/src/expertsystem/reaction/topology.py
+++ b/src/expertsystem/reaction/topology.py
@@ -494,7 +494,9 @@ class SimpleStateTransitionTopologyBuilder:
     ) -> None:
         if not isinstance(interaction_node_set, list):
             raise TypeError("interaction_node_set must be a list")
-        self.interaction_node_set = list(interaction_node_set)
+        self.interaction_node_set: List[InteractionNode] = list(
+            interaction_node_set
+        )
 
     def build_graphs(
         self, number_of_initial_edges: int, number_of_final_edges: int

--- a/src/expertsystem/reaction/topology.py
+++ b/src/expertsystem/reaction/topology.py
@@ -512,12 +512,14 @@ class SimpleStateTransitionTopologyBuilder:
 
         logging.info("building topology graphs...")
         # result list
-        graph_tuple_list = []
+        graph_tuple_list: List[Tuple[Topology, List[int]]] = []
         # create seed graph
         seed_graph = Topology()
         current_open_end_edges = list(range(number_of_initial_edges))
         seed_graph.add_edges(current_open_end_edges)
-        extendable_graph_list = [(seed_graph, current_open_end_edges)]
+        extendable_graph_list: List[Tuple[Topology, List[int]]] = [
+            (seed_graph, current_open_end_edges)
+        ]
 
         while extendable_graph_list:
             active_graph_list = extendable_graph_list

--- a/tests/unit/reaction/test_combinatorics.py
+++ b/tests/unit/reaction/test_combinatorics.py
@@ -4,6 +4,7 @@ from math import factorial
 
 import pytest
 
+from expertsystem.particle import ParticleCollection
 from expertsystem.reaction.combinatorics import (
     _generate_kinematic_permutations,
     _generate_outer_edge_permutations,
@@ -42,7 +43,9 @@ def three_body_decay() -> Topology:
     ],
 )
 def test_initialize_graph(
-    final_state_groupings, three_body_decay, particle_database
+    final_state_groupings,
+    three_body_decay: Topology,
+    particle_database: ParticleCollection,
 ):
     initial_facts = create_initial_facts(
         three_body_decay,
@@ -64,7 +67,10 @@ def test_initialize_graph(
     ],
 )
 def test_generate_outer_edge_permutations(
-    initial_state, final_state, three_body_decay, particle_database
+    initial_state,
+    final_state,
+    three_body_decay: Topology,
+    particle_database: ParticleCollection,
 ):
     initial_state_with_spins = _safe_set_spin_projections(
         initial_state, particle_database
@@ -99,7 +105,7 @@ class TestKinematicRepresentation:
         assert representation.final_state == [["gamma", "pi0"]]
 
     @staticmethod
-    def test_from_topology(three_body_decay):
+    def test_from_topology(three_body_decay: Topology):
         pi0 = ("pi0", [0])
         gamma = ("gamma", [-1, 1])
         edge_props = {0: ("J/psi", [-1, +1]), 2: pi0, 3: pi0, 4: gamma}
@@ -160,7 +166,9 @@ class TestKinematicRepresentation:
             assert ["should be nested list"] in kinematic_representation
 
 
-def test_generate_permutations(three_body_decay, particle_database):
+def test_generate_permutations(
+    three_body_decay: Topology, particle_database: ParticleCollection
+):
     permutations = _generate_kinematic_permutations(
         three_body_decay,
         initial_state=[("J/psi(1S)", [-1, +1])],

--- a/tests/unit/reaction/test_system_control.py
+++ b/tests/unit/reaction/test_system_control.py
@@ -1,5 +1,6 @@
 # pylint: disable=protected-access
 from copy import deepcopy
+from typing import List
 
 import pytest
 
@@ -340,7 +341,9 @@ class TestSolutionFilter:  # pylint: disable=no-self-use
         assert len(filtered_graphs) == result
 
 
-def _create_graph(problem_set: ProblemSet):
+def _create_graph(
+    problem_set: ProblemSet,
+) -> StateTransitionGraph[ParticleWithSpin]:
     return StateTransitionGraph[ParticleWithSpin](
         topology=problem_set.topology,
         node_props=problem_set.initial_facts.node_props,
@@ -369,7 +372,7 @@ def test_edge_swap(particle_database, initial_state, final_state):
     stm.set_allowed_interaction_types([InteractionTypes.Strong])
 
     problem_sets = stm.create_problem_sets()
-    init_graphs = []
+    init_graphs: List[StateTransitionGraph[ParticleWithSpin]] = []
     for _, problem_set_list in problem_sets.items():
         init_graphs.extend([_create_graph(x) for x in problem_set_list])
 
@@ -416,7 +419,7 @@ def test_match_external_edges(particle_database, initial_state, final_state):
     stm.set_allowed_interaction_types([InteractionTypes.Strong])
 
     problem_sets = stm.create_problem_sets()
-    init_graphs = []
+    init_graphs: List[StateTransitionGraph[ParticleWithSpin]] = []
     for _, problem_set_list in problem_sets.items():
         init_graphs.extend([_create_graph(x) for x in problem_set_list])
 
@@ -499,7 +502,7 @@ def test_external_edge_identical_particle_combinatorics(
 
     match_external_edges(init_graphs)
 
-    comb_graphs = []
+    comb_graphs: List[StateTransitionGraph[ParticleWithSpin]] = []
     for group in init_graphs:
         comb_graphs.extend(
             perform_external_edge_identical_particle_combinatorics(group)

--- a/tests/unit/reaction/test_topology.py
+++ b/tests/unit/reaction/test_topology.py
@@ -147,14 +147,14 @@ class TestTopology:
             assert Topology(nodes=nodes, edges=edges)
 
     @staticmethod
-    def test_repr_and_eq(two_to_three_decay):
+    def test_repr_and_eq(two_to_three_decay: Topology):
         topology = eval(str(two_to_three_decay))  # pylint: disable=eval-used
         assert topology == two_to_three_decay
         with pytest.raises(NotImplementedError):
             assert topology == float()
 
     @staticmethod
-    def test_add_and_attach(two_to_three_decay):
+    def test_add_and_attach(two_to_three_decay: Topology):
         topology = deepcopy(two_to_three_decay)
         topology.add_node(3)
         topology.add_edges([7, 8])
@@ -162,10 +162,10 @@ class TestTopology:
         with pytest.raises(ValueError):
             topology.verify()
         topology.attach_edges_to_node_ingoing([6], 3)
-        assert topology.verify() is None
+        topology.verify()
 
     @staticmethod
-    def test_add_exceptions(two_to_three_decay):
+    def test_add_exceptions(two_to_three_decay: Topology):
         with pytest.raises(ValueError):
             two_to_three_decay.add_node(0)
         with pytest.raises(ValueError):
@@ -180,8 +180,8 @@ class TestTopology:
             two_to_three_decay.attach_edges_to_node_outgoing([7], 2)
 
     @staticmethod
-    def test_getters(two_to_three_decay):
-        topology: Topology = two_to_three_decay  # shorter name
+    def test_getters(two_to_three_decay: Topology):
+        topology = two_to_three_decay  # shorter name
         assert topology.get_originating_node_list([0]) == []
         assert topology.get_originating_node_list([5, 6]) == [2, 2]
         assert topology.get_initial_state_edge_ids() == [0, 1]
@@ -189,7 +189,7 @@ class TestTopology:
         assert topology.get_intermediate_state_edge_ids() == [2, 3]
 
     @staticmethod
-    def test_swap(two_to_three_decay):
+    def test_swap(two_to_three_decay: Topology):
         topology = deepcopy(two_to_three_decay)
         topology.swap_edges(0, 1)
         assert topology == two_to_three_decay

--- a/tox.ini
+++ b/tox.ini
@@ -107,7 +107,7 @@ allowlist_externals =
     mypy
     pre-commit
 commands =
-    mypy src .  # run separately because of potential caching problems
+    mypy src tests  # run separately because of potential caching problems
     pre-commit run {posargs} -a
     - bash -ec "cspell --no-progress $(git ls-files)"
 


### PR DESCRIPTION
_Spin-off from #470_

Sometimes test fails for reasons that could have been pointed out with static typing. This PR fixes some of those problems by narrowing down the type hints.