### PR TITLE
ci: add collapsible_headings labextension

### DIFF
--- a/reqs/3.6/requirements-dev.txt
+++ b/reqs/3.6/requirements-dev.txt
@@ -8,6 +8,7 @@ alabaster==0.7.12
 anyio==2.1.0
 apipkg==1.5
 appdirs==1.4.4
+aquirdturtle-collapsible-headings==3.0.1
 argon2-cffi==20.1.0
 astroid==2.5.0
 async-generator==1.10
@@ -49,7 +50,7 @@ identify==1.5.14
 idna==2.10
 imagesize==1.2.0
 immutables==0.15
-importlib-metadata==3.4.0
+importlib-metadata==3.7.0
 importlib-resources==3.0.0
 iniconfig==1.1.1
 ipykernel==5.5.0
@@ -65,13 +66,14 @@ jupyter-cache==0.4.2
 jupyter-client==6.1.11
 jupyter-console==6.2.0
 jupyter-core==4.7.1
-jupyter-server==1.4.0
+jupyter-packaging==0.7.12
+jupyter-server==1.4.1
 jupyter-sphinx==0.3.1
 jupyter==1.0.0
 jupyterlab-code-formatter==1.4.4
 jupyterlab-server==2.3.0
 jupyterlab-widgets==1.0.0
-jupyterlab==3.0.8
+jupyterlab==3.0.9
 labels==20.1.0
 lazy-object-proxy==1.5.2
 livereload==2.6.3
@@ -82,10 +84,10 @@ mdit-py-plugins==0.2.5
 mistune==0.8.4
 mypy-extensions==0.4.3
 mypy==0.812
-myst-nb==0.11.1
+myst-nb==0.12.0
 myst-parser==0.13.5
 nbclassic==0.2.6
-nbclient==0.5.2
+nbclient==0.5.3
 nbconvert==5.6.1
 nbdime==2.1.0
 nbformat==5.1.2
@@ -116,7 +118,7 @@ pydocstyle==5.1.1
 pydot==1.4.2
 pyflakes==2.2.0
 pygments==2.8.0
-pylint==2.7.0
+pylint==2.7.1
 pyparsing==2.4.7
 pyrsistent==0.17.3
 pytest-cov==2.11.1
@@ -162,7 +164,7 @@ testpath==0.4.4
 toml==0.10.2
 tornado==6.1
 tox==3.22.0
-tqdm==4.57.0
+tqdm==4.58.0
 traitlets==4.3.3
 typed-ast==1.4.2
 typing-extensions==3.7.4.3 ; python_version < "3.8.0"

--- a/reqs/3.6/requirements-doc.txt
+++ b/reqs/3.6/requirements-doc.txt
@@ -28,7 +28,7 @@ graphviz==0.16
 hepunits==2.1.0
 idna==2.10
 imagesize==1.2.0
-importlib-metadata==3.4.0
+importlib-metadata==3.7.0
 importlib-resources==3.0.0
 ipykernel==5.5.0
 ipython-genutils==0.2.0
@@ -48,9 +48,9 @@ markdown-it-py==0.6.2
 markupsafe==1.1.1
 mdit-py-plugins==0.2.5
 mistune==0.8.4
-myst-nb==0.11.1
+myst-nb==0.12.0
 myst-parser==0.13.5
-nbclient==0.5.2
+nbclient==0.5.3
 nbconvert==5.6.1
 nbdime==2.1.0
 nbformat==5.1.2
@@ -100,7 +100,7 @@ sqlalchemy==1.3.23
 terminado==0.9.2
 testpath==0.4.4
 tornado==6.1
-tqdm==4.57.0
+tqdm==4.58.0
 traitlets==4.3.3
 typing-extensions==3.7.4.3 ; python_version < "3.8.0"
 urllib3==1.26.3

