### PR TITLE
fix: use tqdm.autonotebook

### DIFF
--- a/reqs/3.6/requirements-dev.txt
+++ b/reqs/3.6/requirements-dev.txt
@@ -28,14 +28,14 @@ contextvars==2.4
 coverage==5.5
 dataclasses==0.8
 decorator==4.4.2
-defusedxml==0.7.0
+defusedxml==0.7.1
 distlib==0.3.1
 docutils==0.16
 entrypoints==0.3
 execnet==1.8.0
 filelock==3.0.12
 flake8-blind-except==0.2.0
-flake8-bugbear==21.3.1
+flake8-bugbear==21.3.2
 flake8-builtins==1.5.3
 flake8-polyfill==1.0.2
 flake8-rst-docstrings==0.0.14
@@ -46,7 +46,7 @@ gitpython==3.1.14
 gprof2dot==2021.2.21
 graphviz==0.16
 hepunits==2.1.0
-identify==2.1.0
+identify==2.1.1
 idna==2.10
 imagesize==1.2.0
 immutables==0.15
@@ -73,7 +73,7 @@ jupyter==1.0.0
 jupyterlab-code-formatter==1.4.4
 jupyterlab-server==2.3.0
 jupyterlab-widgets==1.0.0
-jupyterlab==3.0.9
+jupyterlab==3.0.10
 labels==20.1.0
 lazy-object-proxy==1.5.2
 livereload==2.6.3
@@ -105,7 +105,7 @@ pexpect==4.8.0
 pickleshare==0.7.5
 pip-tools==5.5.0
 pluggy==0.13.1
-pre-commit==2.11.0
+pre-commit==2.11.1
 prometheus-client==0.9.0
 prompt-toolkit==3.0.16
 ptyprocess==0.7.0
@@ -144,7 +144,7 @@ sniffio==1.2.0
 snowballstemmer==2.1.0
 soupsieve==2.2
 sphinx-autobuild==2020.9.1
-sphinx-book-theme==0.0.40
+sphinx-book-theme==0.0.41
 sphinx-copybutton==0.3.1
 sphinx-panels==0.5.2
 sphinx-thebe==0.0.8

--- a/reqs/3.6/requirements-doc.txt
+++ b/reqs/3.6/requirements-doc.txt
@@ -18,7 +18,7 @@ chardet==4.0.0
 click==7.1.2
 colorama==0.4.4
 decorator==4.4.2
-defusedxml==0.7.0
+defusedxml==0.7.1
 docutils==0.16
 entrypoints==0.3
 fuzzywuzzy==0.18.0
@@ -83,7 +83,7 @@ six==1.15.0
 smmap==3.0.5
 snowballstemmer==2.1.0
 soupsieve==2.2
-sphinx-book-theme==0.0.40
+sphinx-book-theme==0.0.41
 sphinx-copybutton==0.3.1
 sphinx-panels==0.5.2
 sphinx-thebe==0.0.8

--- a/reqs/3.6/requirements-sty.txt
+++ b/reqs/3.6/requirements-sty.txt
@@ -19,14 +19,14 @@ docutils==0.16
 execnet==1.8.0
 filelock==3.0.12
 flake8-blind-except==0.2.0
-flake8-bugbear==21.3.1
+flake8-bugbear==21.3.2
 flake8-builtins==1.5.3
 flake8-polyfill==1.0.2
 flake8-rst-docstrings==0.0.14
 flake8==3.8.4
 gprof2dot==2021.2.21
 hepunits==2.1.0
-identify==2.1.0
+identify==2.1.1
 importlib-metadata==3.7.2
 importlib-resources==3.0.0
 iniconfig==1.1.1
@@ -46,7 +46,7 @@ particle==0.14.0
 pathspec==0.8.1
 pep8-naming==0.11.1
 pluggy==0.13.1
-pre-commit==2.11.0
+pre-commit==2.11.1
 py==1.10.0
 pycodestyle==2.6.0
 pydocstyle==5.1.1

--- a/reqs/3.7/requirements-dev.txt
+++ b/reqs/3.7/requirements-dev.txt
@@ -26,14 +26,14 @@ click==7.1.2
 colorama==0.4.4
 coverage==5.5
 decorator==4.4.2
