### PR TITLE
ci: add back jupyterlab-code-formatter

### DIFF
--- a/reqs/3.6/requirements-dev.txt
+++ b/reqs/3.6/requirements-dev.txt
@@ -68,6 +68,7 @@ jupyter-core==4.7.1
 jupyter-server==1.3.0
 jupyter-sphinx==0.3.1
 jupyter==1.0.0
+jupyterlab-code-formatter==1.4.3
 jupyterlab-server==2.2.0
 jupyterlab-widgets==1.0.0
 jupyterlab==3.0.7

--- a/reqs/3.7/requirements-dev.txt
+++ b/reqs/3.7/requirements-dev.txt
@@ -64,6 +64,7 @@ jupyter-core==4.7.1
 jupyter-server==1.3.0
 jupyter-sphinx==0.3.1
 jupyter==1.0.0
+jupyterlab-code-formatter==1.4.3
 jupyterlab-server==2.2.0
 jupyterlab-widgets==1.0.0
 jupyterlab==3.0.7

--- a/reqs/3.8/requirements-dev.txt
+++ b/reqs/3.8/requirements-dev.txt
@@ -64,6 +64,7 @@ jupyter-core==4.7.1
 jupyter-server==1.3.0
 jupyter-sphinx==0.3.1
 jupyter==1.0.0
+jupyterlab-code-formatter==1.4.3
 jupyterlab-server==2.2.0
 jupyterlab-widgets==1.0.0
 jupyterlab==3.0.7

--- a/reqs/3.9/requirements-dev.txt
+++ b/reqs/3.9/requirements-dev.txt
@@ -64,6 +64,7 @@ jupyter-core==4.7.1
 jupyter-server==1.3.0
 jupyter-sphinx==0.3.1
 jupyter==1.0.0
+jupyterlab-code-formatter==1.4.3
 jupyterlab-server==2.2.0
 jupyterlab-widgets==1.0.0
 jupyterlab==3.0.7

--- a/reqs/requirements-dev.in
+++ b/reqs/requirements-dev.in
@@ -5,6 +5,7 @@
 
 # Additional developer tools
 jupyterlab
+jupyterlab-code-formatter
 labels
 pip-tools
 pydeps

--- a/tox.ini
+++ b/tox.ini
@@ -114,7 +114,7 @@ commands =
 [testenv:test]
 description =
     Run ALL tests, including the slow channel tests, and compute coverage
-whitelist_externals =
+allowlist_externals =
     pytest
 commands =
     pytest {posargs:tests} \


### PR DESCRIPTION
#466 removed `jupyterlab-code-formatter` because `nbqa` formatting and `jupyterlab-code-formatter` slightly differ in style. `jupyterlab-code-formatter` is, however, quite a handy tool while working on notebooks, despite the eventual formatting differences.