--- a/reqs/3.6/requirements-sty.txt
+++ b/reqs/3.6/requirements-sty.txt
@@ -27,7 +27,7 @@ flake8==3.8.4
 gprof2dot==2021.2.21
 hepunits==2.1.0
 identify==1.5.14
-importlib-metadata==3.4.0
+importlib-metadata==3.7.0
 importlib-resources==3.0.0
 iniconfig==1.1.1
 ipython-genutils==0.2.0
@@ -52,7 +52,7 @@ pycodestyle==2.6.0
 pydocstyle==5.1.1
 pydot==1.4.2
 pyflakes==2.2.0
-pylint==2.7.0
+pylint==2.7.1
 pyparsing==2.4.7
 pyrsistent==0.17.3
 pytest-cov==2.11.1
@@ -67,7 +67,7 @@ restructuredtext-lint==1.3.2
 six==1.15.0
 snowballstemmer==2.1.0
 toml==0.10.2
-tqdm==4.57.0
+tqdm==4.58.0
 traitlets==4.3.3
 typed-ast==1.4.2
 typing-extensions==3.7.4.3 ; python_version < "3.8.0"

--- a/reqs/3.6/requirements-test.txt
+++ b/reqs/3.6/requirements-test.txt
@@ -10,7 +10,7 @@ coverage==5.4
 execnet==1.8.0
 gprof2dot==2021.2.21
 hepunits==2.1.0
-importlib-metadata==3.4.0
+importlib-metadata==3.7.0
 importlib-resources==3.0.0
 iniconfig==1.1.1
 jsonschema==3.2.0
@@ -30,7 +30,7 @@ python-constraint==1.4.0
 pyyaml==5.4.1
 six==1.15.0
 toml==0.10.2
-tqdm==4.57.0
+tqdm==4.58.0
 typing-extensions==3.7.4.3 ; python_version < "3.8.0"
 zipp==3.4.0
 

--- a/reqs/3.6/requirements.txt
+++ b/reqs/3.6/requirements.txt
@@ -6,7 +6,7 @@
 #
 attrs==20.3.0
 hepunits==2.1.0
-importlib-metadata==3.4.0
+importlib-metadata==3.7.0
 importlib-resources==3.0.0
 jsonschema==3.2.0
 particle==0.14.0
@@ -14,7 +14,7 @@ pyrsistent==0.17.3
 python-constraint==1.4.0
 pyyaml==5.4.1
 six==1.15.0
-tqdm==4.57.0
+tqdm==4.58.0
 typing-extensions==3.7.4.3 ; python_version < "3.8.0"
 zipp==3.4.0
 

--- a/reqs/3.7/requirements-dev.txt
+++ b/reqs/3.7/requirements-dev.txt
@@ -8,6 +8,7 @@ alabaster==0.7.12
 anyio==2.1.0
 apipkg==1.5
 appdirs==1.4.4
+aquirdturtle-collapsible-headings==3.0.1
 argon2-cffi==20.1.0
 astroid==2.5.0
 async-generator==1.10
@@ -46,7 +47,7 @@ hepunits==2.1.0
 identify==1.5.14
 idna==2.10
 imagesize==1.2.0
-importlib-metadata==3.4.0
+importlib-metadata==3.7.0
 iniconfig==1.1.1
 ipykernel==5.5.0
 ipython-genutils==0.2.0
@@ -61,13 +62,14 @@ jupyter-cache==0.4.2
 jupyter-client==6.1.11
 jupyter-console==6.2.0
 jupyter-core==4.7.1
-jupyter-server==1.4.0
+jupyter-packaging==0.7.12
+jupyter-server==1.4.1
 jupyter-sphinx==0.3.1
 jupyter==1.0.0
 jupyterlab-code-formatter==1.4.4
 jupyterlab-server==2.3.0
 jupyterlab-widgets==1.0.0
-jupyterlab==3.0.8
+jupyterlab==3.0.9
 labels==20.1.0
 lazy-object-proxy==1.5.2
 livereload==2.6.3
