### PR TITLE
fix: show spin projections as int

### DIFF
--- a/src/expertsystem/io/_dot.py
+++ b/src/expertsystem/io/_dot.py
@@ -170,14 +170,11 @@ def __edge_label(
     if isinstance(edge_prop, Particle):
         return edge_prop.name
     if isinstance(edge_prop, tuple):
-        particle, projection = edge_prop
-        spin_projection = float(projection)
+        particle, spin_projection = edge_prop
+        spin_projection = float(spin_projection)
         if spin_projection.is_integer():
             spin_projection = int(spin_projection)
-        label = particle.name
-        if spin_projection is not None:
-            label += f"[{projection}]"
-        return label
+        return f"{particle.name}[{spin_projection}]"
     if isinstance(edge_prop, ParticleCollection):
         return "\n".join(sorted(edge_prop.names))
     raise NotImplementedError


### PR DESCRIPTION
Previously, what's shown below would have `1.0` and `0.0` spin projections due to a bug in `io._dot`

<img src="https://user-images.githubusercontent.com/29308176/112318940-dbcfed80-8cad-11eb-8490-5096c871456a.png" width=400>
