### PR TITLE
refactor: let Topology builder return tuple

### DIFF
--- a/src/expertsystem/reaction/__init__.py
+++ b/src/expertsystem/reaction/__init__.py
@@ -466,8 +466,8 @@ class StateTransitionManager:  # pylint: disable=too-many-instance-attributes
                 len(initial_state), len(final_state)
             )
         elif "n-body" in topology_building or "nbody" in topology_building:
-            self.__topologies = frozenset(
-                {create_n_body_topology(len(initial_state), len(final_state))}
+            self.__topologies = (
+                create_n_body_topology(len(initial_state), len(final_state)),
             )
             use_nbody_topology = True
             # turn of mass conservation, in case more than one initial state

--- a/src/expertsystem/reaction/topology.py
+++ b/src/expertsystem/reaction/topology.py
@@ -383,7 +383,7 @@ class SimpleStateTransitionTopologyBuilder:
 
     def build(
         self, number_of_initial_edges: int, number_of_final_edges: int
-    ) -> FrozenSet[Topology]:
+    ) -> Tuple[Topology, ...]:
         number_of_initial_edges = int(number_of_initial_edges)
         number_of_final_edges = int(number_of_final_edges)
         if number_of_initial_edges < 1:
@@ -419,10 +419,10 @@ class SimpleStateTransitionTopologyBuilder:
 
         logging.info("finished building topology graphs...")
         # strip the current open end edges list from the result graph tuples
-        topologies: Set[Topology] = set()
+        topologies: Tuple[Topology, ...] = tuple()
         for graph_tuple in graph_tuple_list:
-            topologies.add(graph_tuple[0].freeze())
-        return frozenset(topologies)
+            topologies += (graph_tuple[0].freeze(),)
+        return topologies
 
     def _extend_graph(
         self, pair: Tuple[_MutableTopology, Sequence[int]]
@@ -464,7 +464,7 @@ class SimpleStateTransitionTopologyBuilder:
 
 def create_isobar_topologies(
     number_of_initial_states: int, number_of_final_states: int
-) -> FrozenSet[Topology]:
+) -> Tuple[Topology, ...]:
     if number_of_initial_states != 1:
         raise ValueError(
             "Can only create an isobar decay if there's one initial state"
@@ -478,7 +478,7 @@ def create_isobar_topologies(
         number_of_initial_edges=number_of_initial_states,
         number_of_final_edges=number_of_final_states,
     )
-    return frozenset(topologies)
+    return tuple(topologies)
 
 
 def create_n_body_topology(


### PR DESCRIPTION
_Spin-off from #454_

`Topology` classes that are created by the `SimpleStateTransitionTopologyBuilder` are sorted randomly because the hash of `Topology` is not suitable for sorting. Therefore it's better to return a `tuple` of `Topology`'s.