-defusedxml==0.7.0
+defusedxml==0.7.1
 distlib==0.3.1
 docutils==0.16
 entrypoints==0.3
 execnet==1.8.0
 filelock==3.0.12
 flake8-blind-except==0.2.0
-flake8-bugbear==21.3.1
+flake8-bugbear==21.3.2
 flake8-builtins==1.5.3
 flake8-polyfill==1.0.2
 flake8-rst-docstrings==0.0.14
@@ -44,7 +44,7 @@ gitpython==3.1.14
 gprof2dot==2021.2.21
 graphviz==0.16
 hepunits==2.1.0
-identify==2.1.0
+identify==2.1.1
 idna==2.10
 imagesize==1.2.0
 importlib-metadata==3.7.2
@@ -69,7 +69,7 @@ jupyter==1.0.0
 jupyterlab-code-formatter==1.4.4
 jupyterlab-server==2.3.0
 jupyterlab-widgets==1.0.0
-jupyterlab==3.0.9
+jupyterlab==3.0.10
 labels==20.1.0
 lazy-object-proxy==1.5.2
 livereload==2.6.3
@@ -101,7 +101,7 @@ pexpect==4.8.0
 pickleshare==0.7.5
 pip-tools==5.5.0
 pluggy==0.13.1
-pre-commit==2.11.0
+pre-commit==2.11.1
 prometheus-client==0.9.0
 prompt-toolkit==3.0.16
 ptyprocess==0.7.0
@@ -140,7 +140,7 @@ sniffio==1.2.0
 snowballstemmer==2.1.0
 soupsieve==2.2
 sphinx-autobuild==2020.9.1
-sphinx-book-theme==0.0.40
+sphinx-book-theme==0.0.41
 sphinx-copybutton==0.3.1
 sphinx-panels==0.5.2
 sphinx-thebe==0.0.8

--- a/reqs/3.7/requirements-doc.txt
+++ b/reqs/3.7/requirements-doc.txt
@@ -18,7 +18,7 @@ chardet==4.0.0
 click==7.1.2
 colorama==0.4.4
 decorator==4.4.2
-defusedxml==0.7.0
+defusedxml==0.7.1
 docutils==0.16
 entrypoints==0.3
 fuzzywuzzy==0.18.0
@@ -82,7 +82,7 @@ six==1.15.0
 smmap==3.0.5
 snowballstemmer==2.1.0
 soupsieve==2.2
-sphinx-book-theme==0.0.40
+sphinx-book-theme==0.0.41
 sphinx-copybutton==0.3.1
 sphinx-panels==0.5.2
 sphinx-thebe==0.0.8

--- a/reqs/3.7/requirements-sty.txt
+++ b/reqs/3.7/requirements-sty.txt
@@ -17,14 +17,14 @@ docutils==0.16
 execnet==1.8.0
 filelock==3.0.12
 flake8-blind-except==0.2.0
-flake8-bugbear==21.3.1
+flake8-bugbear==21.3.2
 flake8-builtins==1.5.3
 flake8-polyfill==1.0.2
 flake8-rst-docstrings==0.0.14
 flake8==3.8.4
 gprof2dot==2021.2.21
 hepunits==2.1.0
-identify==2.1.0
+identify==2.1.1
 importlib-metadata==3.7.2
 iniconfig==1.1.1
 ipython-genutils==0.2.0
@@ -43,7 +43,7 @@ particle==0.14.0
 pathspec==0.8.1
 pep8-naming==0.11.1
 pluggy==0.13.1
-pre-commit==2.11.0
+pre-commit==2.11.1
 py==1.10.0
 pycodestyle==2.6.0
 pydocstyle==5.1.1

--- a/reqs/3.8/requirements-dev.txt
+++ b/reqs/3.8/requirements-dev.txt
@@ -26,14 +26,14 @@ click==7.1.2
 colorama==0.4.4
 coverage==5.5
 decorator==4.4.2
-defusedxml==0.7.0
+defusedxml==0.7.1
 distlib==0.3.1
 docutils==0.16
 entrypoints==0.3
 execnet==1.8.0
 filelock==3.0.12
 flake8-blind-except==0.2.0
-flake8-bugbear==21.3.1
+flake8-bugbear==21.3.2
 flake8-builtins==1.5.3
 flake8-polyfill==1.0.2
 flake8-rst-docstrings==0.0.14
