### PR TITLE
refactor: remove graph_node_comparator from STG

### DIFF
--- a/src/expertsystem/reaction/__init__.py
+++ b/src/expertsystem/reaction/__init__.py
@@ -55,7 +55,6 @@ from expertsystem.reaction.conservation_rules import (
 )
 
 from ._system_control import (
-    CompareGraphNodePropertiesFunctor,
     GammaCheck,
     InteractionDeterminator,
     LeptonCheck,
@@ -793,9 +792,6 @@ class StateTransitionManager:  # pylint: disable=too-many-instance-attributes
                     i: create_particle(x, self.__particles)
                     for i, x in solution.edge_quantum_numbers.items()
                 },
-            )
-            graph.graph_node_properties_comparator = (
-                CompareGraphNodePropertiesFunctor()
             )
             solutions.append(graph)
 

--- a/src/expertsystem/reaction/topology.py
+++ b/src/expertsystem/reaction/topology.py
@@ -531,30 +531,6 @@ class StateTransitionGraph(Generic[EdgeType]):
     def edges(self) -> Dict[int, Edge]:
         return self.topology.edges
 
-    def __eq__(self, other: object) -> bool:
-        if isinstance(other, StateTransitionGraph):
-            if self.nodes != other.nodes:
-                return False
-            if self.edges != other.edges:
-                return False
-            if any(
-                self.get_edge_props(i) != other.get_edge_props(i)
-                for i in self.edges
-            ):
-                return False
-            if self.graph_node_properties_comparator is not None:
-                return all(
-                    self.graph_node_properties_comparator(
-                        self.get_node_props(i), other.get_node_props(i)
-                    )
-                    for i in self.nodes
-                )
-            return all(
-                self.get_node_props(i) == other.get_node_props(i)
-                for i in self.nodes
-            )
-        raise NotImplementedError
-
     def get_initial_state_edge_ids(self) -> List[int]:
         return self.topology.get_initial_state_edge_ids()
 

--- a/tests/unit/reaction/test_system_control.py
+++ b/tests/unit/reaction/test_system_control.py
@@ -11,7 +11,6 @@ from expertsystem.reaction import (
     StateTransitionManager,
 )
 from expertsystem.reaction._system_control import (
-    CompareGraphNodePropertiesFunctor,
     create_edge_properties,
     filter_graphs,
     remove_duplicate_solutions,
@@ -218,9 +217,6 @@ def make_ls_test_graph(
         },
         edge_props={0: (particle, 0)},
     )
-    graph.graph_node_properties_comparator = (
-        CompareGraphNodePropertiesFunctor()
-    )
     return graph
 
 
@@ -237,10 +233,6 @@ def make_ls_test_graph_scrambled(
         },
         edge_props={0: (particle, 0)},
     )
-    graph.graph_node_properties_comparator = (
-        CompareGraphNodePropertiesFunctor()
-    )
-
     return graph
 
 


### PR DESCRIPTION
The `StateTransitionGraph.compare` method provides a sufficient handle to compare graphs. So better not to have an STG carry around its own comparator (the `STG` is in first instance just a mapping of edge and node properties for some underlying topology).