### PR TITLE
refactor: rename solutions to transitions

### DIFF
--- a/docs/usage/visualization.ipynb
+++ b/docs/usage/visualization.ipynb
@@ -72,7 +72,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "{ref}`As noted in the usual workflow <usage/workflow:1.3. Find solutions>`, the {attr}`~.Result.solutions` contain all spin projection combinations (which is necessary for the {mod}`~expertsystem.amplitude` module). It is possible to convert all these solutions to DOT language with {func}`~.convert_to_dot`. To avoid visualizing all solutions, we just take a subset of the {attr}`~.Result.solutions`:"
+    "{ref}`As noted in the usual workflow <usage/workflow:1.3. Find solutions>`, the {attr}`~.Result.transitions` contain all spin projection combinations (which is necessary for the {mod}`~expertsystem.amplitude` module). It is possible to convert all these solutions to DOT language with {func}`~.convert_to_dot`. To avoid visualizing all solutions, we just take a subset of the {attr}`~.Result.transitions`:"
    ]
   },
   {
@@ -82,7 +82,7 @@
    "outputs": [],
    "source": [
     "dot_source = es.io.convert_to_dot(\n",
-    "    result.solutions[::50][:3]\n",
+    "    result.transitions[::50][:3]\n",
     ")  # just some selection"
    ]
   },
@@ -128,7 +128,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "es.io.write(result.solutions, \"decay_topologies_with_spin.gv\")"
+    "es.io.write(result.transitions, \"decay_topologies_with_spin.gv\")"
    ]
   },
   {
@@ -142,7 +142,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Since this list of all possible spin projections {attr}`~.Result.solutions` is rather long, it is often useful to make use of the  {meth}`~.Result.get_particle_graphs` or {meth}`~.Result.collapse_graphs` methods to bundle comparable graphs. First, {meth}`~.get_particle_graphs` allows one collapse (ignore) the spin projections (we again show a selection only):"
+    "Since this list of all possible spin projections {attr}`~.Result.transitions` is rather long, it is often useful to make use of the  {meth}`~.Result.get_particle_graphs` or {meth}`~.Result.collapse_graphs` methods to bundle comparable graphs. First, {meth}`~.get_particle_graphs` allows one collapse (ignore) the spin projections (we again show a selection only):"
    ]
   },
   {

--- a/docs/usage/workflow.ipynb
+++ b/docs/usage/workflow.ipynb
@@ -202,7 +202,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The {meth}`~.StateTransitionManager.find_solutions` method returns a {class}`~.Result` object from which you can extract the {attr}`~.Result.solutions`. Now, you can use {meth}`~.Result.get_intermediate_particles` to print the names of the intermediate states that the {class}`~.StateTransitionManager` found:"
+    "The {meth}`~.StateTransitionManager.find_solutions` method returns a {class}`~.Result` object from which you can extract the {attr}`~.Result.transitions`. Now, you can use {meth}`~.Result.get_intermediate_particles` to print the names of the intermediate states that the {class}`~.StateTransitionManager` found:"
    ]
   },
   {
@@ -211,7 +211,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(\"found\", len(result.solutions), \"solutions!\")\n",
+    "print(\"found\", len(result.transitions), \"solutions!\")\n",
     "result.get_intermediate_particles().names"
    ]
   },
@@ -224,9 +224,9 @@
     "class: dropdown\n",
     "----\n",
     "\n",
-    "The \"number of {attr}`~.Result.solutions`\" is the total number of allowed {obj}`.StateTransitionGraph` instances that the {class}`.StateTransitionManager` has found. This also includes all allowed **spin projection combinations**. In this channel, we for example consider a $J/\\psi$ with spin projection $\\pm1$ that decays into a $\\gamma$ with spin projection $\\pm1$, which already gives us four possibilities.\n",
+    "The \"number of {attr}`~.Result.transitions`\" is the total number of allowed {obj}`.StateTransitionGraph` instances that the {class}`.StateTransitionManager` has found. This also includes all allowed **spin projection combinations**. In this channel, we for example consider a $J/\\psi$ with spin projection $\\pm1$ that decays into a $\\gamma$ with spin projection $\\pm1$, which already gives us four possibilities.\n",
     "\n",