@@ -78,10 +80,10 @@ mdit-py-plugins==0.2.5
 mistune==0.8.4
 mypy-extensions==0.4.3
 mypy==0.812
-myst-nb==0.11.1
+myst-nb==0.12.0
 myst-parser==0.13.5
 nbclassic==0.2.6
-nbclient==0.5.2
+nbclient==0.5.3
 nbconvert==5.6.1
 nbdime==2.1.0
 nbformat==5.1.2
@@ -112,7 +114,7 @@ pydocstyle==5.1.1
 pydot==1.4.2
 pyflakes==2.2.0
 pygments==2.8.0
-pylint==2.7.0
+pylint==2.7.1
 pyparsing==2.4.7
 pyrsistent==0.17.3
 pytest-cov==2.11.1
@@ -158,7 +160,7 @@ testpath==0.4.4
 toml==0.10.2
 tornado==6.1
 tox==3.22.0
-tqdm==4.57.0
+tqdm==4.58.0
 traitlets==5.0.5
 typed-ast==1.4.2
 typing-extensions==3.7.4.3 ; python_version < "3.8.0"

--- a/reqs/3.7/requirements-doc.txt
+++ b/reqs/3.7/requirements-doc.txt
@@ -28,7 +28,7 @@ graphviz==0.16
 hepunits==2.1.0
 idna==2.10
 imagesize==1.2.0
-importlib-metadata==3.4.0
+importlib-metadata==3.7.0
 ipykernel==5.5.0
 ipython-genutils==0.2.0
 ipython==7.20.0
@@ -47,9 +47,9 @@ markdown-it-py==0.6.2
 markupsafe==1.1.1
 mdit-py-plugins==0.2.5
 mistune==0.8.4
-myst-nb==0.11.1
+myst-nb==0.12.0
 myst-parser==0.13.5
-nbclient==0.5.2
+nbclient==0.5.3
 nbconvert==5.6.1
 nbdime==2.1.0
 nbformat==5.1.2
@@ -99,7 +99,7 @@ sqlalchemy==1.3.23
 terminado==0.9.2
 testpath==0.4.4
 tornado==6.1
-tqdm==4.57.0
+tqdm==4.58.0
 traitlets==5.0.5
 typing-extensions==3.7.4.3 ; python_version < "3.8.0"
 urllib3==1.26.3

--- a/reqs/3.7/requirements-sty.txt
+++ b/reqs/3.7/requirements-sty.txt
@@ -25,7 +25,7 @@ flake8==3.8.4
 gprof2dot==2021.2.21
 hepunits==2.1.0
 identify==1.5.14
-importlib-metadata==3.4.0
+importlib-metadata==3.7.0
 iniconfig==1.1.1
 ipython-genutils==0.2.0
 isort==5.7.0
@@ -49,7 +49,7 @@ pycodestyle==2.6.0
 pydocstyle==5.1.1
 pydot==1.4.2
 pyflakes==2.2.0
-pylint==2.7.0
+pylint==2.7.1
 pyparsing==2.4.7
 pyrsistent==0.17.3
 pytest-cov==2.11.1
@@ -64,7 +64,7 @@ restructuredtext-lint==1.3.2
 six==1.15.0
 snowballstemmer==2.1.0
 toml==0.10.2
-tqdm==4.57.0
+tqdm==4.58.0
 traitlets==5.0.5
 typed-ast==1.4.2
 typing-extensions==3.7.4.3 ; python_version < "3.8.0"

--- a/reqs/3.7/requirements-test.txt
+++ b/reqs/3.7/requirements-test.txt
@@ -10,7 +10,7 @@ coverage==5.4
 execnet==1.8.0
 gprof2dot==2021.2.21
 hepunits==2.1.0
-importlib-metadata==3.4.0
+importlib-metadata==3.7.0
 iniconfig==1.1.1
 jsonschema==3.2.0
 packaging==20.9
