### PR TITLE
docs: render module import line on API pages

### DIFF
--- a/docs/_templates/module.rst_t
+++ b/docs/_templates/module.rst_t
@@ -1,6 +1,10 @@
 {%- if show_headings and not separate %}
 {{ basename.split(".")[-1] | e | heading }}
 
+.. code-block:: python
+
+    import {{ basename }}
+
 {% endif -%}
 .. automodule:: {{ qualname }}
 {%- for option in automodule_options %}

--- a/docs/_templates/package.rst_t
+++ b/docs/_templates/package.rst_t
@@ -13,6 +13,11 @@
 {%- endmacro %}
 
 {{ pkgname.split(".")[-1] | e | heading }}
+
+.. code-block:: python
+
+    import {{ pkgname }}
+
 {%- if modulefirst and not is_namespace %}
 {{ automodule(pkgname, automodule_options) }}
 {% endif %}


### PR DESCRIPTION
For instance:
![image](https://user-images.githubusercontent.com/29308176/108180860-84b38780-7107-11eb-8f64-03f06b16a394.png)
