### PR TITLE
feat: export and import transitions to JSON/YAML

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -129,6 +129,7 @@
         "evalf",
         "figsize",
         "flatte",
+        "fromdict",
         "gellmann",
         "genindex",
         "getsource",

--- a/docs/usage/reaction.ipynb
+++ b/docs/usage/reaction.ipynb
@@ -312,7 +312,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "# particles are found by name comparison,\n",
@@ -336,7 +338,62 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 1.4. Generate an amplitude model"
+    "## 1.4 Export generated transitions"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The {class}`.Result`, {class}`.StateTransitionGraph`, and {class}`.Topology` can be serialized to and from a {obj}`dict` with {func}`.io.asdict` and {func}`.io.fromdict`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from expertsystem import io\n",
+    "\n",
+    "graph = result.transitions[0]\n",
+    "io.asdict(graph.topology)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "```{margin}\n",
+    "YAML is more human-readible than JSON, but reading and writing JSON is faster.\n",
+    "```\n",
+    "\n",
+    "This also means that the {obj}`.Result` can be written to JSON or YAML format with {func}`.io.write` and loaded again with {func}`.io.load`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "io.write(result, \"transitions.json\")\n",
+    "imported_result = io.load(\"transitions.json\")\n",
+    "assert imported_result == result"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Handy if it takes a lot of computation time to generate the transitions!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1.5. Generate an amplitude model"
    ]
   },
   {

--- a/docs/usage/reaction.ipynb
+++ b/docs/usage/reaction.ipynb
@@ -365,7 +365,7 @@
    "metadata": {},
    "source": [
     "```{margin}\n",
-    "YAML is more human-readible than JSON, but reading and writing JSON is faster.\n",
+    "YAML is more human-readable than JSON, but reading and writing JSON is faster.\n",
     "```\n",
     "\n",
     "This also means that the {obj}`.Result` can be written to JSON or YAML format with {func}`.io.write` and loaded again with {func}`.io.load`:"

--- a/docs/usage/reaction.ipynb
+++ b/docs/usage/reaction.ipynb
@@ -49,7 +49,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 1.1. Define the problem set"
+    "## 1. Define the problem set"
    ]
   },
   {
@@ -118,7 +118,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 1.2. Prepare Problem Sets"
+    "## 2. Prepare Problem Sets"
    ]
   },
   {
@@ -166,7 +166,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 1.3. Find solutions"
+    "## 3. Find solutions"
    ]
   },
   {
@@ -338,7 +338,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 1.4 Export generated transitions"
+    "## 4. Export generated transitions"
    ]
   },
   {
@@ -393,7 +393,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 1.5. Generate an amplitude model"
+    "## 5. Generate an amplitude model"
    ]
   },
   {

--- a/docs/usage/reaction.ipynb
+++ b/docs/usage/reaction.ipynb
@@ -393,6 +393,15 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "```{warning}\n",
+    "It's not possible to {mod}`pickle` a {class}`.Result`, because {class}`.StateTransitionGraph` makes use of {class}`~typing.Generic`.\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## 5. Generate an amplitude model"
    ]
   },

--- a/docs/usage/visualize.ipynb
+++ b/docs/usage/visualize.ipynb
@@ -141,13 +141,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Convert to DOT and visualize"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "As noted in {ref}`usage/reaction:3. Find solutions`, the {attr}`~.Result.transitions` contain all spin projection combinations (which is necessary for the {mod}`~expertsystem.amplitude` module). It is possible to convert all these solutions to DOT language with {func}`~.asdot`. To avoid visualizing all solutions, we just take a subset of the {attr}`~.Result.transitions`:"
    ]
   },
