### PR TITLE
docs: visualize Topology with node IDs

### DIFF
--- a/docs/usage/visualization.ipynb
+++ b/docs/usage/visualization.ipynb
@@ -29,21 +29,80 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The {mod}`~expertsystem.io` module allows you to convert a {class}`.StateTransitionGraph` to [DOT language](https://graphviz.org/doc/info/lang.html), which you can then visualize with third-party libraries such as [Graphviz](https://graphviz.org). This is particularly useful after running {meth}`~.StateTransitionManager.find_solutions`, which produces a {class}`.Result` object with a {class}`.list` of {class}`.StateTransitionGraph` instances (see {doc}`transition`)."
+    "The {mod}`~expertsystem.io` module allows you to convert {class}`.StateTransitionGraph` and {class}`.Topology` instances to [DOT language](https://graphviz.org/doc/info/lang.html) with {func}`.convert_to_dot`. You can visualize its output with third-party libraries, such as [Graphviz](https://graphviz.org). This is particularly useful after running {meth}`~.StateTransitionManager.find_solutions`, which produces a {class}`.Result` object with a {class}`.list` of {class}`.StateTransitionGraph` instances (see {doc}`transition`)."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Setup"
+    "## Topologies"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In this notebook, we'll visualize the allowed transitions for the decay $\\psi' \\to \\gamma\\eta\\eta$ as an example."
+    "First of all, here are is an example of how to visualize a group of {class}`.Topology` instances. We use {func}`.create_isobar_topologies` and {func}`.create_n_body_topology` to create a few standard topologies."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "hide-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "import graphviz\n",
+    "from expertsystem import io\n",
+    "from expertsystem.reaction.topology import (\n",
+    "    create_isobar_topologies,\n",
+    "    create_n_body_topology,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "topology = create_n_body_topology(2, 4)\n",
+    "graphviz.Source(io.convert_to_dot(topology))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note the IDs of the {attr}`~.Topology.nodes` is also rendered if there is more than node:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "topologies = create_isobar_topologies(4)\n",
+    "graphviz.Source(io.convert_to_dot(topologies))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## {class}`.StateTransitionGraph`s"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here, we'll visualize the allowed transitions for the decay $\\psi' \\to \\gamma\\eta\\eta$ as an example."
    ]
   },
   {

--- a/src/expertsystem/io/__init__.py
+++ b/src/expertsystem/io/__init__.py
@@ -7,6 +7,7 @@ the state of the system.
 """
 
 import json
+from collections import abc
 from pathlib import Path
 
 import yaml
@@ -128,7 +129,7 @@ def convert_to_dot(instance: object) -> str:
     """
     if isinstance(instance, (StateTransitionGraph, Topology)):
         return _dot.graph_to_dot(instance)
-    if isinstance(instance, list):
+    if isinstance(instance, abc.Sequence):
         return _dot.graph_list_to_dot(instance)
     raise NotImplementedError(
         f"Cannot convert a {instance.__class__.__name__} to DOT language"

--- a/src/expertsystem/io/_dot.py
+++ b/src/expertsystem/io/_dot.py
@@ -3,7 +3,7 @@
 See :doc:`/usage/visualization` for more info.
 """
 
-from typing import Any, Callable, Iterable, List, Optional, Union
+from typing import Any, Callable, Iterable, Optional, Sequence, Union
 
 from expertsystem.particle import Particle, ParticleCollection
 from expertsystem.reaction.quantum_numbers import (
@@ -37,7 +37,7 @@ def embed_dot(func: Callable[[Any], str]) -> Callable[[Any], str]:
 
 
 @embed_dot
-def graph_list_to_dot(graphs: List[StateTransitionGraph]) -> str:
+def graph_list_to_dot(graphs: Sequence[StateTransitionGraph]) -> str:
     dot_source = ""
     for i, graph in enumerate(reversed(graphs)):
         dot_source += __graph_to_dot_content(graph, prefix=f"g{i}_")

--- a/src/expertsystem/io/_dot.py
+++ b/src/expertsystem/io/_dot.py
@@ -86,6 +86,12 @@ def __graph_to_dot_content(
             dot_source += _DOT_DEFAULT_NODE.format(
                 f"{prefix}node{node_id}", node_label
             )
+    if isinstance(graph, Topology):
+        if len(topology.nodes) > 1:
+            for node_id in topology.nodes:
+                dot_source += _DOT_DEFAULT_NODE.format(
+                    f"{prefix}node{node_id}", f"({node_id})"
+                )
     return dot_source
 
 

--- a/tests/unit/io/test_dot.py
+++ b/tests/unit/io/test_dot.py
@@ -3,10 +3,15 @@ import pytest
 
 from expertsystem import io
 from expertsystem.reaction import Result
-from expertsystem.reaction.topology import Edge, Topology
+from expertsystem.reaction.topology import (
+    Edge,
+    Topology,
+    create_isobar_topologies,
+    create_n_body_topology,
+)
 
 
-def test_dot_syntax(jpsi_to_gamma_pi_pi_helicity_solutions: Result):
+def test_convert_to_dot(jpsi_to_gamma_pi_pi_helicity_solutions: Result):
     result = jpsi_to_gamma_pi_pi_helicity_solutions
     for transition in result.transitions:
         dot_data = io.convert_to_dot(transition)
@@ -16,6 +21,14 @@ def test_dot_syntax(jpsi_to_gamma_pi_pi_helicity_solutions: Result):
     dot_data = io.convert_to_dot(result.get_particle_graphs())
     assert pydot.graph_from_dot_data(dot_data) is not None
     dot_data = io.convert_to_dot(result.collapse_graphs())
+    assert pydot.graph_from_dot_data(dot_data) is not None
+    dot_data = io.convert_to_dot(create_n_body_topology(3, 4))
+    assert pydot.graph_from_dot_data(dot_data) is not None
+    dot_data = io.convert_to_dot(create_isobar_topologies(2))
+    assert pydot.graph_from_dot_data(dot_data) is not None
+    dot_data = io.convert_to_dot(create_isobar_topologies(3))
+    assert pydot.graph_from_dot_data(dot_data) is not None
+    dot_data = io.convert_to_dot(create_isobar_topologies(4))
     assert pydot.graph_from_dot_data(dot_data) is not None
 
 


### PR DESCRIPTION
- The visualize page now also illustrates how to visualize topologies.
- It's now possible to run `convert_to_dot` on a `tuple` as well. This is required if one wants to do:
  ```python
  from expertsystem.io import convert_to_dot
  from expertsystem.reaction.topology import create_isobar_topologies
  convert_to_dot(create_isobar_topologies(4))
  ```
  because `create_isobar_topologies` returns a `tuple`.
- Node IDs are also rendered in DOT if there is more than one node