@@ -44,7 +44,7 @@ gitpython==3.1.14
 gprof2dot==2021.2.21
 graphviz==0.16
 hepunits==2.1.0
-identify==2.1.0
+identify==2.1.1
 idna==2.10
 imagesize==1.2.0
 importlib-metadata==3.7.2
@@ -69,7 +69,7 @@ jupyter==1.0.0
 jupyterlab-code-formatter==1.4.4
 jupyterlab-server==2.3.0
 jupyterlab-widgets==1.0.0
-jupyterlab==3.0.9
+jupyterlab==3.0.10
 labels==20.1.0
 lazy-object-proxy==1.5.2
 livereload==2.6.3
@@ -101,7 +101,7 @@ pexpect==4.8.0
 pickleshare==0.7.5
 pip-tools==5.5.0
 pluggy==0.13.1
-pre-commit==2.11.0
+pre-commit==2.11.1
 prometheus-client==0.9.0
 prompt-toolkit==3.0.16
 ptyprocess==0.7.0
@@ -140,7 +140,7 @@ sniffio==1.2.0
 snowballstemmer==2.1.0
 soupsieve==2.2
 sphinx-autobuild==2020.9.1
-sphinx-book-theme==0.0.40
+sphinx-book-theme==0.0.41
 sphinx-copybutton==0.3.1
 sphinx-panels==0.5.2
 sphinx-thebe==0.0.8

--- a/reqs/3.8/requirements-doc.txt
+++ b/reqs/3.8/requirements-doc.txt
@@ -18,7 +18,7 @@ chardet==4.0.0
 click==7.1.2
 colorama==0.4.4
 decorator==4.4.2
-defusedxml==0.7.0
+defusedxml==0.7.1
 docutils==0.16
 entrypoints==0.3
 fuzzywuzzy==0.18.0
@@ -82,7 +82,7 @@ six==1.15.0
 smmap==3.0.5
 snowballstemmer==2.1.0
 soupsieve==2.2
-sphinx-book-theme==0.0.40
+sphinx-book-theme==0.0.41
 sphinx-copybutton==0.3.1
 sphinx-panels==0.5.2
 sphinx-thebe==0.0.8

--- a/reqs/3.8/requirements-sty.txt
+++ b/reqs/3.8/requirements-sty.txt
@@ -17,14 +17,14 @@ docutils==0.16
 execnet==1.8.0
 filelock==3.0.12
 flake8-blind-except==0.2.0
-flake8-bugbear==21.3.1
+flake8-bugbear==21.3.2
 flake8-builtins==1.5.3
 flake8-polyfill==1.0.2
 flake8-rst-docstrings==0.0.14
 flake8==3.8.4
 gprof2dot==2021.2.21
 hepunits==2.1.0
-identify==2.1.0
+identify==2.1.1
 iniconfig==1.1.1
 ipython-genutils==0.2.0
 isort==5.7.0
@@ -42,7 +42,7 @@ particle==0.14.0
 pathspec==0.8.1
 pep8-naming==0.11.1
 pluggy==0.13.1
-pre-commit==2.11.0
+pre-commit==2.11.1
 py==1.10.0
 pycodestyle==2.6.0
 pydocstyle==5.1.1

--- a/reqs/3.9/requirements-dev.txt
+++ b/reqs/3.9/requirements-dev.txt
@@ -26,14 +26,14 @@ click==7.1.2
 colorama==0.4.4
 coverage==5.5
 decorator==4.4.2
-defusedxml==0.7.0
+defusedxml==0.7.1
 distlib==0.3.1
 docutils==0.16
 entrypoints==0.3
 execnet==1.8.0
 filelock==3.0.12
 flake8-blind-except==0.2.0
-flake8-bugbear==21.3.1
+flake8-bugbear==21.3.2
 flake8-builtins==1.5.3
 flake8-polyfill==1.0.2
 flake8-rst-docstrings==0.0.14
@@ -44,7 +44,7 @@ gitpython==3.1.14
 gprof2dot==2021.2.21
 graphviz==0.16
 hepunits==2.1.0
-identify==2.1.0
+identify==2.1.1
 idna==2.10
 imagesize==1.2.0
 importlib-metadata==3.7.2
