### PR TITLE
refactor: rename parameters to parameter_defaults

### DIFF
--- a/docs/usage/amplitude.ipynb
+++ b/docs/usage/amplitude.ipynb
@@ -226,7 +226,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The {attr}`.HelicityModel.parameters` attribute can be used to substitute all parameters with suggested values:"
+    "The {attr}`.HelicityModel.parameter_defaults` attribute can be used to substitute all parameters with suggested values:"
    ]
   },
   {
@@ -235,7 +235,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "some_amplitude.doit().subs(model.parameters)"
+    "some_amplitude.doit().subs(model.parameter_defaults)"
    ]
   },
   {
@@ -259,7 +259,7 @@
    "outputs": [],
    "source": [
     "no_dynamics = model_no_dynamics.expression.doit()\n",
-    "no_dynamics_substituted = no_dynamics.subs(model.parameters)\n",
+    "no_dynamics_substituted = no_dynamics.subs(model.parameter_defaults)\n",
     "no_dynamics_substituted"
    ]
   },
@@ -334,7 +334,7 @@
     "\n",
     "total = 0\n",
     "for i, intensity in enumerate(no_dynamics.args):\n",
-    "    total += intensity.subs(model.parameters).doit()\n",
+    "    total += intensity.subs(model.parameter_defaults).doit()\n",
     "    plots.append(\n",
     "        sy.plot(\n",
     "            total,\n",
@@ -387,7 +387,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "First, we can use {attr}`.HelicityModel.parameters` to substitute the parameters with suggested values:"
+    "First, we can use {attr}`.HelicityModel.parameter_defaults` to substitute the parameters with suggested values:"
    ]
   },
   {
@@ -396,7 +396,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "suggested_expression = model.expression.subs(model.parameters)\n",
+    "suggested_expression = model.expression.subs(model.parameter_defaults)\n",
     "suggested_expression.free_symbols"
    ]
   },

--- a/docs/usage/dynamics/custom.ipynb
+++ b/docs/usage/dynamics/custom.ipynb
@@ -205,7 +205,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As can be seen, the {attr}`.HelicityModel.parameters` section has been updated with the some additional parameters for the custom parameter and there corresponding suggested initial values:"
+    "As can be seen, the {attr}`.HelicityModel.parameter_defaults` section has been updated with the some additional parameters for the custom parameter and there corresponding suggested initial values:"
    ]
   },
   {
@@ -214,7 +214,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model.parameters"
+    "model.parameter_defaults"
    ]
   },
   {
@@ -230,7 +230,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "expr = model.expression.doit().subs(model.parameters)\n",
+    "expr = model.expression.doit().subs(model.parameter_defaults)\n",
     "free_symbols = tuple(sorted(expr.free_symbols, key=lambda s: s.name))\n",
     "free_symbols"
    ]

--- a/src/expertsystem/amplitude/helicity.py
+++ b/src/expertsystem/amplitude/helicity.py
@@ -111,7 +111,7 @@ class HelicityModel:
     _expression: sp.Expr = attr.ib(
         validator=attr.validators.instance_of(sp.Expr)
     )
