### PR TITLE
fix: allow Iterable in Topology constructor

### DIFF
--- a/src/expertsystem/reaction/topology.py
+++ b/src/expertsystem/reaction/topology.py
@@ -91,6 +91,12 @@ class Edge:
         return connected_nodes  # type: ignore
 
 
+def _to_frozenset(iterable: Iterable[int]) -> FrozenSet[int]:
+    if not all(map(lambda i: isinstance(i, int), iterable)):
+        raise TypeError(f"Not all items in {iterable} are of type int")
+    return frozenset(iterable)
+
+
 @attr.s(frozen=True)
 class Topology:
     """Directed Feynman-like graph without edge or node properties.
@@ -102,7 +108,7 @@ class Topology:
     because it allows open edges, like a Feynman-diagram.
     """
 
-    nodes: FrozenSet[int] = attr.ib(converter=frozenset)
+    nodes: FrozenSet[int] = attr.ib(converter=_to_frozenset)
     edges: FrozenDict[int, Edge] = attr.ib(converter=FrozenDict)
 
     incoming_edge_ids: FrozenSet[int] = attr.ib(init=False, repr=False)
@@ -271,7 +277,7 @@ class _MutableTopology:
     def freeze(self) -> Topology:
         return Topology(
             edges=self.edges,
-            nodes=self.nodes,  # type: ignore
+            nodes=self.nodes,
         )
 
     def add_node(self, node_id: int) -> None:

--- a/tests/unit/io/test_dot.py
+++ b/tests/unit/io/test_dot.py
@@ -32,7 +32,7 @@ class TestWrite:
     def test_write_topology(output_dir):
         output_file = output_dir + "two_body_decay_topology.gv"
         topology = Topology(
-            nodes={0},  # type: ignore
+            nodes={0},
             edges={0: Edge(0, None), 1: Edge(None, 0), 2: Edge(None, 0)},
         )
         io.write(

--- a/tests/unit/reaction/test_system_control.py
+++ b/tests/unit/reaction/test_system_control.py
@@ -209,7 +209,7 @@ def make_ls_test_graph(
 ):
     graph = StateTransitionGraph[ParticleWithSpin](
         topology=Topology(
-            nodes={0},  # type: ignore
+            nodes={0},
             edges={0: Edge(None, 0)},
         ),
         node_props={
@@ -228,7 +228,7 @@ def make_ls_test_graph_scrambled(
 ):
     graph = StateTransitionGraph[ParticleWithSpin](
         topology=Topology(
-            nodes={0},  # type: ignore
+            nodes={0},
             edges={0: Edge(None, 0)},
         ),
         node_props={

--- a/tests/unit/reaction/test_topology.py
+++ b/tests/unit/reaction/test_topology.py
@@ -34,7 +34,7 @@ def two_to_three_decay() -> Topology:
             e1                 e4            e5
     """
     topology = Topology(
-        nodes={0, 1, 2},  # type: ignore
+        nodes={0, 1, 2},
         edges={
             0: Edge(None, 0),
             1: Edge(None, 0),


### PR DESCRIPTION
Even though the constructor `Topology` allows one to use `nodes={0, 1}` (the `set` is cast internally to a `frozenset`), `mypy` says this is not allowed. This PR fixes this behaviour.