@@ -69,7 +69,7 @@ jupyter==1.0.0
 jupyterlab-code-formatter==1.4.4
 jupyterlab-server==2.3.0
 jupyterlab-widgets==1.0.0
-jupyterlab==3.0.9
+jupyterlab==3.0.10
 labels==20.1.0
 lazy-object-proxy==1.5.2
 livereload==2.6.3
@@ -101,7 +101,7 @@ pexpect==4.8.0
 pickleshare==0.7.5
 pip-tools==5.5.0
 pluggy==0.13.1
-pre-commit==2.11.0
+pre-commit==2.11.1
 prometheus-client==0.9.0
 prompt-toolkit==3.0.16
 ptyprocess==0.7.0
@@ -140,7 +140,7 @@ sniffio==1.2.0
 snowballstemmer==2.1.0
 soupsieve==2.2
 sphinx-autobuild==2020.9.1
-sphinx-book-theme==0.0.40
+sphinx-book-theme==0.0.41
 sphinx-copybutton==0.3.1
 sphinx-panels==0.5.2
 sphinx-thebe==0.0.8

--- a/reqs/3.9/requirements-doc.txt
+++ b/reqs/3.9/requirements-doc.txt
@@ -18,7 +18,7 @@ chardet==4.0.0
 click==7.1.2
 colorama==0.4.4
 decorator==4.4.2
-defusedxml==0.7.0
+defusedxml==0.7.1
 docutils==0.16
 entrypoints==0.3
 fuzzywuzzy==0.18.0
@@ -82,7 +82,7 @@ six==1.15.0
 smmap==3.0.5
 snowballstemmer==2.1.0
 soupsieve==2.2
-sphinx-book-theme==0.0.40
+sphinx-book-theme==0.0.41
 sphinx-copybutton==0.3.1
 sphinx-panels==0.5.2
 sphinx-thebe==0.0.8

--- a/reqs/3.9/requirements-sty.txt
+++ b/reqs/3.9/requirements-sty.txt
@@ -17,14 +17,14 @@ docutils==0.16
 execnet==1.8.0
 filelock==3.0.12
 flake8-blind-except==0.2.0
-flake8-bugbear==21.3.1
+flake8-bugbear==21.3.2
 flake8-builtins==1.5.3
 flake8-polyfill==1.0.2
 flake8-rst-docstrings==0.0.14
 flake8==3.8.4
 gprof2dot==2021.2.21
 hepunits==2.1.0
-identify==2.1.0
+identify==2.1.1
 iniconfig==1.1.1
 ipython-genutils==0.2.0
 isort==5.7.0
@@ -42,7 +42,7 @@ particle==0.14.0
 pathspec==0.8.1
 pep8-naming==0.11.1
 pluggy==0.13.1
-pre-commit==2.11.0
+pre-commit==2.11.1
 py==1.10.0
 pycodestyle==2.6.0
 pydocstyle==5.1.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,7 @@ install_requires =
     particle
     python-constraint
     PyYAML
-    tqdm
+    tqdm >= 4.24.0  # autonotebook
     typing-extensions; python_version < "3.8.0"
 packages = find:
 package_dir =

--- a/src/expertsystem/reaction/__init__.py
+++ b/src/expertsystem/reaction/__init__.py
@@ -28,7 +28,7 @@ from typing import (
 )
 
 import attr
-from tqdm import tqdm
+from tqdm.auto import tqdm
 
 from expertsystem import io
 from expertsystem.particle import Particle, ParticleCollection


### PR DESCRIPTION
Previously, the progress bar was using a `tqdm` instance for console, which results in rendering errors in notebooks. This PR uses `from tqdm.auto import tqdm`. See https://github.com/tqdm/tqdm#ipythonjupyter-integration

![image](https://user-images.githubusercontent.com/29308176/110778200-54708c00-8262-11eb-879e-5317b9f09fde.png)

Unfortunately, the bar is now also rendered in the docs
![image](https://user-images.githubusercontent.com/29308176/110778213-5aff0380-8262-11eb-8cae-374ef2673b96.png)

This is because `autonotebook` is unaffected by
https://github.com/ComPWA/expertsystem/blob/22d6f67dec4716d9d0bddc197c230efb46313e1e/docs/conf.py#L208
(see https://myst-nb.readthedocs.io/en/latest/use/formatting_outputs.html#removing-stdout-and-stderr)
