### PR TITLE
fix: use Iterable or Sized where possible

### DIFF
--- a/src/expertsystem/amplitude/canonical_decay.py
+++ b/src/expertsystem/amplitude/canonical_decay.py
@@ -84,10 +84,11 @@ def _clebsch_gordan_decorator(
             )
 
         in_edge_ids = graph.get_edge_ids_ingoing_to_node(node_id)
+        in_edge_id = next(iter(in_edge_ids))
 
         parent_spin = Spin(
-            graph.get_edge_props(in_edge_ids[0])[0].spin,
-            graph.get_edge_props(in_edge_ids[0])[1],
+            graph.get_edge_props(in_edge_id)[0].spin,
+            graph.get_edge_props(in_edge_id)[1],
         )
 
         daughter_spins: List[Spin] = []

--- a/src/expertsystem/amplitude/helicity_decay.py
+++ b/src/expertsystem/amplitude/helicity_decay.py
@@ -84,10 +84,11 @@ def _get_graph_group_unique_label(
 ) -> str:
     label = ""
     if graph_group:
-        ise = graph_group[0].get_initial_state_edge_ids()
-        fse = graph_group[0].get_final_state_edge_ids()
-        is_names = _get_name_hel_list(graph_group[0], ise)
-        fs_names = _get_name_hel_list(graph_group[0], fse)
+        first_graph = next(iter(graph_group))
+        ise = first_graph.topology.get_initial_state_edge_ids()
+        fse = first_graph.topology.get_final_state_edge_ids()
+        is_names = _get_name_hel_list(first_graph, ise)
+        fs_names = _get_name_hel_list(first_graph, fse)
         label += (
             _generate_particles_string(is_names)
             + "_to_"
@@ -136,7 +137,7 @@ def _get_recoil_edge(
             f"The node with id {node_id} has more than 2 outgoing edges:\n"
             + str(graph)
         )
-    return outgoing_edges[0]
+    return next(iter(outgoing_edges))
 
 
 def _get_parent_recoil_edge(
@@ -152,7 +153,8 @@ def _get_parent_recoil_edge(
             f"The node with id {node_id} does not have a single ingoing edge!\n"
             + str(graph)
         )
-    return _get_recoil_edge(graph, ingoing_edges[0])
+    ingoing_edge = next(iter(ingoing_edges))
+    return _get_recoil_edge(graph, ingoing_edge)
 
 
 def _get_prefactor(
@@ -504,7 +506,7 @@ class HelicityAmplitudeGenerator:
         in_edge_ids = graph.get_edge_ids_ingoing_to_node(node_id)
         if len(in_edge_ids) != 1:
             raise ValueError("This node does not represent a two body decay!")
-        ingoing_edge_id = in_edge_ids[0]
+        ingoing_edge_id = next(iter(in_edge_ids))
         edge_props = graph.get_edge_props(ingoing_edge_id)
         helicity_particle = create_helicity_particle(edge_props)
         helicity_decay = HelicityDecay(helicity_particle, decay_products)

--- a/src/expertsystem/amplitude/helicity_decay.py
+++ b/src/expertsystem/amplitude/helicity_decay.py
@@ -1,7 +1,7 @@
 """Implementation of the helicity formalism for amplitude model generation."""
 
 import logging
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Dict, Iterable, List, Optional, Tuple, Union
 
 from expertsystem.particle import ParticleCollection, Spin
 from expertsystem.reaction import Result
@@ -189,7 +189,7 @@ def _generate_kinematics(result: Result) -> Kinematics:
 
 
 def _generate_particles_string(
-    name_hel_list: List[Tuple[str, float]],
+    name_hel_list: Iterable[Tuple[str, float]],
     use_helicity: bool = True,
     make_parity_partner: bool = False,
 ) -> str:
@@ -206,7 +206,7 @@ def _generate_particles_string(
 
 
 def _get_name_hel_list(
-    graph: StateTransitionGraph[ParticleWithSpin], edge_ids: List[int]
+    graph: StateTransitionGraph[ParticleWithSpin], edge_ids: Iterable[int]
 ) -> List[Tuple[str, float]]:
     name_hel_list = []
     for i in edge_ids:
@@ -430,7 +430,8 @@ class HelicityAmplitudeGenerator:
         return incoherent_intensity
 
     def __create_parameter_couplings(
-        self, graph_groups: List[List[StateTransitionGraph[ParticleWithSpin]]]
+        self,
+        graph_groups: Iterable[List[StateTransitionGraph[ParticleWithSpin]]],
     ) -> None:
         for graph_group in graph_groups:
             for graph in graph_group:

--- a/src/expertsystem/io/_dot.py
+++ b/src/expertsystem/io/_dot.py
@@ -3,7 +3,7 @@
 See :doc:`/usage/visualization` for more info.
 """
 
-from typing import Any, Callable, List, Optional
+from typing import Any, Callable, Iterable, List, Optional
 
 from expertsystem.particle import Particle, ParticleCollection
 from expertsystem.reaction.topology import StateTransitionGraph, Topology
@@ -78,7 +78,7 @@ def __node_name(edge_id: int, node_id: Optional[int] = None) -> str:
     return f"node{node_id}"
 
 
-def __rank_string(node_edge_ids: List[int], prefix: str = "") -> str:
+def __rank_string(node_edge_ids: Iterable[int], prefix: str = "") -> str:
     name_list = [f'"{prefix}{__node_name(i)}"' for i in node_edge_ids]
     name_string = ", ".join(name_list)
     return _DOT_RANK_SAME.format(name_string)

--- a/src/expertsystem/reaction/__init__.py
+++ b/src/expertsystem/reaction/__init__.py
@@ -202,7 +202,7 @@ class Result:
             raise ValueError(
                 f"No solutions in {self.__class__.__name__} object"
             )
-        return self.solutions[0]
+        return next(iter(self.solutions))
 
     def get_intermediate_particles(self) -> ParticleCollection:
         """Extract the names of the intermediate state particles."""

--- a/src/expertsystem/reaction/combinatorics.py
+++ b/src/expertsystem/reaction/combinatorics.py
@@ -14,11 +14,13 @@ from typing import (
     Callable,
     Dict,
     Generator,
+    Iterable,
     List,
     Mapping,
     Optional,
     Sequence,
     Set,
+    Sized,
     Tuple,
     Union,
 )
@@ -202,12 +204,12 @@ def _get_kinematic_representation(
     """
 
     def get_state_groupings(
-        edge_per_node_getter: Callable[[int], List[int]]
-    ) -> List[List[int]]:
+        edge_per_node_getter: Callable[[int], Iterable[int]]
+    ) -> List[Iterable[int]]:
         return [edge_per_node_getter(i) for i in topology.nodes]
 
     def fill_groupings(
-        grouping_with_ids: List[List[int]],
+        grouping_with_ids: Iterable[Iterable[int]],
     ) -> List[List[StateWithSpins]]:
         return [
             [initial_facts[edge_id] for edge_id in group]
@@ -277,7 +279,7 @@ def _generate_kinematic_permutations(
     ] = None,
 ) -> List[Dict[int, StateWithSpins]]:
     def assert_number_of_states(
-        state_definitions: Sequence, edge_ids: Sequence[int]
+        state_definitions: Sized, edge_ids: Sized
     ) -> None:
         if len(state_definitions) != len(edge_ids):
             raise ValueError(
@@ -412,13 +414,13 @@ def _generate_spin_permutations(
 
 def __get_initial_state_edge_ids(
     graph: StateTransitionGraph[ParticleWithSpin],
-) -> List[int]:
+) -> Iterable[int]:
     return graph.get_initial_state_edge_ids()
 
 
 def __get_final_state_edge_ids(
     graph: StateTransitionGraph[ParticleWithSpin],
-) -> List[int]:
+) -> Iterable[int]:
     return graph.get_final_state_edge_ids()
 
 
@@ -440,7 +442,7 @@ def _match_external_edge_ids(  # pylint: disable=too-many-locals
     graphs: List[StateTransitionGraph[ParticleWithSpin]],
     ref_graph_id: int,
     external_edge_getter_function: Callable[
-        [StateTransitionGraph], Sequence[int]
+        [StateTransitionGraph], Iterable[int]
     ],
 ) -> None:
     ref_graph = graphs[ref_graph_id]
@@ -502,7 +504,7 @@ def perform_external_edge_identical_particle_combinatorics(
 def _external_edge_identical_particle_combinatorics(
     graph: StateTransitionGraph[ParticleWithSpin],
     external_edge_getter_function: Callable[
-        [StateTransitionGraph], Sequence[int]
+        [StateTransitionGraph], Iterable[int]
     ],
 ) -> List[StateTransitionGraph]:
     # pylint: disable=too-many-locals
@@ -560,7 +562,7 @@ def _calculate_swappings(id_mapping: Dict[int, int]) -> OrderedDict:
 
 
 def _create_edge_id_particle_mapping(
-    graph: StateTransitionGraph[ParticleWithSpin], edge_ids: Sequence[int]
+    graph: StateTransitionGraph[ParticleWithSpin], edge_ids: Iterable[int]
 ) -> Dict[int, str]:
     return {
         i: graph.get_edge_props(i)[0].name

--- a/src/expertsystem/reaction/solving.py
+++ b/src/expertsystem/reaction/solving.py
@@ -20,9 +20,9 @@ from typing import (
     Callable,
     Dict,
     Generic,
+    Iterable,
     List,
     Optional,
-    Sequence,
     Set,
     Tuple,
     Type,
@@ -323,7 +323,7 @@ def validate_full_solution(problem_set: QNProblemSet) -> QNResult:
         return variables
 
     def _create_edge_variables(
-        edge_ids: Sequence[int],
+        edge_ids: Iterable[int],
         qn_list: Set[Type[EdgeQuantumNumber]],
     ) -> List[dict]:
         """Create variables for the quantum numbers of the specified edges.
@@ -762,7 +762,7 @@ class CSPSolver(Solver):
 
     def __create_edge_variables(
         self,
-        edge_ids: Sequence[int],
+        edge_ids: Iterable[int],
         qn_list: Set[Type[EdgeQuantumNumber]],
         problem_set: QNProblemSet,
     ) -> Tuple[Set[_EdgeVariableInfo], Dict[int, GraphEdgePropertyMap]]:

--- a/src/expertsystem/reaction/topology.py
+++ b/src/expertsystem/reaction/topology.py
@@ -492,7 +492,7 @@ class SimpleStateTransitionTopologyBuilder:
     """
 
     def __init__(
-        self, interaction_node_set: Sequence[InteractionNode]
+        self, interaction_node_set: Iterable[InteractionNode]
     ) -> None:
         if not isinstance(interaction_node_set, list):
             raise TypeError("interaction_node_set must be a list")
@@ -582,7 +582,7 @@ class SimpleStateTransitionTopologyBuilder:
 def _attach_node_to_edges(
     graph: Tuple[Topology, Sequence[int]],
     interaction_node: InteractionNode,
-    ingoing_edge_ids: Sequence[int],
+    ingoing_edge_ids: Iterable[int],
 ) -> Tuple[Topology, List[int]]:
     temp_graph = copy.deepcopy(graph[0])
     new_open_end_lines = list(copy.deepcopy(graph[1]))

--- a/tests/unit/reaction/test_solving.py
+++ b/tests/unit/reaction/test_solving.py
@@ -40,8 +40,8 @@ class TestResult:
         assert len(particle_graphs) == 2
         collapsed_graphs = result.collapse_graphs()
         assert len(collapsed_graphs) == 1
-        graph = collapsed_graphs[0]
-        edge_id = graph.get_intermediate_state_edge_ids()[0]
+        graph = next(iter(collapsed_graphs))
+        edge_id = next(iter(graph.get_intermediate_state_edge_ids()))
         f_resonances = pdg.filter(
             lambda p: p.name in ["f(0)(980)", "f(0)(1500)"]
         )


### PR DESCRIPTION
Many existing interfaces use `Sequence` where the implementation only iterates over the sequence. So `Iterable` (and in one case `Sized`) is more appropriate.

Note: this allows switching from `list` to `set`, see #470.