@@ -29,7 +29,7 @@ python-constraint==1.4.0
 pyyaml==5.4.1
 six==1.15.0
 toml==0.10.2
-tqdm==4.57.0
+tqdm==4.58.0
 typing-extensions==3.7.4.3 ; python_version < "3.8.0"
 zipp==3.4.0
 

--- a/reqs/3.7/requirements.txt
+++ b/reqs/3.7/requirements.txt
@@ -6,14 +6,14 @@
 #
 attrs==20.3.0
 hepunits==2.1.0
-importlib-metadata==3.4.0
+importlib-metadata==3.7.0
 jsonschema==3.2.0
 particle==0.14.0
 pyrsistent==0.17.3
 python-constraint==1.4.0
 pyyaml==5.4.1
 six==1.15.0
-tqdm==4.57.0
+tqdm==4.58.0
 typing-extensions==3.7.4.3 ; python_version < "3.8.0"
 zipp==3.4.0
 

--- a/reqs/3.8/requirements-dev.txt
+++ b/reqs/3.8/requirements-dev.txt
@@ -8,6 +8,7 @@ alabaster==0.7.12
 anyio==2.1.0
 apipkg==1.5
 appdirs==1.4.4
+aquirdturtle-collapsible-headings==3.0.1
 argon2-cffi==20.1.0
 astroid==2.5.0
 async-generator==1.10
@@ -46,7 +47,7 @@ hepunits==2.1.0
 identify==1.5.14
 idna==2.10
 imagesize==1.2.0
-importlib-metadata==3.4.0
+importlib-metadata==3.7.0
 iniconfig==1.1.1
 ipykernel==5.5.0
 ipython-genutils==0.2.0
@@ -61,13 +62,14 @@ jupyter-cache==0.4.2
 jupyter-client==6.1.11
 jupyter-console==6.2.0
 jupyter-core==4.7.1
-jupyter-server==1.4.0
+jupyter-packaging==0.7.12
+jupyter-server==1.4.1
 jupyter-sphinx==0.3.1
 jupyter==1.0.0
 jupyterlab-code-formatter==1.4.4
 jupyterlab-server==2.3.0
 jupyterlab-widgets==1.0.0
-jupyterlab==3.0.8
+jupyterlab==3.0.9
 labels==20.1.0
 lazy-object-proxy==1.5.2
 livereload==2.6.3
@@ -78,10 +80,10 @@ mdit-py-plugins==0.2.5
 mistune==0.8.4
 mypy-extensions==0.4.3
 mypy==0.812
-myst-nb==0.11.1
+myst-nb==0.12.0
 myst-parser==0.13.5
 nbclassic==0.2.6
-nbclient==0.5.2
+nbclient==0.5.3
 nbconvert==5.6.1
 nbdime==2.1.0
 nbformat==5.1.2
@@ -112,7 +114,7 @@ pydocstyle==5.1.1
 pydot==1.4.2
 pyflakes==2.2.0
 pygments==2.8.0
-pylint==2.7.0
+pylint==2.7.1
 pyparsing==2.4.7
 pyrsistent==0.17.3
 pytest-cov==2.11.1
@@ -158,7 +160,7 @@ testpath==0.4.4
 toml==0.10.2
 tornado==6.1
 tox==3.22.0
-tqdm==4.57.0
+tqdm==4.58.0
 traitlets==5.0.5
 typed-ast==1.4.2
 typing-extensions==3.7.4.3

--- a/reqs/3.8/requirements-doc.txt
+++ b/reqs/3.8/requirements-doc.txt
@@ -28,7 +28,7 @@ graphviz==0.16
 hepunits==2.1.0
 idna==2.10
 imagesize==1.2.0
-importlib-metadata==3.4.0
+importlib-metadata==3.7.0
 ipykernel==5.5.0
 ipython-genutils==0.2.0
 ipython==7.20.0
@@ -47,9 +47,9 @@ markdown-it-py==0.6.2
 markupsafe==1.1.1
 mdit-py-plugins==0.2.5
 mistune==0.8.4