@@ -209,7 +202,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Collapse graphs"
+    "### Collapse graphs"
    ]
   },
   {

--- a/docs/usage/visualize.ipynb
+++ b/docs/usage/visualize.ipynb
@@ -148,7 +148,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As noted in {ref}`usage/reaction:1.3. Find solutions`, the {attr}`~.Result.transitions` contain all spin projection combinations (which is necessary for the {mod}`~expertsystem.amplitude` module). It is possible to convert all these solutions to DOT language with {func}`~.asdot`. To avoid visualizing all solutions, we just take a subset of the {attr}`~.Result.transitions`:"
+    "As noted in {ref}`usage/reaction:3. Find solutions`, the {attr}`~.Result.transitions` contain all spin projection combinations (which is necessary for the {mod}`~expertsystem.amplitude` module). It is possible to convert all these solutions to DOT language with {func}`~.asdot`. To avoid visualizing all solutions, we just take a subset of the {attr}`~.Result.transitions`:"
    ]
   },
   {

--- a/src/expertsystem/__init__.py
+++ b/src/expertsystem/__init__.py
@@ -43,13 +43,29 @@ __all__ = [
     # Facade functions
     "generate_transitions",
     "check_reaction_violations",
+    "load_default_particles",
 ]
 
 
 from . import amplitude, io, particle, reaction
+from .reaction.default_settings import ADDITIONAL_PARTICLES_DEFINITIONS_PATH
 
 generate_transitions = reaction.generate
 """An alias to `.reaction.generate`."""
 
 check_reaction_violations = reaction.check_reaction_violations
 """An alias to `.reaction.check_reaction_violations`."""
+
+
+def load_default_particles() -> particle.ParticleCollection:
+    """Load the default particle list that comes with the `expertsystem`.
+
+    Runs `.load_pdg` and supplements its output definitions from the file
+    :download:`particle/additional_definitions.yml
+    </../src/expertsystem/particle/additional_definitions.yml>`.
+    """
+    particles = particle.load_pdg()
+    additional_particles = io.load(ADDITIONAL_PARTICLES_DEFINITIONS_PATH)
+    assert isinstance(additional_particles, particle.ParticleCollection)
+    particles.update(additional_particles)
+    return particles

--- a/src/expertsystem/io/__init__.py
+++ b/src/expertsystem/io/__init__.py
@@ -24,6 +24,8 @@ def asdict(instance: object) -> dict:
         return _dict.from_particle(instance)
     if isinstance(instance, ParticleCollection):
         return _dict.from_particle_collection(instance)
+    if isinstance(instance, StateTransitionGraph):
+        return _dict.from_stg(instance)
     if isinstance(instance, Topology):
         return _dict.from_topology(instance)
     raise NotImplementedError(
@@ -37,6 +39,8 @@ def fromdict(definition: dict) -> object:
         return _dict.build_particle(definition)
     if type_defined == ParticleCollection:
         return _dict.build_particle_collection(definition)
+    if type_defined == StateTransitionGraph:
+        return _dict.build_stg(definition)
     if type_defined == Topology:
         return _dict.build_topology(definition)
     raise NotImplementedError
@@ -48,6 +52,8 @@ def __determine_type(definition: dict) -> type:
         return ParticleCollection
     if __REQUIRED_PARTICLE_FIELDS <= keys:
         return Particle
+    if __REQUIRED_STG_FIELDS == keys:
+        return StateTransitionGraph
     if __REQUIRED_TOPOLOGY_FIELDS == keys:
         return Topology
     raise NotImplementedError(f"Could not determine type from keys {keys}")
@@ -58,6 +64,7 @@ __REQUIRED_PARTICLE_FIELDS = {
     for field in attr.fields(Particle)
     if field.default == attr.NOTHING
 }
+__REQUIRED_STG_FIELDS = {"topology", "edge_props", "node_props"}
 __REQUIRED_TOPOLOGY_FIELDS = {
     field.name for field in attr.fields(Topology) if field.init
 }

--- a/src/expertsystem/io/__init__.py
+++ b/src/expertsystem/io/__init__.py
@@ -14,7 +14,7 @@ import attr
 import yaml
 
 from expertsystem.particle import Particle, ParticleCollection
-from expertsystem.reaction import StateTransitionGraph, Topology
+from expertsystem.reaction import Result, StateTransitionGraph, Topology
 
 from . import _dict, _dot
 
@@ -24,6 +24,8 @@ def asdict(instance: object) -> dict:
         return _dict.from_particle(instance)
     if isinstance(instance, ParticleCollection):
         return _dict.from_particle_collection(instance)
+    if isinstance(instance, Result):
+        return _dict.from_result(instance)
     if isinstance(instance, StateTransitionGraph):
         return _dict.from_stg(instance)
     if isinstance(instance, Topology):
@@ -39,6 +41,8 @@ def fromdict(definition: dict) -> object:
         return _dict.build_particle(definition)
     if type_defined == ParticleCollection:
         return _dict.build_particle_collection(definition)
+    if type_defined == Result:
+        return _dict.build_result(definition)
     if type_defined == StateTransitionGraph:
         return _dict.build_stg(definition)
     if type_defined == Topology:
@@ -52,6 +56,8 @@ def __determine_type(definition: dict) -> type:
         return ParticleCollection
     if __REQUIRED_PARTICLE_FIELDS <= keys:
         return Particle
+    if __REQUIRED_RESULT_FIELDS == keys:
+        return Result
     if __REQUIRED_STG_FIELDS == keys:
         return StateTransitionGraph
     if __REQUIRED_TOPOLOGY_FIELDS == keys:
@@ -64,6 +70,7 @@ __REQUIRED_PARTICLE_FIELDS = {
     for field in attr.fields(Particle)
     if field.default == attr.NOTHING
 }
+__REQUIRED_RESULT_FIELDS = {"transitions", "formalism_type"}
 __REQUIRED_STG_FIELDS = {"topology", "edge_props", "node_props"}
 __REQUIRED_TOPOLOGY_FIELDS = {
     field.name for field in attr.fields(Topology) if field.init

--- a/src/expertsystem/io/__init__.py
+++ b/src/expertsystem/io/__init__.py
@@ -24,6 +24,8 @@ def asdict(instance: object) -> dict:
         return _dict.from_particle(instance)
     if isinstance(instance, ParticleCollection):
         return _dict.from_particle_collection(instance)
+    if isinstance(instance, Topology):
+        return _dict.from_topology(instance)
     raise NotImplementedError(
         f"No conversion for dict available for class {instance.__class__.__name__}"
     )
@@ -35,6 +37,8 @@ def fromdict(definition: dict) -> object:
         return _dict.build_particle(definition)
     if type_defined == ParticleCollection:
         return _dict.build_particle_collection(definition)
+    if type_defined == Topology:
+        return _dict.build_topology(definition)
     raise NotImplementedError
 
 
@@ -44,6 +48,8 @@ def __determine_type(definition: dict) -> type:
         return ParticleCollection
     if __REQUIRED_PARTICLE_FIELDS <= keys:
         return Particle
+    if __REQUIRED_TOPOLOGY_FIELDS == keys:
+        return Topology
     raise NotImplementedError(f"Could not determine type from keys {keys}")
 
 
@@ -51,6 +57,9 @@ __REQUIRED_PARTICLE_FIELDS = {
     field.name
     for field in attr.fields(Particle)
     if field.default == attr.NOTHING
+}
+__REQUIRED_TOPOLOGY_FIELDS = {
+    field.name for field in attr.fields(Topology) if field.init
 }
 
 

--- a/src/expertsystem/io/__init__.py
+++ b/src/expertsystem/io/__init__.py
@@ -14,7 +14,7 @@ import attr
 import yaml
 
 from expertsystem.particle import Particle, ParticleCollection
-from expertsystem.reaction.topology import StateTransitionGraph, Topology
+from expertsystem.reaction import StateTransitionGraph, Topology
 
 from . import _dict, _dot
 

--- a/src/expertsystem/io/__init__.py
+++ b/src/expertsystem/io/__init__.py
@@ -36,32 +36,17 @@ def asdict(instance: object) -> dict:
 
 
 def fromdict(definition: dict) -> object:
-    type_defined = __determine_type(definition)
-    if type_defined == Particle:
-        return _dict.build_particle(definition)
-    if type_defined == ParticleCollection:
-        return _dict.build_particle_collection(definition)
-    if type_defined == Result:
-        return _dict.build_result(definition)
-    if type_defined == StateTransitionGraph:
-        return _dict.build_stg(definition)
-    if type_defined == Topology:
-        return _dict.build_topology(definition)
-    raise NotImplementedError
-
-
-def __determine_type(definition: dict) -> type:
     keys = set(definition.keys())
-    if keys == {"particles"}:
-        return ParticleCollection
     if __REQUIRED_PARTICLE_FIELDS <= keys:
-        return Particle
-    if __REQUIRED_RESULT_FIELDS == keys:
-        return Result
-    if __REQUIRED_STG_FIELDS == keys:
-        return StateTransitionGraph
-    if __REQUIRED_TOPOLOGY_FIELDS == keys:
-        return Topology
+        return _dict.build_particle(definition)
+    if keys == {"particles"}:
+        return _dict.build_particle_collection(definition)
+    if keys == {"transitions", "formalism_type"}:
+        return _dict.build_result(definition)
+    if keys == {"topology", "edge_props", "node_props"}:
+        return _dict.build_stg(definition)
+    if keys == __REQUIRED_TOPOLOGY_FIELDS:
+        return _dict.build_topology(definition)
     raise NotImplementedError(f"Could not determine type from keys {keys}")
 
 
@@ -70,8 +55,6 @@ __REQUIRED_PARTICLE_FIELDS = {
     for field in attr.fields(Particle)
     if field.default == attr.NOTHING
 }
-__REQUIRED_RESULT_FIELDS = {"transitions", "formalism_type"}
-__REQUIRED_STG_FIELDS = {"topology", "edge_props", "node_props"}
 __REQUIRED_TOPOLOGY_FIELDS = {
     field.name for field in attr.fields(Topology) if field.init
 }

--- a/src/expertsystem/io/_dict.py
+++ b/src/expertsystem/io/_dict.py
@@ -12,6 +12,7 @@ from expertsystem.particle import Parity, Particle, ParticleCollection, Spin
 from expertsystem.reaction import (
     InteractionProperties,
     ParticleWithSpin,
+    Result,
     StateTransitionGraph,
     Topology,
 )
@@ -29,6 +30,15 @@ def from_particle(particle: Particle) -> dict:
         value_serializer=__value_serializer,
         filter=lambda attr, value: attr.default != value,
     )
+
+
+def from_result(result: Result) -> dict:
+    output: Dict[str, Any] = {
+        "transitions": [from_stg(graph) for graph in result.transitions],
+    }
+    if result.formalism_type is not None:
+        output["formalism_type"] = result.formalism_type
+    return output
 
 
 def from_stg(graph: StateTransitionGraph[ParticleWithSpin]) -> dict:
@@ -102,6 +112,17 @@ def build_particle(definition: dict) -> Particle:
         if parity_def is not None:
             definition[parity] = Parity(**parity_def)
     return Particle(**definition)
+
+
+def build_result(definition: dict) -> Result:
+    formalism_type = definition.get("formalism_type")
+    transitions = [
+        build_stg(graph_def) for graph_def in definition["transitions"]
+    ]
+    return Result(
+        transitions=transitions,
+        formalism_type=formalism_type,
+    )
 
 
 def build_stg(definition: dict) -> StateTransitionGraph[ParticleWithSpin]:

--- a/src/expertsystem/io/_dict.py
+++ b/src/expertsystem/io/_dict.py
@@ -134,10 +134,10 @@ def build_stg(definition: dict) -> StateTransitionGraph[ParticleWithSpin]:
         spin_projection = float(edge_def["spin_projection"])
         if spin_projection.is_integer():
             spin_projection = int(spin_projection)
-        edge_props[i] = (particle, spin_projection)
+        edge_props[int(i)] = (particle, spin_projection)
     node_props_def: Dict[int, dict] = definition["node_props"]
     node_props = {
-        i: InteractionProperties(**node_def)
+        int(i): InteractionProperties(**node_def)
         for i, node_def in node_props_def.items()
     }
     return StateTransitionGraph(
@@ -150,7 +150,7 @@ def build_stg(definition: dict) -> StateTransitionGraph[ParticleWithSpin]:
 def build_topology(definition: dict) -> Topology:
     nodes = definition["nodes"]
     edges_def: Dict[int, dict] = definition["edges"]
-    edges = {i: Edge(**edge_def) for i, edge_def in edges_def.items()}
+    edges = {int(i): Edge(**edge_def) for i, edge_def in edges_def.items()}
     return Topology(
         edges=edges,
         nodes=nodes,

--- a/src/expertsystem/io/_dict.py
+++ b/src/expertsystem/io/_dict.py
@@ -9,11 +9,13 @@ import attr
 import jsonschema
 
 from expertsystem.particle import Parity, Particle, ParticleCollection, Spin
-from expertsystem.reaction.quantum_numbers import (
+from expertsystem.reaction import (
     InteractionProperties,
     ParticleWithSpin,
+    StateTransitionGraph,
+    Topology,
 )
-from expertsystem.reaction.topology import Edge, StateTransitionGraph, Topology
+from expertsystem.reaction.topology import Edge
 
 
 def from_particle_collection(particles: ParticleCollection) -> dict:

--- a/src/expertsystem/io/_dot.py
+++ b/src/expertsystem/io/_dot.py
@@ -6,11 +6,12 @@ See :doc:`/usage/visualize` for more info.
 from typing import Callable, Iterable, Optional, Sequence, Union
 
 from expertsystem.particle import Particle, ParticleCollection
-from expertsystem.reaction.quantum_numbers import (
+from expertsystem.reaction import (
     InteractionProperties,
     ParticleWithSpin,
+    StateTransitionGraph,
+    Topology,
 )
-from expertsystem.reaction.topology import StateTransitionGraph, Topology
 
 _DOT_HEAD = """digraph {
     rankdir=LR;

--- a/src/expertsystem/reaction/__init__.py
+++ b/src/expertsystem/reaction/__init__.py
@@ -30,7 +30,6 @@ from typing import (
 import attr
 from tqdm.auto import tqdm
 
-from expertsystem import io
 from expertsystem.particle import Particle, ParticleCollection, load_pdg
 from expertsystem.reaction.conservation_rules import (
     BaryonNumberConservation,
@@ -72,7 +71,6 @@ from .combinatorics import (
     match_external_edges,
 )
 from .default_settings import (
-    ADDITIONAL_PARTICLES_DEFINITIONS_PATH,
     InteractionTypes,
     create_default_interaction_settings,
 )
@@ -483,7 +481,7 @@ class StateTransitionManager:  # pylint: disable=too-many-instance-attributes
             )
 
         if reload_pdg or len(self.__particles) == 0:
-            self.__particles = load_default_particles()
+            self.__particles = load_pdg()
 
         self.__user_allowed_intermediate_particles = (
             allowed_intermediate_particles
@@ -990,7 +988,7 @@ def check_reaction_violations(
 
     initial_facts = create_initial_facts(
         topology=topology,
-        particles=load_default_particles(),
+        particles=load_pdg(),
         initial_state=initial_state,
         final_state=final_state,
     )
@@ -1057,21 +1055,6 @@ def check_reaction_violations(
     return violations
 
 
-def load_default_particles() -> ParticleCollection:
-    """Load the default particle list that comes with the `expertsystem`.
-
-    Runs `.load_pdg` and supplements its output definitions from the file
-    :download:`additional_definitions.yml
-    </../src/expertsystem/particle/additional_definitions.yml>`.
-    """
-    particles = load_pdg()
-    additional_particles = io.load(ADDITIONAL_PARTICLES_DEFINITIONS_PATH)
-    assert isinstance(additional_particles, ParticleCollection)
-    particles.update(additional_particles)
-    logging.info(f"Loaded {len(particles)} particles!")
-    return particles
-
-
 def generate(  # pylint: disable=too-many-arguments
     initial_state: Union[StateDefinition, Sequence[StateDefinition]],
     final_state: Sequence[StateDefinition],
@@ -1112,10 +1095,10 @@ def generate(  # pylint: disable=too-many-arguments
             eventual `.HelicityModel`.
 
         particles (`.ParticleCollection`, optional): The particles that you
-            want to be involved in the reaction. Uses `.load_default_particles`
-            by default. It's better to use a subset for larger reactions,
-            because of the computation times. This argument is especially
-            useful when you want to use your own particle definitions (see
+            want to be involved in the reaction. Uses `.load_pdg` by default.
+            It's better to use a subset for larger reactions, because of
+            the computation times. This argument is especially useful when you
+            want to use your own particle definitions (see
             :doc:`/usage/particle`).
 
         mass_conservation_factor: Width factor that is taken into account for

--- a/src/expertsystem/reaction/__init__.py
+++ b/src/expertsystem/reaction/__init__.py
@@ -72,7 +72,7 @@ from .combinatorics import (
     match_external_edges,
 )
 from .default_settings import (
-    DEFAULT_PARTICLE_LIST_PATH,
+    ADDITIONAL_PARTICLES_DEFINITIONS_PATH,
     InteractionTypes,
     create_default_interaction_settings,
 )
@@ -1065,7 +1065,7 @@ def load_default_particles() -> ParticleCollection:
     </../src/expertsystem/particle/additional_definitions.yml>`.
     """
     particles = load_pdg()
-    additional_particles = io.load(DEFAULT_PARTICLE_LIST_PATH)
+    additional_particles = io.load(ADDITIONAL_PARTICLES_DEFINITIONS_PATH)
     assert isinstance(additional_particles, ParticleCollection)
     particles.update(additional_particles)
     logging.info(f"Loaded {len(particles)} particles!")

--- a/src/expertsystem/reaction/default_settings.py
+++ b/src/expertsystem/reaction/default_settings.py
@@ -41,7 +41,7 @@ from expertsystem.reaction.solving import EdgeSettings, NodeSettings
 
 __EXPERT_SYSTEM_PATH = dirname(dirname(realpath(__file__)))
 __DEFAULT_PARTICLE_LIST_FILE = "particle/additional_definitions.yml"
-DEFAULT_PARTICLE_LIST_PATH = join(
+ADDITIONAL_PARTICLES_DEFINITIONS_PATH = join(
     __EXPERT_SYSTEM_PATH, __DEFAULT_PARTICLE_LIST_FILE
 )
 

--- a/src/expertsystem/reaction/quantum_numbers.py
+++ b/src/expertsystem/reaction/quantum_numbers.py
@@ -107,6 +107,18 @@ NodeQuantumNumber = Union[
 ]
 
 
+def _to_optional_float(optional_float: Optional[float]) -> Optional[float]:
+    if optional_float is None:
+        return None
+    return float(optional_float)
+
+
+def _to_optional_int(optional_int: Optional[int]) -> Optional[int]:
+    if optional_int is None:
+        return None
+    return int(optional_int)
+
+
 @attr.s(frozen=True)
 class InteractionProperties:
     """Immutable data structure containing interaction properties.
@@ -115,10 +127,18 @@ class InteractionProperties:
         class serves as an interface to the user.
     """
 
-    l_magnitude: Optional[int] = attr.ib(
-        default=None
-    )  # L cannot be half integer
-    l_projection: Optional[int] = attr.ib(default=None)
-    s_magnitude: Optional[float] = attr.ib(default=None)
-    s_projection: Optional[float] = attr.ib(default=None)
-    parity_prefactor: Optional[float] = attr.ib(default=None)
+    l_magnitude: Optional[int] = attr.ib(  # L cannot be half integer
+        default=None, converter=_to_optional_int
+    )
+    l_projection: Optional[int] = attr.ib(
+        default=None, converter=_to_optional_int
+    )
+    s_magnitude: Optional[float] = attr.ib(
+        default=None, converter=_to_optional_float
+    )
+    s_projection: Optional[float] = attr.ib(
+        default=None, converter=_to_optional_float
+    )
+    parity_prefactor: Optional[float] = attr.ib(
+        default=None, converter=_to_optional_float
+    )

--- a/src/expertsystem/reaction/topology.py
+++ b/src/expertsystem/reaction/topology.py
@@ -78,12 +78,22 @@ class FrozenDict(  # pylint: disable=too-many-ancestors
         return self.__mapping.values()
 
 
+def _to_optional_int(optional_int: Optional[int]) -> Optional[int]:
+    if optional_int is None:
+        return None
+    return int(optional_int)
+
+
 @attr.s(frozen=True)
 class Edge:
     """Struct-like definition of an edge, used in `Topology`."""
 
-    originating_node_id: Optional[int] = attr.ib(default=None)
-    ending_node_id: Optional[int] = attr.ib(default=None)
+    originating_node_id: Optional[int] = attr.ib(
+        default=None, converter=_to_optional_int
+    )
+    ending_node_id: Optional[int] = attr.ib(
+        default=None, converter=_to_optional_int
+    )
 
     def get_connected_nodes(self) -> Set[int]:
         connected_nodes = {self.ending_node_id, self.originating_node_id}

--- a/src/expertsystem/reaction/topology.py
+++ b/src/expertsystem/reaction/topology.py
@@ -604,6 +604,23 @@ class StateTransitionGraph(Generic[EdgeType]):
         _assert_over_defined(self.topology.nodes, self.__node_props)
         _assert_over_defined(self.topology.edges, self.__edge_props)
 
+    def __eq__(self, other: object) -> bool:
+        """Check if two `.StateTransitionGraph` instances are **identical**."""
+        if isinstance(other, StateTransitionGraph):
+            if self.topology != other.topology:
+                return False
+            for i in self.topology.edges:
+                if self.get_edge_props(i) != other.get_edge_props(i):
+                    return False
+            for i in self.topology.nodes:
+                if self.get_node_props(i) != other.get_node_props(i):
+                    return False
+            return True
+        raise NotImplementedError(
+            f"Cannot compare {self.__class__.__name__}"
+            f" with {other.__class__.__name__}"
+        )
+
     def get_node_props(self, node_id: int) -> InteractionProperties:
         return self.__node_props[node_id]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 import pytest
 
+from expertsystem import load_default_particles
 from expertsystem.particle import ParticleCollection
-from expertsystem.reaction import load_default_particles
 
 
 @pytest.fixture(scope="session")

--- a/tests/unit/io/test_io.py
+++ b/tests/unit/io/test_io.py
@@ -2,6 +2,11 @@ import pytest
 
 from expertsystem import io
 from expertsystem.particle import Particle, ParticleCollection
+from expertsystem.reaction import (
+    create_isobar_topologies,
+    create_n_body_topology,
+)
+from expertsystem.reaction.topology import Topology
 
 
 def test_asdict_fromdict(particle_selection: ParticleCollection):
@@ -16,6 +21,19 @@ def test_asdict_fromdict(particle_selection: ParticleCollection):
         fromdict = io.fromdict(asdict)
         assert isinstance(fromdict, Particle)
         assert particle == fromdict
+    # Topology
+    for n_final_states in range(2, 6):
+        for topology in create_isobar_topologies(n_final_states):
+            asdict = io.asdict(topology)
+            fromdict = io.fromdict(asdict)
+            assert isinstance(fromdict, Topology)
+            assert topology == fromdict
+        for n_initial_states in range(1, 3):
+            topology = create_n_body_topology(n_initial_states, n_final_states)
+            asdict = io.asdict(topology)
+            fromdict = io.fromdict(asdict)
+            assert isinstance(fromdict, Topology)
+            assert topology == fromdict
 
 
 def test_fromdict_exceptions():

--- a/tests/unit/io/test_io.py
+++ b/tests/unit/io/test_io.py
@@ -51,6 +51,15 @@ def test_asdict_fromdict(
         fromdict = io.fromdict(asdict)
         assert isinstance(fromdict, StateTransitionGraph)
         assert graph == fromdict
+    # Result
+    asdict = io.asdict(jpsi_to_gamma_pi_pi_canonical_solutions)
+    fromdict = io.fromdict(asdict)
+    assert isinstance(fromdict, Result)
+    assert jpsi_to_gamma_pi_pi_canonical_solutions == fromdict
+    asdict = io.asdict(jpsi_to_gamma_pi_pi_helicity_solutions)
+    fromdict = io.fromdict(asdict)
+    assert isinstance(fromdict, Result)
+    assert jpsi_to_gamma_pi_pi_helicity_solutions == fromdict
 
 
 def test_fromdict_exceptions():

--- a/tests/unit/io/test_io.py
+++ b/tests/unit/io/test_io.py
@@ -3,14 +3,18 @@ import pytest
 from expertsystem import io
 from expertsystem.particle import Particle, ParticleCollection
 from expertsystem.reaction import (
+    Result,
     create_isobar_topologies,
     create_n_body_topology,
 )
-from expertsystem.reaction.topology import Topology
+from expertsystem.reaction.topology import StateTransitionGraph, Topology
 
 
-def test_asdict_fromdict(particle_selection: ParticleCollection):
-    # ParticleCollection
+def test_asdict_fromdict(
+    particle_selection: ParticleCollection,
+    jpsi_to_gamma_pi_pi_canonical_solutions: Result,
+    jpsi_to_gamma_pi_pi_helicity_solutions: Result,
+):
     asdict = io.asdict(particle_selection)
     fromdict = io.fromdict(asdict)
     assert isinstance(fromdict, ParticleCollection)
@@ -34,6 +38,19 @@ def test_asdict_fromdict(particle_selection: ParticleCollection):
             fromdict = io.fromdict(asdict)
             assert isinstance(fromdict, Topology)
             assert topology == fromdict
+    # StateTransitionGraph
+    result = jpsi_to_gamma_pi_pi_canonical_solutions
+    for graph in result.transitions:
+        asdict = io.asdict(graph)
+        fromdict = io.fromdict(asdict)
+        assert isinstance(fromdict, StateTransitionGraph)
+        assert graph == fromdict
+    result = jpsi_to_gamma_pi_pi_helicity_solutions
+    for graph in result.transitions:
+        asdict = io.asdict(graph)
+        fromdict = io.fromdict(asdict)
+        assert isinstance(fromdict, StateTransitionGraph)
+        assert graph == fromdict
 
 
 def test_fromdict_exceptions():

--- a/tests/unit/io/test_io.py
+++ b/tests/unit/io/test_io.py
@@ -1,3 +1,5 @@
+import json
+
 import pytest
 
 from expertsystem import io
@@ -10,54 +12,52 @@ from expertsystem.reaction import (
 from expertsystem.reaction.topology import StateTransitionGraph, Topology
 
 
+def through_dict(instance):
+    asdict = io.asdict(instance)
+    asdict = json.loads(json.dumps(asdict))  # check JSON serialization
+    return io.fromdict(asdict)
+
+
 def test_asdict_fromdict(
     particle_selection: ParticleCollection,
     jpsi_to_gamma_pi_pi_canonical_solutions: Result,
     jpsi_to_gamma_pi_pi_helicity_solutions: Result,
 ):
-    asdict = io.asdict(particle_selection)
-    fromdict = io.fromdict(asdict)
+    fromdict = through_dict(particle_selection)
     assert isinstance(fromdict, ParticleCollection)
     assert particle_selection == fromdict
     # Particle
     for particle in particle_selection:
-        asdict = io.asdict(particle)
-        fromdict = io.fromdict(asdict)
+        fromdict = through_dict(particle)
         assert isinstance(fromdict, Particle)
         assert particle == fromdict
     # Topology
     for n_final_states in range(2, 6):
         for topology in create_isobar_topologies(n_final_states):
-            asdict = io.asdict(topology)
-            fromdict = io.fromdict(asdict)
+            fromdict = through_dict(topology)
             assert isinstance(fromdict, Topology)
             assert topology == fromdict
         for n_initial_states in range(1, 3):
             topology = create_n_body_topology(n_initial_states, n_final_states)
-            asdict = io.asdict(topology)
-            fromdict = io.fromdict(asdict)
+            fromdict = through_dict(topology)
             assert isinstance(fromdict, Topology)
             assert topology == fromdict
     # StateTransitionGraph
     result = jpsi_to_gamma_pi_pi_canonical_solutions
     for graph in result.transitions:
-        asdict = io.asdict(graph)
-        fromdict = io.fromdict(asdict)
+        fromdict = through_dict(graph)
         assert isinstance(fromdict, StateTransitionGraph)
         assert graph == fromdict
     result = jpsi_to_gamma_pi_pi_helicity_solutions
     for graph in result.transitions:
-        asdict = io.asdict(graph)
-        fromdict = io.fromdict(asdict)
+        fromdict = through_dict(graph)
         assert isinstance(fromdict, StateTransitionGraph)
         assert graph == fromdict
     # Result
-    asdict = io.asdict(jpsi_to_gamma_pi_pi_canonical_solutions)
-    fromdict = io.fromdict(asdict)
+    fromdict = through_dict(jpsi_to_gamma_pi_pi_canonical_solutions)
     assert isinstance(fromdict, Result)
     assert jpsi_to_gamma_pi_pi_canonical_solutions == fromdict
-    asdict = io.asdict(jpsi_to_gamma_pi_pi_helicity_solutions)
-    fromdict = io.fromdict(asdict)
+    fromdict = through_dict(jpsi_to_gamma_pi_pi_helicity_solutions)
     assert isinstance(fromdict, Result)
     assert jpsi_to_gamma_pi_pi_helicity_solutions == fromdict
 

--- a/tests/unit/io/test_io.py
+++ b/tests/unit/io/test_io.py
@@ -1,16 +1,20 @@
 import pytest
 
 from expertsystem import io
-from expertsystem.particle import ParticleCollection
+from expertsystem.particle import Particle, ParticleCollection
 
 
 def test_asdict_fromdict(particle_selection: ParticleCollection):
+    # ParticleCollection
     asdict = io.asdict(particle_selection)
     fromdict = io.fromdict(asdict)
+    assert isinstance(fromdict, ParticleCollection)
     assert particle_selection == fromdict
+    # Particle
     for particle in particle_selection:
         asdict = io.asdict(particle)
         fromdict = io.fromdict(asdict)
+        assert isinstance(fromdict, Particle)
         assert particle == fromdict
 
 


### PR DESCRIPTION
Allow to serialize `Result`, `StateTransitionGraph[ParticleWithSpin]`, and `Topology` to and from `dict` with `io.asdict`/`io.fromdict` so that they can be written to disk with `io.write`. This is useful if it takes a long time to generate transitions.

Some changes were required:
- `load_default_particles` had to be moved to the top import, so that the `reaction` module is not dependent on the `io` module (the type hint for `Result` in the `io` introduces a circular dependency).
- Some converters were added to the `attr`-decorated classes that are being serialized, so that they still work after serializing to and from JSON (which has `str` keys only).
- Added a 'strict' `__eq__` method for `StateTransitionGraph` for testing.