### PR TITLE
refactor: relabel edge IDs to range [-m, n+i]

### DIFF
--- a/src/expertsystem/reaction/topology.py
+++ b/src/expertsystem/reaction/topology.py
@@ -237,6 +237,31 @@ class Topology:
             temp_edge_list = new_temp_edge_list
         return edge_ids
 
+    def relabel_edges(self, mapping: Mapping[int, int]) -> "Topology":
+        mapping = dict(mapping)
+        if not set(mapping) <= set(self.edges):
+            raise KeyError(
+                f"Keys {set(mapping)} do not match the existing edge IDs {set(self.edges)}"
+            )
+        # perform swappings if mapping to existing IDs
+        mapping.update(
+            {
+                new_edge_id: old_edge_id
+                for old_edge_id, new_edge_id in mapping.items()
+                if new_edge_id in self.edges
+            }
+        )
+        new_edge_ids = set(mapping.values())
+        if len(new_edge_ids) != len(mapping):
+            raise ValueError(f"Mapping {mapping} is not a bijection")
+        new_edges = dict(self.edges.items())
+        new_edges = {mapping.get(i, i): edge for i, edge in self.edges.items()}
+        if len(new_edges) != len(self.edges):
+            raise ValueError(
+                f"Mapping {mapping} resulted in a different number of edge IDs"
+            )
+        return attr.evolve(self, edges=FrozenDict(new_edges))
+
     def swap_edges(self, edge_id1: int, edge_id2: int) -> "Topology":
         new_edges = dict(self.edges.items())
         new_edges.update(

--- a/src/expertsystem/reaction/topology.py
+++ b/src/expertsystem/reaction/topology.py
@@ -237,6 +237,35 @@ class Topology:
             temp_edge_list = new_temp_edge_list
         return edge_ids
 
+    def organize_edge_ids(self) -> "Topology":
+        """Create a new topology with edge IDs in range :code:`[-m, n+i]`.
+
+        where :code:`m` is the number of `.incoming_edge_ids`, :code:`n` is the
+        number of `.outgoing_edge_ids`, and :code:`i` is the number of
+        `.intermediate_edge_ids`.
+
+        In other words, relabel the edges so that:
+
+        - `.incoming_edge_ids` lies in the range :code:`[-1, -2, ...]`
+        - `.outgoing_edge_ids` lies in the range :code:`[0, 1, ..., n]`
+        - `.intermediate_edge_ids` lies in the range :code:`[n+1, n+2, ...]`
+        """
+        new_edges = dict()
+        # Relabel so that initial edge IDs are [-1, -2, ...]
+        for new_edge_id, edge_id in zip(
+            range(-1, -len(self.incoming_edge_ids) - 1, -1),
+            self.incoming_edge_ids,
+        ):
+            new_edges[new_edge_id] = self.edges[edge_id]
+        # Relabel so that
+        # outgoing edge IDs are [0, 1, 2, ..., n]
+        # intermediate edge IDs are [n+1, n+2, ...]
+        for new_edge_id, edge_id in enumerate(
+            tuple(self.outgoing_edge_ids) + tuple(self.intermediate_edge_ids)
+        ):
+            new_edges[new_edge_id] = self.edges[edge_id]
+        return attr.evolve(self, edges=new_edges)
+
     def swap_edges(self, edge_id1: int, edge_id2: int) -> "Topology":
         new_edges = dict(self.edges.items())
         new_edges.update(
@@ -428,22 +457,7 @@ class SimpleStateTransitionTopologyBuilder:
         topologies = list()
         for graph_tuple in graph_tuple_list:
             topology = graph_tuple[0].freeze()
-            new_edges = dict()
-            # Relabel so that initial edge IDs are [-1, -2, ...]
-            for new_edge_id, edge_id in zip(
-                range(-1, -len(topology.incoming_edge_ids) - 1, -1),
-                topology.incoming_edge_ids,
-            ):
-                new_edges[new_edge_id] = topology.edges[edge_id]
-            # Relabel so that
-            # outgoing edge IDs are [0, 1, 2, ..., n]
-            # intermediate edge IDs are [n+1, n+2, ...]
-            for new_edge_id, edge_id in enumerate(
-                tuple(topology.outgoing_edge_ids)
-                + tuple(topology.intermediate_edge_ids)
-            ):
-                new_edges[new_edge_id] = topology.edges[edge_id]
-            topology = attr.evolve(topology, edges=new_edges)
+            topology = topology.organize_edge_ids()
             topologies.append(topology)
         return tuple(topologies)
 

--- a/src/expertsystem/reaction/topology.py
+++ b/src/expertsystem/reaction/topology.py
@@ -237,31 +237,6 @@ class Topology:
             temp_edge_list = new_temp_edge_list
         return edge_ids
 
-    def relabel_edges(self, mapping: Mapping[int, int]) -> "Topology":
-        mapping = dict(mapping)
-        if not set(mapping) <= set(self.edges):
-            raise KeyError(
-                f"Keys {set(mapping)} do not match the existing edge IDs {set(self.edges)}"
-            )
-        # perform swappings if mapping to existing IDs
-        mapping.update(
-            {
-                new_edge_id: old_edge_id
-                for old_edge_id, new_edge_id in mapping.items()
-                if new_edge_id in self.edges
-            }
-        )
-        new_edge_ids = set(mapping.values())
-        if len(new_edge_ids) != len(mapping):
-            raise ValueError(f"Mapping {mapping} is not a bijection")
-        new_edges = dict(self.edges.items())
-        new_edges = {mapping.get(i, i): edge for i, edge in self.edges.items()}
-        if len(new_edges) != len(self.edges):
-            raise ValueError(
-                f"Mapping {mapping} resulted in a different number of edge IDs"
-            )
-        return attr.evolve(self, edges=FrozenDict(new_edges))
-
     def swap_edges(self, edge_id1: int, edge_id2: int) -> "Topology":
         new_edges = dict(self.edges.items())
         new_edges.update(

--- a/src/expertsystem/schemas/amplitude-model.json
+++ b/src/expertsystem/schemas/amplitude-model.json
@@ -25,7 +25,7 @@
           "type": "object",
           "additionalProperties": false,
           "patternProperties": {
-            "^[0-9]+$": { "type": "string" }
+            "^-?[0-9]+$": { "type": "string" }
           }
         },
         "final_state": {

--- a/tests/unit/amplitude/test_model.py
+++ b/tests/unit/amplitude/test_model.py
@@ -63,10 +63,10 @@ class TestKinematics:
         kinematics = Kinematics.from_graph(graph)
         assert len(kinematics.initial_state) == 1
         assert len(kinematics.final_state) == 3
-        assert kinematics.id_to_particle[0].name == "J/psi(1S)"
-        assert kinematics.id_to_particle[2].name == "gamma"
-        assert kinematics.id_to_particle[3].name == "pi0"
-        assert kinematics.id_to_particle[4].name == "pi0"
+        assert kinematics.id_to_particle[-1].name == "J/psi(1S)"
+        assert kinematics.id_to_particle[0].name == "gamma"
+        assert kinematics.id_to_particle[1].name == "pi0"
+        assert kinematics.id_to_particle[2].name == "pi0"
         assert kinematics.type == KinematicsType.HELICITY
 
 

--- a/tests/unit/io/expected_recipe.yml
+++ b/tests/unit/io/expected_recipe.yml
@@ -1,11 +1,11 @@
 kinematics:
   type: HELICITY
   initial_state:
-    0: J/psi(1S)
+    -1: J/psi(1S)
   final_state:
-    2: gamma
-    3: pi0
-    4: pi0
+    0: gamma
+    1: pi0
+    2: pi0
 
 parameters:
   - name: &par1 Magnitude_J/psi(1S)_to_f(0)(980)_0+gamma_1;f(0)(980)_to_pi0_0+pi0_0;

--- a/tests/unit/io/test_dict.py
+++ b/tests/unit/io/test_dict.py
@@ -116,8 +116,8 @@ class TestHelicityFormalism:
         initial_state = kinematics["initial_state"]
         final_state = kinematics["final_state"]
         assert kinematics["type"] == "HELICITY"
-        assert initial_state == {0: "J/psi(1S)"}
-        assert final_state == {2: "gamma", 3: "pi0", 4: "pi0"}
+        assert initial_state == {-1: "J/psi(1S)"}
+        assert final_state == {0: "gamma", 1: "pi0", 2: "pi0"}
 
     def test_parameter_section(self, imported_dict):
         parameter_list = imported_dict["parameters"]

--- a/tests/unit/reaction/test_combinatorics.py
+++ b/tests/unit/reaction/test_combinatorics.py
@@ -101,7 +101,12 @@ class TestKinematicRepresentation:
     def test_from_topology(three_body_decay: Topology):
         pi0 = ("pi0", [0])
         gamma = ("gamma", [-1, 1])
-        edge_props = {0: ("J/psi", [-1, +1]), 2: pi0, 3: pi0, 4: gamma}
+        edge_props = {
+            -1: ("J/psi", [-1, +1]),
+            0: pi0,
+            1: pi0,
+            2: gamma,
+        }
         kinematic_representation1 = _get_kinematic_representation(
             three_body_decay, edge_props
         )
@@ -116,17 +121,22 @@ class TestKinematicRepresentation:
 
         kinematic_representation2 = _get_kinematic_representation(
             topology=three_body_decay,
-            initial_facts={0: ("J/psi", [-1, +1]), 2: pi0, 3: gamma, 4: pi0},
+            initial_facts={
+                -1: ("J/psi", [-1, +1]),
+                0: pi0,
+                1: gamma,
+                2: pi0,
+            },
         )
         assert kinematic_representation1 == kinematic_representation2
 
         kinematic_representation3 = _get_kinematic_representation(
             topology=three_body_decay,
             initial_facts={
-                0: ("J/psi", [-1, +1]),
-                2: pi0,
-                3: gamma,
-                4: gamma,
+                -1: ("J/psi", [-1, +1]),
+                0: pi0,
+                1: gamma,
+                2: gamma,
             },
         )
         assert kinematic_representation2 != kinematic_representation3
@@ -200,9 +210,9 @@ def test_generate_permutations(
         permutation0, particle_database
     )
     assert len(spin_permutations) == 4
+    assert spin_permutations[0][-1][1] == -1
     assert spin_permutations[0][0][1] == -1
-    assert spin_permutations[0][2][1] == -1
-    assert spin_permutations[1][0][1] == -1
-    assert spin_permutations[1][2][1] == +1
-    assert spin_permutations[2][0][1] == +1
-    assert spin_permutations[3][0][1] == +1
+    assert spin_permutations[1][-1][1] == -1
+    assert spin_permutations[1][0][1] == +1
+    assert spin_permutations[2][-1][1] == +1
+    assert spin_permutations[3][-1][1] == +1

--- a/tests/unit/reaction/test_solving.py
+++ b/tests/unit/reaction/test_solving.py
@@ -21,10 +21,10 @@ class TestResult:
         result = jpsi_to_gamma_pi_pi_helicity_solutions
         particle_graphs = result.get_particle_graphs()
         assert len(particle_graphs) == 2
-        assert particle_graphs[0].get_edge_props(1) == pdg["f(0)(980)"]
-        assert particle_graphs[1].get_edge_props(1) == pdg["f(0)(1500)"]
+        assert particle_graphs[0].get_edge_props(3) == pdg["f(0)(980)"]
+        assert particle_graphs[1].get_edge_props(3) == pdg["f(0)(1500)"]
         assert len(particle_graphs[0].topology.edges) == 5
-        for edge_id in (0, 2, 3, 4):
+        for edge_id in range(-1, 3):
             assert particle_graphs[0].get_edge_props(
                 edge_id
             ) is particle_graphs[1].get_edge_props(edge_id)

--- a/tests/unit/reaction/test_topology.py
+++ b/tests/unit/reaction/test_topology.py
@@ -225,6 +225,18 @@ class TestTopology:
             node += 666
         assert two_to_three_decay.nodes == {0, 1, 2}
 
+    def test_relabel_edges(self, two_to_three_decay: Topology):
+        with pytest.raises(KeyError):
+            two_to_three_decay.relabel_edges({10: 2})
+        new_topology = two_to_three_decay.relabel_edges({2: 6})
+        assert new_topology.incoming_edge_ids == frozenset({0, 1})
+        assert new_topology.intermediate_edge_ids == frozenset({3, 6})
+        assert new_topology.outgoing_edge_ids == frozenset({2, 4, 5})
+        new_topology = two_to_three_decay.relabel_edges({2: 10})
+        assert new_topology.incoming_edge_ids == frozenset({0, 1})
+        assert new_topology.intermediate_edge_ids == frozenset({3, 10})
+        assert new_topology.outgoing_edge_ids == frozenset({4, 5, 6})
+
     @staticmethod
     def test_swap_edges(two_to_three_decay: Topology):
         original_topology = two_to_three_decay

--- a/tests/unit/reaction/test_topology.py
+++ b/tests/unit/reaction/test_topology.py
@@ -225,18 +225,6 @@ class TestTopology:
             node += 666
         assert two_to_three_decay.nodes == {0, 1, 2}
 
-    def test_relabel_edges(self, two_to_three_decay: Topology):
-        with pytest.raises(KeyError):
-            two_to_three_decay.relabel_edges({10: 2})
-        new_topology = two_to_three_decay.relabel_edges({2: 6})
-        assert new_topology.incoming_edge_ids == frozenset({0, 1})
-        assert new_topology.intermediate_edge_ids == frozenset({3, 6})
-        assert new_topology.outgoing_edge_ids == frozenset({2, 4, 5})
-        new_topology = two_to_three_decay.relabel_edges({2: 10})
-        assert new_topology.incoming_edge_ids == frozenset({0, 1})
-        assert new_topology.intermediate_edge_ids == frozenset({3, 10})
-        assert new_topology.outgoing_edge_ids == frozenset({4, 5, 6})
-
     @staticmethod
     def test_swap_edges(two_to_three_decay: Topology):
         original_topology = two_to_three_decay

--- a/tests/unit/reaction/test_topology.py
+++ b/tests/unit/reaction/test_topology.py
@@ -226,6 +226,13 @@ class TestTopology:
         assert two_to_three_decay.nodes == {0, 1, 2}
 
     @staticmethod
+    def test_organize_edge_ids(two_to_three_decay: Topology):
+        topology = two_to_three_decay.organize_edge_ids()
+        assert topology.incoming_edge_ids == frozenset({-1, -2})
+        assert topology.outgoing_edge_ids == frozenset({0, 1, 2})
+        assert topology.intermediate_edge_ids == frozenset({3, 4})
+
+    @staticmethod
     def test_swap_edges(two_to_three_decay: Topology):
         original_topology = two_to_three_decay
         topology = original_topology.swap_edges(0, 1)


### PR DESCRIPTION
The `SimpleStateTransitionTopologyBuilder` now creates topologies that are labeled in such a way that:

- initial edges are labeled `[-1, -2, ...]`
- final edges are labeled `[0, 1, 2, ..., n]`
- intermediate edges are labeled `[n+1, n+2, ...]`

This way, final state and intermediate state edge IDs are always within the same domain, no matter the underlying topology.

**Old (9ea200a9)**
|  |  |  |
| --- | --- | --- |
| ![image](https://user-images.githubusercontent.com/29308176/109818216-0987c080-7c33-11eb-9a7b-9221570ecb02.png) | ![image](https://user-images.githubusercontent.com/29308176/109818239-0f7da180-7c33-11eb-8402-f7987058c614.png) | ![image](https://user-images.githubusercontent.com/29308176/109818392-39cf5f00-7c33-11eb-8dc0-5f280303b0bd.png) |

**New (2579a837)**
|  |  |  |
| --- | --- | --- |
| ![image](https://user-images.githubusercontent.com/29308176/109818026-d6ddc800-7c32-11eb-8d5d-db2e0d736d43.png) | ![image](https://user-images.githubusercontent.com/29308176/109818040-db09e580-7c32-11eb-89b0-4e11481f616f.png) | ![image](https://user-images.githubusercontent.com/29308176/109818523-5b304b00-7c33-11eb-8384-16d2cc678f8d.png) |

