### PR TITLE
feat: implement time-ordered nodes and decay path

### DIFF
--- a/tests/unit/reaction/test_topology.py
+++ b/tests/unit/reaction/test_topology.py
@@ -18,6 +18,7 @@ from expertsystem.reaction.topology import (
     _MutableTopology,
     create_isobar_topologies,
     create_n_body_topology,
+    get_decay_path_representation,
     get_originating_node_list,
     get_time_ordered_nodes,
 )
@@ -302,6 +303,70 @@ def test_create_n_body_topology(n_initial: int, n_final: int, exception):
         assert len(topology.outgoing_edge_ids) == n_final
         assert len(topology.intermediate_edge_ids) == 0
         assert len(topology.nodes) == 1
+
+
+@pytest.mark.parametrize(
+    "n_final_states, expected",
+    [
+        (
+            2,
+            [
+                (0, 1),
+            ],
+        ),
+        (
+            3,
+            [
+                (0, (1, 2)),
+            ],
+        ),
+        (
+            4,
+            [
+                ((0, 1), (2, 3)),
+                (0, (1, (2, 3))),
+            ],
+        ),
+        (
+            5,
+            [
+                ((0, (3, 4)), (1, 2)),
+                ((0, 1), (2, (3, 4))),
+                ((0, (1, 2)), (3, 4)),
+                (0, ((1, 2), (3, 4))),
+                (0, (1, (2, (3, 4)))),
+            ],
+        ),
+        (
+            6,
+            [
+                (((2, 3), (4, 5)), (0, 1)),
+                ((0, (2, 3)), (1, (4, 5))),
+                ((0, (3, (4, 5))), (1, 2)),
+                ((0, (4, 5)), (1, (2, 3))),
+                ((0, 1), ((2, 3), (4, 5))),
+                ((0, 1), (2, (3, (4, 5)))),
+                (((0, 1), (4, 5)), (2, 3)),
+                ((0, (1, (4, 5))), (2, 3)),
+                ((0, (1, 2)), (3, (4, 5))),
+                (((0, 1), (2, 3)), (4, 5)),
+                (0, ((1, (4, 5)), (2, 3))),
+                (0, ((1, 2), (3, (4, 5)))),
+                ((0, (1, (2, 3))), (4, 5)),
+                (0, ((1, (2, 3)), (4, 5))),
+                (0, (1, ((2, 3), (4, 5)))),
+                (0, (1, (2, (3, (4, 5))))),
+            ],
+        ),
+    ],
+)
+def test_get_decay_path_representation(
+    n_final_states: int, expected: Tuple[int, ...]
+):
+    topologies = create_isobar_topologies(n_final_states)
+    assert len(topologies) == len(expected)
+    for i, topology in enumerate(topologies):
+        assert get_decay_path_representation(topology) == expected[i]
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/reaction/test_topology.py
+++ b/tests/unit/reaction/test_topology.py
@@ -2,6 +2,7 @@
 # pylint: disable=no-self-use, redefined-outer-name, too-many-arguments
 
 import typing
+from typing import Tuple
 
 import attr
 import pytest
@@ -18,6 +19,7 @@ from expertsystem.reaction.topology import (
     create_isobar_topologies,
     create_n_body_topology,
     get_originating_node_list,
+    get_time_ordered_nodes,
 )
 
 
@@ -300,3 +302,67 @@ def test_create_n_body_topology(n_initial: int, n_final: int, exception):
         assert len(topology.outgoing_edge_ids) == n_final
         assert len(topology.intermediate_edge_ids) == 0
         assert len(topology.nodes) == 1