-    "On the other hand, the intermediate state names that was extracted with {meth}`.Result.get_intermediate_particles`, is just a {obj}`set` of the state names on the intermediate edges of the list of {attr}`~.Result.solutions`, regardless of spin projection.\n",
+    "On the other hand, the intermediate state names that was extracted with {meth}`.Result.get_intermediate_particles`, is just a {obj}`set` of the state names on the intermediate edges of the list of {attr}`~.Result.transitions`, regardless of spin projection.\n",
     "    \n",
     "```{tip}\n",
     "Have a look at {meth}`.Result.get_particle_graphs`, if you want to extract a {obj}`list` of {class}`.StateTransitionGraph` s of which the spin projections have been stripped. This is especially useful when [visualizing the decay topologies](/usage/visualization).\n",
@@ -258,7 +258,7 @@
     "problem_sets = stm.create_problem_sets()\n",
     "result = stm.find_solutions(problem_sets)\n",
     "\n",
-    "print(\"found\", len(result.solutions), \"solutions!\")\n",
+    "print(\"found\", len(result.transitions), \"solutions!\")\n",
     "result.get_intermediate_particles().names"
    ]
   },
@@ -285,7 +285,7 @@
     "problem_sets = stm.create_problem_sets()\n",
     "result = stm.find_solutions(problem_sets)\n",
     "\n",
-    "print(\"found\", len(result.solutions), \"solutions!\")\n",
+    "print(\"found\", len(result.transitions), \"solutions!\")\n",
     "result.get_intermediate_particles().names"
    ]
   },
@@ -325,7 +325,7 @@
     "\n",
     "result = stm.find_solutions(problem_sets)\n",
     "\n",
-    "print(\"found\", len(result.solutions), \"solutions!\")\n",
+    "print(\"found\", len(result.transitions), \"solutions!\")\n",
     "result.get_intermediate_particles().names"
    ]
   },