-myst-nb==0.11.1
+myst-nb==0.12.0
 myst-parser==0.13.5
-nbclient==0.5.2
+nbclient==0.5.3
 nbconvert==5.6.1
 nbdime==2.1.0
 nbformat==5.1.2
@@ -99,7 +99,7 @@ sqlalchemy==1.3.23
 terminado==0.9.2
 testpath==0.4.4
 tornado==6.1
-tqdm==4.57.0
+tqdm==4.58.0
 traitlets==5.0.5
 urllib3==1.26.3
 wcwidth==0.2.5

--- a/reqs/3.8/requirements-sty.txt
+++ b/reqs/3.8/requirements-sty.txt
@@ -48,7 +48,7 @@ pycodestyle==2.6.0
 pydocstyle==5.1.1
 pydot==1.4.2
 pyflakes==2.2.0
-pylint==2.7.0
+pylint==2.7.1
 pyparsing==2.4.7
 pyrsistent==0.17.3
 pytest-cov==2.11.1
@@ -63,7 +63,7 @@ restructuredtext-lint==1.3.2
 six==1.15.0
 snowballstemmer==2.1.0
 toml==0.10.2
-tqdm==4.57.0
+tqdm==4.58.0
 traitlets==5.0.5
 typed-ast==1.4.2
 typing-extensions==3.7.4.3

--- a/reqs/3.8/requirements-test.txt
+++ b/reqs/3.8/requirements-test.txt
@@ -28,7 +28,7 @@ python-constraint==1.4.0
 pyyaml==5.4.1
 six==1.15.0
 toml==0.10.2
-tqdm==4.57.0
+tqdm==4.58.0
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/reqs/3.8/requirements.txt
+++ b/reqs/3.8/requirements.txt
@@ -12,7 +12,7 @@ pyrsistent==0.17.3
 python-constraint==1.4.0
 pyyaml==5.4.1
 six==1.15.0
-tqdm==4.57.0
+tqdm==4.58.0
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/reqs/3.9/requirements-dev.txt
+++ b/reqs/3.9/requirements-dev.txt
@@ -8,6 +8,7 @@ alabaster==0.7.12
 anyio==2.1.0
 apipkg==1.5
 appdirs==1.4.4
+aquirdturtle-collapsible-headings==3.0.1
 argon2-cffi==20.1.0
 astroid==2.5.0
 async-generator==1.10
@@ -46,7 +47,7 @@ hepunits==2.1.0
 identify==1.5.14
 idna==2.10
 imagesize==1.2.0
-importlib-metadata==3.4.0
+importlib-metadata==3.7.0
 iniconfig==1.1.1
 ipykernel==5.5.0
 ipython-genutils==0.2.0
@@ -61,13 +62,14 @@ jupyter-cache==0.4.2
 jupyter-client==6.1.11
 jupyter-console==6.2.0
 jupyter-core==4.7.1
-jupyter-server==1.4.0
+jupyter-packaging==0.7.12
+jupyter-server==1.4.1
 jupyter-sphinx==0.3.1
 jupyter==1.0.0
 jupyterlab-code-formatter==1.4.4
 jupyterlab-server==2.3.0
 jupyterlab-widgets==1.0.0
-jupyterlab==3.0.8
+jupyterlab==3.0.9
 labels==20.1.0
 lazy-object-proxy==1.5.2
 livereload==2.6.3
@@ -78,10 +80,10 @@ mdit-py-plugins==0.2.5
 mistune==0.8.4
 mypy-extensions==0.4.3
 mypy==0.812
-myst-nb==0.11.1
+myst-nb==0.12.0
 myst-parser==0.13.5
 nbclassic==0.2.6
-nbclient==0.5.2
+nbclient==0.5.3
 nbconvert==5.6.1
 nbdime==2.1.0
 nbformat==5.1.2