-    _parameters: Dict[sp.Symbol, ParameterValue] = attr.ib(
+    _parameter_defaults: Dict[sp.Symbol, ParameterValue] = attr.ib(
         validator=attr.validators.instance_of(dict)
     )
     _components: Dict[str, sp.Expr] = attr.ib(
@@ -133,8 +133,8 @@ class HelicityModel:
         return self._components
 
     @property
-    def parameters(self) -> Dict[sp.Symbol, ParameterValue]:
-        return self._parameters
+    def parameter_defaults(self) -> Dict[sp.Symbol, ParameterValue]:
+        return self._parameter_defaults
 
     @property
     def adapter(self) -> HelicityAdapter:
@@ -461,7 +461,7 @@ class HelicityAmplitudeBuilder:  # pylint: disable=too-many-instance-attributes
     def __init__(self, reaction_result: Result) -> None:
         self.name_generator = _HelicityAmplitudeNameGenerator()
         self.__graphs = reaction_result.transitions
-        self.__parameters: Dict[sp.Symbol, ParameterValue] = dict()
+        self.__parameter_defaults: Dict[sp.Symbol, ParameterValue] = dict()
         self.__components: Dict[str, sp.Expr] = dict()
         self.__dynamics_choices: Dict[
             _TwoBodyDecay, ResonanceDynamicsBuilder
@@ -492,11 +492,11 @@ class HelicityAmplitudeBuilder:  # pylint: disable=too-many-instance-attributes
 
     def generate(self) -> HelicityModel:
         self.__components = dict()
-        self.__parameters = dict()
+        self.__parameter_defaults = dict()
         return HelicityModel(
             expression=self.__generate_intensity(),
             components=self.__components,
-            parameters=self.__parameters,
+            parameter_defaults=self.__parameter_defaults,
             adapter=self.__adapter,
             particles=self.__particles,
         )
@@ -526,14 +526,14 @@ class HelicityAmplitudeBuilder:  # pylint: disable=too-many-instance-attributes
                 decay.parent.state.particle, variable_set
             )
             for par, value in parameters.items():
-                if par in self.__parameters:
-                    previous_value = self.__parameters[par]
+                if par in self.__parameter_defaults:
+                    previous_value = self.__parameter_defaults[par]
                     if value != previous_value:
                         logging.warning(
                             f"Default value for parameter {par.name}"
                             f" inconsistent {value} and {previous_value}"
                         )
-                self.__parameters[par] = value
+                self.__parameter_defaults[par] = value
 
             return expression
 
@@ -621,7 +621,7 @@ class HelicityAmplitudeBuilder:  # pylint: disable=too-many-instance-attributes
             graph
         )
         coefficient_symbol = sp.Symbol(f"C[{suffix}]")
-        self.__parameters[coefficient_symbol] = complex(1, 0)
+        self.__parameter_defaults[coefficient_symbol] = complex(1, 0)
         return coefficient_symbol
 
     def __generate_amplitude_prefactor(

--- a/src/expertsystem/amplitude/helicity.py
+++ b/src/expertsystem/amplitude/helicity.py
@@ -114,7 +114,7 @@ class HelicityModel:
     _parameters: Dict[sp.Symbol, ParameterValue] = attr.ib(
         validator=attr.validators.instance_of(dict)
     )
-    components: Dict[str, sp.Expr] = attr.ib(
+    _components: Dict[str, sp.Expr] = attr.ib(
         validator=attr.validators.instance_of(dict)
     )
     _adapter: HelicityAdapter = attr.ib(
@@ -127,6 +127,10 @@ class HelicityModel:
     @property
     def expression(self) -> sp.Expr:
         return self._expression
+
+    @property
+    def components(self) -> Dict[str, sp.Expr]:
+        return self._components
 
     @property
     def parameters(self) -> Dict[sp.Symbol, ParameterValue]:

--- a/src/expertsystem/amplitude/helicity.py
+++ b/src/expertsystem/amplitude/helicity.py
@@ -129,7 +129,7 @@ class HelicityModel:
         return self._expression
 
     @property
-    def parameters(self) -> Dict[str, ParameterValue]:
+    def parameters(self) -> Dict[sp.Symbol, ParameterValue]:
         return self._parameters
 
     @property

--- a/tests/channels/test_d0_to_ks_kp_km.py
+++ b/tests/channels/test_d0_to_ks_kp_km.py
@@ -22,4 +22,4 @@ def test_script():
     }
     model_builder = es.amplitude.get_builder(result)
     model = model_builder.generate()
-    assert len(model.parameters) == 5
+    assert len(model.parameter_defaults) == 5

--- a/tests/channels/test_y_to_d0_d0bar_pi0_pi0.py
+++ b/tests/channels/test_y_to_d0_d0bar_pi0_pi0.py
@@ -23,7 +23,7 @@ def test_simple(formalism_type, n_solutions, particle_database):
     assert len(result.transitions) == n_solutions
     model_builder = es.amplitude.get_builder(result)
     model = model_builder.generate()
-    assert len(model.parameters) == 4
+    assert len(model.parameter_defaults) == 4
 
 
 @pytest.mark.slow
@@ -50,4 +50,4 @@ def test_full(formalism_type, n_solutions, particle_database):
     assert len(result.transitions) == n_solutions
     model_builder = es.amplitude.get_builder(result)
     model = model_builder.generate()
-    assert len(model.parameters) == 4
+    assert len(model.parameter_defaults) == 4

--- a/tests/unit/amplitude/test_angular_distributions.py
+++ b/tests/unit/amplitude/test_angular_distributions.py
@@ -77,7 +77,7 @@ class TestEpemToDmD0Pip:
 
         amplitude_model = es.amplitude.get_builder(result).generate()
         full_model = sp.simplify(
-            amplitude_model.expression.subs(amplitude_model.parameters)
+            amplitude_model.expression.subs(amplitude_model.parameter_defaults)
             .doit()
             .expand(complex=True)
         )
@@ -160,7 +160,7 @@ class TestD1ToD0PiPi:
         )
         amplitude_model = es.amplitude.get_builder(result).generate()
 
-        amplitude_model.parameters[
+        amplitude_model.parameter_defaults[
             sp.Symbol(
                 "C[D_{1}(2420)^{0} \\to D^{*}(2010)^{+}_{0} \\pi^{-}_{0};"
                 "D^{*}(2010)^{+} \\to D^{0}_{0} \\pi^{+}_{0}]"
@@ -168,7 +168,7 @@ class TestD1ToD0PiPi:
         ] = 0.5
 
         full_model = sp.simplify(
-            amplitude_model.expression.subs(amplitude_model.parameters)
+            amplitude_model.expression.subs(amplitude_model.parameter_defaults)
             .doit()
             .expand(complex=True)
         )

--- a/tests/unit/amplitude/test_helicity.py
+++ b/tests/unit/amplitude/test_helicity.py
@@ -20,5 +20,5 @@ def test_generate(
     else:
         raise NotImplementedError
     sympy_model = get_builder(result).generate()
-    assert len(sympy_model.parameters) == 2
+    assert len(sympy_model.parameter_defaults) == 2
     assert len(sympy_model.components) == 4 + n_amplitudes

--- a/tests/unit/amplitude/test_parity_prefactor.py
+++ b/tests/unit/amplitude/test_parity_prefactor.py
@@ -131,4 +131,4 @@ def test_parity_amplitude_coupling(
 
     model_builder = es.amplitude.get_builder(result)
     amplitude_model = model_builder.generate()
-    assert len(amplitude_model.parameters) == parameter_count
+    assert len(amplitude_model.parameter_defaults) == parameter_count


### PR DESCRIPTION
This naming makes more sense, as `HelicityModel.parameters` sounds like some sequence that lists the parameters in the model, while it's actually a mapping of those parameters to default ('suggested') values.

<img src="https://user-images.githubusercontent.com/29308176/112305362-e33bca80-8c9e-11eb-8a9c-9640a3c8381b.png" width=600>
