### PR TITLE
fix: remove cell ids from notebooks

### DIFF
--- a/docs/adr/001/operators.ipynb
+++ b/docs/adr/001/operators.ipynb
@@ -2,7 +2,6 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "thick-yesterday",
    "metadata": {},
    "source": [
     "# Python `operator` library"
@@ -10,7 +9,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "concerned-wheat",
    "metadata": {},
    "source": [
     "See Python's built-in [`operator`](https://docs.python.org/3/library/operator.html) library"
@@ -18,7 +16,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "intermediate-passenger",
    "metadata": {},
    "source": [
     "## What we have now"
@@ -26,7 +23,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "assured-segment",
    "metadata": {},
    "source": [
     "Build test model"
@@ -35,7 +31,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fiscal-indonesian",
    "metadata": {
     "tags": [
      "keep_output"
@@ -67,7 +62,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fitted-hungarian",
    "metadata": {},
    "source": [
     "Visualize the decay:"
@@ -76,7 +70,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "incomplete-creativity",
    "metadata": {
     "tags": [
      "keep_output"
@@ -232,7 +225,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "featured-horizon",
    "metadata": {
     "tags": [
      "keep_output"
@@ -272,7 +264,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "satisfactory-pacific",
    "metadata": {},
    "source": [
     "## Implementation with `operators`"
@@ -280,7 +271,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "measured-characterization",
    "metadata": {},
    "source": [
     "See [this answer](https://stackoverflow.com/a/7844038) on Stack Overflow:"
@@ -289,7 +279,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "humanitarian-sitting",
    "metadata": {
     "tags": [
      "keep_output"
@@ -383,7 +372,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "recreational-involvement",
    "metadata": {},
    "source": [
     "## Other ideas"
@@ -391,7 +379,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "brutal-question",
    "metadata": {},
    "source": [
     "````{dropdown} Option 1: parameter _container_\n",
@@ -407,7 +394,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "improving-force",
    "metadata": {},
    "source": [
     "````{dropdown} Option 2: read-only parameter _manager_\n",
@@ -530,5 +516,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 5
+ "nbformat_minor": 4
 }

--- a/docs/adr/002/composition.ipynb
+++ b/docs/adr/002/composition.ipynb
@@ -2,7 +2,6 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "boring-google",
    "metadata": {},
    "source": [
     "# Using composition"
@@ -11,7 +10,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "chubby-spice",
    "metadata": {
     "tags": [
      "remove-cell"
@@ -25,7 +23,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "asian-marking",
    "metadata": {
     "jupyter": {
      "source_hidden": true
@@ -55,7 +52,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "animated-spare",
    "metadata": {},
    "source": [
     "A frozen `DynamicExpression` class keeps track of `variables`, `parameters`, and the dynamics `expression` in which they should appear:"
@@ -64,7 +60,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "printable-relay",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -80,7 +75,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "domestic-sleeve",
    "metadata": {},
    "source": [
     "The `expression` attribute can be formulated as a simple Python function that takes `sympy.Symbol`s as arguments and returns a `sympy.Expr`:"
@@ -89,7 +83,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "finnish-passport",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -102,7 +95,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "requested-banks",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -131,7 +123,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "unlikely-phrase",
    "metadata": {},
    "source": [
     "The `DynamicsExpression` container class enables us to provide the `expression` with correctly named `Symbol`s for the decay that is being described. Here, we use some naming scheme for an $f_0(980)$ decaying to final state edges 3 and 4 (say $\\pi^0\\pi^0$):"
@@ -140,7 +131,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "breeding-control",
    "metadata": {
     "tags": [
      "keep_output"
@@ -172,7 +162,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "anticipated-microwave",
    "metadata": {},
    "source": [
     "For each dynamics expression, we have to provide a 'builder' function that can create a `DynamicsExpression` for a specific edge within the `StateTransitionGraph`:"
@@ -181,7 +170,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "binding-reducing",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -204,7 +192,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "canadian-preparation",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -232,7 +219,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "medium-scholar",
    "metadata": {},
    "source": [
     "The fact that `DynamicsExpression.expression` is just a Python function, allows one to inspect the dynamics formulation of these functions **independently**, purely in terms of SymPy:"
@@ -241,7 +227,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "atmospheric-depth",
    "metadata": {
     "tags": [
      "keep_output"
@@ -296,7 +281,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "educational-jenny",
    "metadata": {},
    "source": [
     "This closes the gap between the code and the theory that is being implemented."
@@ -304,7 +288,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "lonely-fighter",
    "metadata": {},
    "source": [
     "## Alternative signature"
@@ -312,7 +295,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dietary-berkeley",
    "metadata": {},
    "source": [
     "An alternative way to specify the expression is:"
@@ -321,7 +303,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "promising-greene",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -333,7 +314,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "close-fighter",
    "metadata": {},
    "source": [
     "Here, one would however need to unpack the `variables` and `parameters`. The advantage is that the signature becomes more general."
@@ -341,7 +321,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "variable-gossip",
    "metadata": {},
    "source": [
     "## Type checking"
@@ -349,7 +328,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "broadband-filename",
    "metadata": {},
    "source": [
     "There is no way to enforce the appropriate signature on the builder function, other than following a {class}`~typing.Protocol`:"
@@ -358,7 +336,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "greater-brush",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -371,7 +348,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "applied-internship",
    "metadata": {},
    "source": [
     "This `DynamicsBuilder` protocol would be used in the syntax proposed at {ref}`adr/002:Considered solutions`.\n",
@@ -400,5 +376,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 5
+ "nbformat_minor": 4
 }

--- a/docs/adr/002/expr.ipynb
+++ b/docs/adr/002/expr.ipynb
@@ -2,7 +2,6 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "technical-netherlands",
    "metadata": {},
    "source": [
     "# Subclassing `sympy.Expr`"
@@ -11,7 +10,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "japanese-organ",
    "metadata": {
     "tags": [
      "hide-cell",
@@ -26,7 +24,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "inclusive-basics",
    "metadata": {
     "jupyter": {
      "source_hidden": true
@@ -51,7 +48,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "adaptive-trailer",
    "metadata": {},
    "source": [
     "The major disadvantage of {doc}`function`, is that there is no way to identify which `Symbol`s are variables and which are parameters. This can be solved by sub-classing from {class}`sympy.core.expr.Expr`.\n",
@@ -64,7 +60,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "underlying-admission",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -90,7 +85,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "interested-belgium",
    "metadata": {},
    "source": [
     "The `__new__` and `doit` methods split the construction from the evaluation of the expression. This allows one to distinguish `variables` and `parameters` and present them as properties:"
@@ -99,7 +93,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "widespread-centre",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -163,7 +156,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "modern-machinery",
    "metadata": {
     "jupyter": {
      "source_hidden": true
@@ -259,7 +251,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "arabic-cover",
    "metadata": {},
    "source": [
     "The following illustrates the difference with {doc}`function`. First, notice that a class derived from `DynamicsExpr` is still **identifiable** upon construction:"
@@ -268,7 +259,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "gentle-brooks",
    "metadata": {
     "tags": [
      "keep_output"
@@ -297,7 +287,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "mounted-transcript",
    "metadata": {},
    "source": [
     "```{toggle}\n",
@@ -307,7 +296,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cloudy-queens",
    "metadata": {},
    "source": [
     "Only once `doit()` is called, is the `DynamicsExpr` converted into a mathematical expression:"
@@ -316,7 +304,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "automated-monitoring",
    "metadata": {
     "tags": [
      "keep_output"
@@ -345,7 +332,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "sunrise-anxiety",
    "metadata": {
     "tags": [
      "keep_output"
@@ -376,7 +362,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "affecting-junior",
    "metadata": {},
    "source": [
     "## Decorator"
@@ -384,7 +369,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "mobile-injection",
    "metadata": {},
    "source": [
     "There are a lot of implicit conventions that need to be followed to provide a correct implementation of a `DynamicsExpr`. Some of this may be mitigated by proving some class decorator that can easily construct the `__new__()` and `doit()` methods for you."
@@ -393,7 +377,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "dietary-baseline",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -422,7 +405,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dependent-cowboy",
    "metadata": {},
    "source": [
     "This saves some lines of code:"
@@ -431,7 +413,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "julian-potential",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -476,7 +457,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "infinite-partnership",
    "metadata": {
     "tags": [
      "keep_output"
@@ -505,7 +485,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "seventh-sudan",
    "metadata": {
     "tags": [
      "keep_output"
@@ -532,7 +511,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "victorian-savage",
    "metadata": {},
    "source": [
     "## Issue with lambdify"
@@ -540,7 +518,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "square-custody",
    "metadata": {},
    "source": [
     "It's not possible to plot a `DynamicsExpr` directly as long as no `lambdify` hook has been provided: **`doit()` has to be executed first**."
@@ -549,7 +526,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "romantic-winner",
    "metadata": {
     "tags": [
      "keep_output",
@@ -615,5 +591,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 5
+ "nbformat_minor": 4
 }

--- a/docs/adr/002/function.ipynb
+++ b/docs/adr/002/function.ipynb
@@ -2,7 +2,6 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "prompt-queen",
    "metadata": {},
    "source": [
     "# Subclassing `sympy.Function`"
@@ -11,7 +10,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "approved-austria",
    "metadata": {
     "tags": [
      "hide-cell",
@@ -27,7 +25,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "corporate-twelve",
    "metadata": {
     "jupyter": {
      "source_hidden": true
@@ -51,7 +48,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "black-underwear",
    "metadata": {},
    "source": [
     "One way to address the Cons of {doc}`composition`, is to sub-class {class}`~sympy.core.function.Function`. The expression is implemented by overwriting the inherited `eval()` method and the builder is provided through the class through an additional `from_graph` class method. The interface would look like this:"
@@ -60,7 +56,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "narrow-effort",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -78,7 +73,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "lined-conclusion",
    "metadata": {},
    "source": [
     "As can be seen from the implementation of a relativistic Breit-Wigner, the implementation of the expression is nicely kept together with the implementation of the expression:"
@@ -87,7 +81,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "known-thanksgiving",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -116,7 +109,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "annoying-favorite",
    "metadata": {},
    "source": [
     "It becomes a bit less clear when using a form factor, but the `DynamicsFunction` base class enforces a correct interfaces:"
@@ -125,7 +117,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "suspected-cream",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -176,7 +167,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "crucial-emerald",
    "metadata": {},
    "source": [
     "The `expression_builder` used in the syntax proposed at {ref}`adr/002:Considered solutions`, would now just be a class that is derived of `DynamicsFunction`."
@@ -184,7 +174,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ready-destiny",
    "metadata": {},
    "source": [
     "The `sympy.Function` class provides mixin methods, so that the derived class behaves as a `sympy` expression. So the expression can be inspected with the usual `sympy` tools (compare the Pros of {doc}`composition`):"
@@ -193,7 +182,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "advanced-sherman",
    "metadata": {
     "tags": [
      "keep_output"
@@ -267,5 +255,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 5
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
Somehow if a Jupyter notebook contains
```
  "nbformat_minor": 5
```
in its [top-level structure](https://ipython.org/ipython-doc/dev/notebook/nbformat.html#top-level-structure), instead of
```
  "nbformat_minor": 4
```
both `nbstripout` and Jupyter lab add randomly generated cell IDs to each cell. This is super bothersome for diffs and merge conflicts. Worst part is that the IDs are random which causes a lot of unnecessary file changes.

This PR removes the `"id"` items and lowers the `nbformat_minor`. With the current dev set-up (pinned versions of `jupyterlab` etc) new notebooks will again get `"nbformat_minor": 5`, but I'm not sure how to work around this. Just something to keep an eye on now.