@@ -112,7 +114,7 @@ pydocstyle==5.1.1
 pydot==1.4.2
 pyflakes==2.2.0
 pygments==2.8.0
-pylint==2.7.0
+pylint==2.7.1
 pyparsing==2.4.7
 pyrsistent==0.17.3
 pytest-cov==2.11.1
@@ -158,7 +160,7 @@ testpath==0.4.4
 toml==0.10.2
 tornado==6.1
 tox==3.22.0
-tqdm==4.57.0
+tqdm==4.58.0
 traitlets==5.0.5
 typed-ast==1.4.2
 typing-extensions==3.7.4.3

--- a/reqs/3.9/requirements-doc.txt
+++ b/reqs/3.9/requirements-doc.txt
@@ -28,7 +28,7 @@ graphviz==0.16
 hepunits==2.1.0
 idna==2.10
 imagesize==1.2.0
-importlib-metadata==3.4.0
+importlib-metadata==3.7.0
 ipykernel==5.5.0
 ipython-genutils==0.2.0
 ipython==7.20.0
@@ -47,9 +47,9 @@ markdown-it-py==0.6.2
 markupsafe==1.1.1
 mdit-py-plugins==0.2.5
 mistune==0.8.4
-myst-nb==0.11.1
+myst-nb==0.12.0
 myst-parser==0.13.5
-nbclient==0.5.2
+nbclient==0.5.3
 nbconvert==5.6.1
 nbdime==2.1.0
 nbformat==5.1.2
@@ -99,7 +99,7 @@ sqlalchemy==1.3.23
 terminado==0.9.2
 testpath==0.4.4
 tornado==6.1
-tqdm==4.57.0
+tqdm==4.58.0
 traitlets==5.0.5
 urllib3==1.26.3
 wcwidth==0.2.5

--- a/reqs/3.9/requirements-sty.txt
+++ b/reqs/3.9/requirements-sty.txt
@@ -48,7 +48,7 @@ pycodestyle==2.6.0
 pydocstyle==5.1.1
 pydot==1.4.2
 pyflakes==2.2.0
-pylint==2.7.0
+pylint==2.7.1
 pyparsing==2.4.7
 pyrsistent==0.17.3
 pytest-cov==2.11.1
@@ -63,7 +63,7 @@ restructuredtext-lint==1.3.2
 six==1.15.0
 snowballstemmer==2.1.0
 toml==0.10.2
-tqdm==4.57.0
+tqdm==4.58.0
 traitlets==5.0.5
 typed-ast==1.4.2
 typing-extensions==3.7.4.3

--- a/reqs/3.9/requirements-test.txt
+++ b/reqs/3.9/requirements-test.txt
@@ -28,7 +28,7 @@ python-constraint==1.4.0
 pyyaml==5.4.1
 six==1.15.0
 toml==0.10.2
-tqdm==4.57.0
+tqdm==4.58.0
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/reqs/3.9/requirements.txt
+++ b/reqs/3.9/requirements.txt
@@ -12,7 +12,7 @@ pyrsistent==0.17.3
 python-constraint==1.4.0
 pyyaml==5.4.1
 six==1.15.0
-tqdm==4.57.0
+tqdm==4.58.0
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/reqs/requirements-dev.in
+++ b/reqs/requirements-dev.in
@@ -4,6 +4,7 @@
 -r requirements-sty.in
 
 # Additional developer tools
+aquirdturtle_collapsible_headings
 jupyterlab
 jupyterlab-code-formatter
 labels


### PR DESCRIPTION
Adds [`aquirdturtle-collapsible-headings`](https://pypi.org/project/aquirdturtle-collapsible-headings) to the dev requirements. Activates directly through `pip` install since Jupyter Lab v3, so no need to call `jupyter labextension install`. Helps to keep notebooks organised while working on them:
![image](https://user-images.githubusercontent.com/29308176/109308562-7a4d6800-7842-11eb-80eb-180d85cb2fa8.png)
