### PR TITLE
fix: create_isobar_topologies only requires n_final

### DIFF
--- a/src/expertsystem/reaction/__init__.py
+++ b/src/expertsystem/reaction/__init__.py
@@ -462,9 +462,7 @@ class StateTransitionManager:  # pylint: disable=too-many-instance-attributes
         use_nbody_topology = False
         topology_building = topology_building.lower()
         if topology_building == "isobar":
-            self.__topologies = create_isobar_topologies(
-                len(initial_state), len(final_state)
-            )
+            self.__topologies = create_isobar_topologies(len(final_state))
         elif "n-body" in topology_building or "nbody" in topology_building:
             self.__topologies = (
                 create_n_body_topology(len(initial_state), len(final_state)),

--- a/src/expertsystem/reaction/topology.py
+++ b/src/expertsystem/reaction/topology.py
@@ -469,19 +469,15 @@ class SimpleStateTransitionTopologyBuilder:
 
 
 def create_isobar_topologies(
-    number_of_initial_states: int, number_of_final_states: int
+    number_of_final_states: int,
 ) -> Tuple[Topology, ...]:
-    if number_of_initial_states != 1:
-        raise ValueError(
-            "Can only create an isobar decay if there's one initial state"
-        )
     if number_of_final_states < 2:
         raise ValueError(
             "At least two final states required for an isobar decay"
         )
     builder = SimpleStateTransitionTopologyBuilder([InteractionNode(1, 2)])
     topologies = builder.build(
-        number_of_initial_edges=number_of_initial_states,
+        number_of_initial_edges=1,
         number_of_final_edges=number_of_final_states,
     )
     return tuple(topologies)

--- a/tests/unit/reaction/test_combinatorics.py
+++ b/tests/unit/reaction/test_combinatorics.py
@@ -19,7 +19,7 @@ from expertsystem.reaction.topology import Topology, create_isobar_topologies
 
 @pytest.fixture(scope="session")
 def three_body_decay() -> Topology:
-    topologies = create_isobar_topologies(1, 3)
+    topologies = create_isobar_topologies(3)
     topology = next(iter(topologies))
     return topology
 

--- a/tests/unit/reaction/test_topology.py
+++ b/tests/unit/reaction/test_topology.py
@@ -237,38 +237,33 @@ class TestTopology:
 
 
 @pytest.mark.parametrize(
-    "n_initial, n_final, n_topologies, exception",
+    "n_final, n_topologies, exception",
     [
-        (1, 0, None, ValueError),
-        (0, 1, None, ValueError),
-        (0, 0, None, ValueError),
-        (1, 1, None, ValueError),
-        (2, 1, None, ValueError),
-        (1, 2, 1, None),
-        (1, 3, 1, None),
-        (1, 4, 2, None),
-        (1, 5, 5, None),
-        (1, 6, 16, None),
-        (1, 7, 61, None),
-        (1, 8, 272, None),
+        (0, None, ValueError),
+        (1, None, ValueError),
+        (2, 1, None),
+        (3, 1, None),
+        (4, 2, None),
+        (5, 5, None),
+        (6, 16, None),
+        (7, 61, None),
+        (8, 272, None),
     ],
 )
 def test_create_isobar_topologies(
-    n_initial: int,
     n_final: int,
     n_topologies: int,
     exception,
 ):
     if exception is not None:
         with pytest.raises(exception):
-            create_isobar_topologies(n_initial, n_final)
+            create_isobar_topologies(n_final)
     else:
-        topologies = create_isobar_topologies(n_initial, n_final)
+        topologies = create_isobar_topologies(n_final)
         assert len(topologies) == n_topologies
         n_expected_nodes = n_final - 1
         n_intermediate_edges = n_final - 2
         for topology in topologies:
-            assert len(topology.incoming_edge_ids) == n_initial
             assert len(topology.outgoing_edge_ids) == n_final
             assert len(topology.intermediate_edge_ids) == n_intermediate_edges
             assert len(topology.nodes) == n_expected_nodes


### PR DESCRIPTION
`create_isobar_topologies` now only needs a number of final states: it is assumed that the number of initial states is one.