--- a/src/expertsystem/amplitude/helicity_decay.py
+++ b/src/expertsystem/amplitude/helicity_decay.py
@@ -180,7 +180,7 @@ def _generate_particle_collection(
 
 
 def _generate_kinematics(result: Result) -> Kinematics:
-    graph = next(iter(result.solutions))
+    graph = next(iter(result.transitions))
     return Kinematics.from_graph(graph)
 
 
@@ -378,7 +378,7 @@ class HelicityAmplitudeGenerator:
         self.fit_parameters: FitParameters = FitParameters()
 
     def generate(self, reaction_result: Result) -> AmplitudeModel:
-        graphs = reaction_result.solutions
+        graphs = reaction_result.transitions
         if len(graphs) < 1:
             raise ValueError(
                 f"At least one {StateTransitionGraph.__name__} required to"

--- a/src/expertsystem/reaction/__init__.py
+++ b/src/expertsystem/reaction/__init__.py
@@ -226,10 +226,10 @@ class Result:
     def get_intermediate_particles(self) -> ParticleCollection:
         """Extract the names of the intermediate state particles."""
         intermediate_states = ParticleCollection()
-        for graph in self.transitions:
+        for transition in self.transitions:
             for edge_props in map(
-                graph.get_edge_props,
-                graph.topology.intermediate_edge_ids,
+                transition.get_edge_props,
+                transition.topology.intermediate_edge_ids,
             ):
                 if edge_props:
                     particle, _ = edge_props
@@ -246,10 +246,10 @@ class Result:
         .. seealso:: :doc:`/usage/visualization`
         """
         inventory: List[StateTransitionGraph[Particle]] = list()
-        for graph in self.transitions:
+        for transition in self.transitions:
             if any(
                 [
-                    graph.compare(
+                    transition.compare(
                         other, edge_comparator=lambda e1, e2: e1[0] == e2
                     )
                     for other in inventory
@@ -257,18 +257,21 @@ class Result:
             ):
                 continue
             new_edge_props = dict()
-            for edge_id in graph.topology.edges:
-                edge_props = graph.get_edge_props(edge_id)
+            for edge_id in transition.topology.edges:
+                edge_props = transition.get_edge_props(edge_id)
                 if edge_props:
                     new_edge_props[edge_id] = edge_props[0]
             inventory.append(
                 StateTransitionGraph[Particle](
-                    topology=graph.topology,
+                    topology=transition.topology,
                     node_props={
                         i: node_props
                         for i, node_props in zip(
-                            graph.topology.nodes,
-                            map(graph.get_node_props, graph.topology.nodes),
+                            transition.topology.nodes,
+                            map(
+                                transition.get_node_props,
+                                transition.topology.nodes,
+                            ),
                         )
                         if node_props
                     },
@@ -322,9 +325,9 @@ class Result:
                     return False
             return True
 
-        graphs = self.get_particle_graphs()
+        particle_graphs = self.get_particle_graphs()
         inventory: List[StateTransitionGraph[ParticleCollection]] = list()
-        for graph in graphs:
+        for graph in particle_graphs:
             append_to_inventory = True
             for merged_graph in inventory:
                 if is_same_shape(graph, merged_graph):

--- a/src/expertsystem/reaction/__init__.py
+++ b/src/expertsystem/reaction/__init__.py
@@ -191,7 +191,7 @@ class _SolutionContainer:
 
 @attr.s(on_setattr=attr.setters.frozen)
 class Result:
-    solutions: List[StateTransitionGraph[ParticleWithSpin]] = attr.ib(
+    transitions: List[StateTransitionGraph[ParticleWithSpin]] = attr.ib(
         factory=list
     )
     formalism_type: Optional[str] = attr.ib(default=None)
@@ -217,16 +217,16 @@ class Result:
         ]
 
     def __get_first_graph(self) -> StateTransitionGraph[ParticleWithSpin]:
-        if len(self.solutions) == 0:
+        if len(self.transitions) == 0:
             raise ValueError(
                 f"No solutions in {self.__class__.__name__} object"
             )
-        return next(iter(self.solutions))
+        return next(iter(self.transitions))
 
     def get_intermediate_particles(self) -> ParticleCollection:
         """Extract the names of the intermediate state particles."""
         intermediate_states = ParticleCollection()
-        for graph in self.solutions:
+        for graph in self.transitions:
             for edge_props in map(
                 graph.get_edge_props,
                 graph.topology.intermediate_edge_ids,
@@ -246,7 +246,7 @@ class Result:
         .. seealso:: :doc:`/usage/visualization`
         """
         inventory: List[StateTransitionGraph[Particle]] = list()
-        for graph in self.solutions:
+        for graph in self.transitions:
             if any(
                 [
                     graph.compare(
@@ -1117,7 +1117,7 @@ def generate(  # pylint: disable=too-many-arguments
     ...     particles=es.io.load_pdg(),
     ...     topology_building="isobar",
     ... )
-    >>> len(result.solutions)
+    >>> len(result.transitions)
     4
     """
     if isinstance(initial_state, str) or (

--- a/tests/channels/test_d0_to_ks_kp_km.py
+++ b/tests/channels/test_d0_to_ks_kp_km.py
@@ -12,7 +12,7 @@ def test_script(output_dir):
         ],
         number_of_threads=1,
     )
-    assert len(result.solutions) == 5
+    assert len(result.transitions) == 5
     assert result.get_intermediate_particles().names == {
         "a(0)(980)+",
         "a(0)(980)-",

--- a/tests/channels/test_jpsi_to_gamma_pi0_pi0.py
+++ b/tests/channels/test_jpsi_to_gamma_pi0_pi0.py
@@ -37,7 +37,7 @@ def test_number_of_solutions(
         allowed_intermediate_particles=allowed_intermediate_particles,
         number_of_threads=1,
     )
-    assert len(result.solutions) == number_of_solutions
+    assert len(result.transitions) == number_of_solutions
     assert result.get_intermediate_particles().names == set(
         allowed_intermediate_particles
     )
@@ -52,8 +52,8 @@ def test_id_to_particle_mappings(particle_database):
         allowed_intermediate_particles=["f(0)(980)"],
         number_of_threads=1,
     )
-    assert len(result.solutions) == 4
-    iter_solutions = iter(result.solutions)
+    assert len(result.transitions) == 4
+    iter_solutions = iter(result.transitions)
     first_solution = next(iter_solutions)
     ref_mapping_fs = _create_edge_id_particle_mapping(
         first_solution, first_solution.topology.outgoing_edge_ids

--- a/tests/channels/test_y_to_d0_d0bar_pi0_pi0.py
+++ b/tests/channels/test_y_to_d0_d0bar_pi0_pi0.py
@@ -20,7 +20,7 @@ def test_simple(formalism_type, n_solutions, particle_database):
         allowed_interaction_types="strong",
         number_of_threads=1,
     )
-    assert len(result.solutions) == n_solutions
+    assert len(result.transitions) == n_solutions
     model = es.generate_amplitudes(result)
     assert len(model.parameters) == 9
 
@@ -46,6 +46,6 @@ def test_full(formalism_type, n_solutions, particle_database):
     stm.add_final_state_grouping([["D0", "pi0"], ["D~0", "pi0"]])
     problem_sets = stm.create_problem_sets()
     result = stm.find_solutions(problem_sets)
-    assert len(result.solutions) == n_solutions
+    assert len(result.transitions) == n_solutions
     model = es.generate_amplitudes(result)
     assert len(model.parameters) == 9

--- a/tests/unit/amplitude/test_model.py
+++ b/tests/unit/amplitude/test_model.py
@@ -59,7 +59,7 @@ class TestKinematics:
     @staticmethod
     def test_from_graph(jpsi_to_gamma_pi_pi_helicity_solutions: Result):
         result = jpsi_to_gamma_pi_pi_helicity_solutions
-        graph = next(iter(result.solutions))
+        graph = next(iter(result.transitions))
         kinematics = Kinematics.from_graph(graph)
         assert len(kinematics.initial_state) == 1
         assert len(kinematics.final_state) == 3

--- a/tests/unit/amplitude/test_parity_prefactor.py
+++ b/tests/unit/amplitude/test_parity_prefactor.py
@@ -65,7 +65,7 @@ def test_parity_prefactor(
 
     result = stm.find_solutions(problem_sets)
 
-    for solution in result.solutions:
+    for solution in result.transitions:
         in_edge = [
             edge_id
             for edge_id in solution.topology.edges

--- a/tests/unit/io/test_dot.py
+++ b/tests/unit/io/test_dot.py
@@ -8,8 +8,8 @@ from expertsystem.reaction.topology import Edge, Topology
 
 def test_dot_syntax(jpsi_to_gamma_pi_pi_helicity_solutions: Result):
     result = jpsi_to_gamma_pi_pi_helicity_solutions
-    for graph in result.transitions:
-        dot_data = io.convert_to_dot(graph)
+    for transition in result.transitions:
+        dot_data = io.convert_to_dot(transition)
         assert pydot.graph_from_dot_data(dot_data) is not None
     dot_data = io.convert_to_dot(result.transitions)
     assert pydot.graph_from_dot_data(dot_data) is not None

--- a/tests/unit/io/test_dot.py
+++ b/tests/unit/io/test_dot.py
@@ -8,10 +8,10 @@ from expertsystem.reaction.topology import Edge, Topology
 
 def test_dot_syntax(jpsi_to_gamma_pi_pi_helicity_solutions: Result):
     result = jpsi_to_gamma_pi_pi_helicity_solutions
-    for graph in result.solutions:
+    for graph in result.transitions:
         dot_data = io.convert_to_dot(graph)
         assert pydot.graph_from_dot_data(dot_data) is not None
-    dot_data = io.convert_to_dot(result.solutions)
+    dot_data = io.convert_to_dot(result.transitions)
     assert pydot.graph_from_dot_data(dot_data) is not None
     dot_data = io.convert_to_dot(result.get_particle_graphs())
     assert pydot.graph_from_dot_data(dot_data) is not None
@@ -50,7 +50,7 @@ class TestWrite:
     ):
         output_file = output_dir + "test_single_graph.gv"
         io.write(
-            instance=jpsi_to_gamma_pi_pi_helicity_solutions.solutions[0],
+            instance=jpsi_to_gamma_pi_pi_helicity_solutions.transitions[0],
             filename=output_file,
         )
         with open(output_file, "r") as stream:
@@ -63,7 +63,7 @@ class TestWrite:
     ):
         output_file = output_dir + "test_graph_list.gv"
         io.write(
-            instance=jpsi_to_gamma_pi_pi_helicity_solutions.solutions,
+            instance=jpsi_to_gamma_pi_pi_helicity_solutions.transitions,
             filename=output_file,
         )
         with open(output_file, "r") as stream:


### PR DESCRIPTION
The `Result` class by now (#459) is just a container with a `solutions` list and a `formalism_type`. In the long term, the idea is that `generate_transitions` only returns `transitions` as a `StateTransitionCollection` object (see #458) and that a `formalism_type` does not have to be carried around within the `reaction` module (#168).

In preparation to this, the variable names are shifting from `graph`/`solution` to `transition`.