+
+
+@pytest.mark.parametrize(
+    "n_final_states, expected",
+    [
+        (
+            2,
+            [
+                (0,),
+            ],
+        ),
+        (
+            3,
+            [
+                (0, 1),
+            ],
+        ),
+        (
+            4,
+            [
+                (0, 1, 2),
+                (0, 1, 2),
+            ],
+        ),
+        (
+            5,
+            [
+                (0, 1, 3, 2),
+                (0, 1, 2, 3),
+                (0, 1, 2, 3),
+                (0, 1, 2, 3),
+                (0, 1, 2, 3),
+            ],
+        ),
+        (
+            6,
+            [
+                (0, 1, 3, 4, 2),
+                (0, 1, 3, 2, 4),
+                (0, 1, 3, 4, 2),
+                (0, 1, 4, 2, 3),
+                (0, 1, 2, 3, 4),
+                (0, 1, 2, 3, 4),
+                (0, 1, 2, 4, 3),
+                (0, 1, 2, 4, 3),
+                (0, 1, 2, 3, 4),
+                (0, 1, 2, 3, 4),
+                (0, 1, 2, 4, 3),
+                (0, 1, 2, 3, 4),
+                (0, 1, 2, 3, 4),
+                (0, 1, 2, 3, 4),
+                (0, 1, 2, 3, 4),
+                (0, 1, 2, 3, 4),
+            ],
+        ),
+    ],
+)
+def test_get_time_ordered_nodes(
+    n_final_states: int, expected: Tuple[int, ...]
+):
+    topologies = create_isobar_topologies(n_final_states)
+    assert len(topologies) == len(expected)
+    for i, topology in enumerate(topologies):
+        assert get_time_ordered_nodes(topology) == expected[i]

--- a/tests/unit/reaction/test_topology.py
+++ b/tests/unit/reaction/test_topology.py
@@ -2,7 +2,8 @@
 # pylint: disable=no-self-use, redefined-outer-name, too-many-arguments
 
 import typing
-from typing import Tuple
+from collections import abc
+from typing import Iterable, Tuple
 
 import attr
 import pytest
@@ -363,10 +364,21 @@ def test_create_n_body_topology(n_initial: int, n_final: int, exception):
 def test_get_decay_path_representation(
     n_final_states: int, expected: Tuple[int, ...]
 ):
+    def flatten(nested_list: Iterable) -> list:
+        ids = list()
+        for x in nested_list:
+            if isinstance(x, abc.Iterable):
+                ids.extend(flatten(x))
+            else:
+                ids.append(x)
+        return ids
+
     topologies = create_isobar_topologies(n_final_states)
     assert len(topologies) == len(expected)
     for i, topology in enumerate(topologies):
-        assert get_decay_path_representation(topology) == expected[i]
+        decay_path = get_decay_path_representation(topology)
+        assert set(flatten(decay_path)) == topology.outgoing_edge_ids
+        assert decay_path == expected[i]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
**`get_time_ordered_nodes`**
```python
>>> from expertsystem.reaction.topology import (
...     create_isobar_topologies,
...     get_time_ordered_nodes,
... )
>>> topologies = create_isobar_topologies(5)
>>> get_time_ordered_nodes(topologies[0])
(0, 1, 3, 2)
>>> get_time_ordered_nodes(topologies[1])
(0, 1, 2, 3)
```
**`get_decay_path_representation`**
```python
>>> from expertsystem.reaction.topology import (
...     create_isobar_topologies,
...     get_decay_path_representation,
... )
>>> topology = create_isobar_topologies(3)[0]
>>> get_decay_path_representation(topology)
(0, (1, 2))
>>> topologies = create_isobar_topologies(4)
>>> get_decay_path_representation(topologies[0])
((0, 1), (2, 3))
>>> get_decay_path_representation(topologies[1])
(0, (1, (2, 3)))
```

|  |  |  |  |
| --- | --- | --- | --- |
| time-ordered nodes | `(0, 1, 3, 2)` | `(0, 1, 2, 3)` | `(0, 1, 2, 3)` |
| decay path representation | `((0, (3, 4)), (1, 2)),` | `((0, 1), (2, (3, 4)))` | `((0, (1, 2)), (3, 4))` |
| `Topology` | ![image](https://user-images.githubusercontent.com/29308176/109820544-64221c00-7c35-11eb-85b5-0134ffcf7046.png) | ![image](https://user-images.githubusercontent.com/29308176/109820570-6ab09380-7c35-11eb-86e7-a8bb2cb397ff.png) | ![image](https://user-images.githubusercontent.com/29308176/109828890-56709480-7c3d-11eb-8d2d-abd575c43661.png) |

