### PR TITLE
feat: render edge IDs in graph visualization

### DIFF
--- a/docs/usage.ipynb
+++ b/docs/usage.ipynb
@@ -141,7 +141,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.8.8"
   }
  },
  "nbformat": 4,

--- a/docs/usage/visualization.ipynb
+++ b/docs/usage/visualization.ipynb
@@ -95,6 +95,23 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "This can be turned off with the arguments of {func}`.convert_to_dot`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "topologies = create_isobar_topologies(3)\n",
+    "graphviz.Source(io.convert_to_dot(topologies, render_node=False))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## {class}`.StateTransitionGraph`s"
    ]
   },

--- a/docs/usage/visualization.ipynb
+++ b/docs/usage/visualization.ipynb
@@ -211,8 +211,17 @@
    "outputs": [],
    "source": [
     "graphs = result.get_particle_graphs()\n",
-    "dot_source = es.io.convert_to_dot(graphs[:3])\n",
+    "dot_source = es.io.convert_to_dot(graphs[:3], render_edge_id=False)\n",
     "graphviz.Source(dot_source)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "```{note}\n",
+    "By default, `.convert_to_dot` renders edge IDs, because they represent the (final) state IDs as well. In the example above, we switched this off.\n",
+    "```"
    ]
   },
   {
@@ -250,7 +259,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.8.8"
   }
  },
  "nbformat": 4,

--- a/src/expertsystem/io/__init__.py
+++ b/src/expertsystem/io/__init__.py
@@ -119,7 +119,10 @@ def write(instance: object, filename: str) -> None:
     )
 
 
-def convert_to_dot(instance: object) -> str:
+def convert_to_dot(
+    instance: object,
+    render_edge_id: bool = True,
+) -> str:
     """Convert a `object` to a DOT language `str`.
 
     Only works for objects that can be represented as a graph, particularly a
@@ -128,9 +131,15 @@ def convert_to_dot(instance: object) -> str:
     .. seealso:: :doc:`/usage/visualization`
     """
     if isinstance(instance, (StateTransitionGraph, Topology)):
-        return _dot.graph_to_dot(instance)
+        return _dot.graph_to_dot(
+            instance,
+            render_edge_id=render_edge_id,
+        )
     if isinstance(instance, abc.Sequence):
-        return _dot.graph_list_to_dot(instance)
+        return _dot.graph_list_to_dot(
+            instance,
+            render_edge_id=render_edge_id,
+        )
     raise NotImplementedError(
         f"Cannot convert a {instance.__class__.__name__} to DOT language"
     )

--- a/src/expertsystem/io/__init__.py
+++ b/src/expertsystem/io/__init__.py
@@ -122,6 +122,7 @@ def write(instance: object, filename: str) -> None:
 def convert_to_dot(
     instance: object,
     render_edge_id: bool = True,
+    render_node: bool = True,
 ) -> str:
     """Convert a `object` to a DOT language `str`.
 
@@ -134,11 +135,13 @@ def convert_to_dot(
         return _dot.graph_to_dot(
             instance,
             render_edge_id=render_edge_id,
+            render_node=render_node,
         )
     if isinstance(instance, abc.Sequence):
         return _dot.graph_list_to_dot(
             instance,
             render_edge_id=render_edge_id,
+            render_node=render_node,
         )
     raise NotImplementedError(
         f"Cannot convert a {instance.__class__.__name__} to DOT language"

--- a/src/expertsystem/io/_dot.py
+++ b/src/expertsystem/io/_dot.py
@@ -40,6 +40,7 @@ def embed_dot(func: Callable) -> Callable:
 def graph_list_to_dot(
     graphs: Sequence[StateTransitionGraph],
     render_edge_id: bool = True,
+    render_node: bool = True,
 ) -> str:
     dot_source = ""
     for i, graph in enumerate(reversed(graphs)):
@@ -47,6 +48,7 @@ def graph_list_to_dot(
             graph,
             prefix=f"g{i}_",
             render_edge_id=render_edge_id,
+            render_node=render_node,
         )
     return dot_source
 
@@ -55,17 +57,20 @@ def graph_list_to_dot(
 def graph_to_dot(
     graph: StateTransitionGraph,
     render_edge_id: bool = True,
+    render_node: bool = True,
 ) -> str:
     return __graph_to_dot_content(
         graph,
         render_edge_id=render_edge_id,
+        render_node=render_node,
     )
 
 
-def __graph_to_dot_content(
+def __graph_to_dot_content(  # pylint: disable=too-many-locals,too-many-branches
     graph: Union[StateTransitionGraph, Topology],
     prefix: str = "",
     render_edge_id: bool = True,
+    render_node: bool = True,
 ) -> str:
     dot_source = ""
     if isinstance(graph, StateTransitionGraph):
@@ -98,15 +103,20 @@ def __graph_to_dot_content(
     if isinstance(graph, StateTransitionGraph):
         for node_id in topology.nodes:
             node_prop = graph.get_node_props(node_id)
-            node_label = __node_label(node_prop)
+            node_label = ""
+            if render_node:
+                node_label = __node_label(node_prop)
             dot_source += _DOT_DEFAULT_NODE.format(
                 f"{prefix}node{node_id}", node_label
             )
     if isinstance(graph, Topology):
         if len(topology.nodes) > 1:
             for node_id in topology.nodes:
+                node_label = ""
+                if render_node:
+                    node_label = f"({node_id})"
                 dot_source += _DOT_DEFAULT_NODE.format(
-                    f"{prefix}node{node_id}", f"({node_id})"
+                    f"{prefix}node{node_id}", node_label
                 )
     return dot_source
 

--- a/src/expertsystem/io/_dot.py
+++ b/src/expertsystem/io/_dot.py
@@ -114,7 +114,10 @@ def __get_edge_label(
         edge_prop = graph.get_edge_props(edge_id)
         if not edge_prop:
             return str(edge_id)
-        return __edge_label(edge_prop)
+        edge_label = __edge_label(edge_prop)
+        if "\n" in edge_label:
+            return f"{edge_id}:\n{edge_label}"
+        return f"{edge_id}: {edge_label}"
     if isinstance(graph, Topology):
         return str(edge_id)
     raise NotImplementedError


### PR DESCRIPTION
_Extracted from #454 and extended with options to configure_

Result:
<img src="https://user-images.githubusercontent.com/29308176/110808247-15ebc900-8284-11eb-8053-ab98bbf5a1f7.png" width=500>

Since #504, edge IDs have become more important because they are the same as the final state IDs (at least when considering output that comes from the `reaction` module).

In addition, it's possible to switch off node edge ID rendering.