### PR TITLE
ci: add custom pre-commit hooks for notebooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -105,3 +105,26 @@ repos:
         language: system
         types:
           - python
+
+      # Custom hooks
+      - id: fix-nbformat-version
+        name: Set nbformat minor version 4 and remove cell IDs
+        entry: python .pre-commit-hooks/fix_nbformat_version.py
+        language: system
+        types:
+          - jupyter
+
+      - id: set-first-nb-cell
+        name: Check first cells in notebooks
+        entry: python .pre-commit-hooks/set_first_cell.py
+        args:
+          - --autofix
+          - --replace
+          - --additional_packages=graphviz
+        exclude: >
+          (?x)^(
+            docs/adr/.*
+          )$
+        language: system
+        types:
+          - jupyter

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -107,24 +107,23 @@ repos:
           - python
 
       # Custom hooks
-      - id: fix-nbformat-version
-        name: Set nbformat minor version 4 and remove cell IDs
-        entry: python .pre-commit-hooks/fix_nbformat_version.py
-        language: system
-        types:
-          - jupyter
-
-      - id: set-first-nb-cell
+      - id: fix-first-nbcell
         name: Check first cells in notebooks
-        entry: python .pre-commit-hooks/set_first_cell.py
+        entry: python .pre-commit-hooks/fix_first_nbcell.py
         args:
-          - --autofix
           - --replace
           - --additional_packages=graphviz
         exclude: >
           (?x)^(
             docs/adr/.*
           )$
+        language: system
+        types:
+          - jupyter
+
+      - id: fix-nbformat-version
+        name: Set nbformat minor version 4 and remove cell IDs
+        entry: python .pre-commit-hooks/fix_nbformat_version.py
         language: system
         types:
           - jupyter

--- a/.pre-commit-hooks/fix_first_nbcell.py
+++ b/.pre-commit-hooks/fix_first_nbcell.py
@@ -12,10 +12,8 @@ to SVG. This is because the Sphinx configuration can't set this externally.
 
 import argparse
 import configparser
-import json
 import sys
-import textwrap
-from typing import List, Optional, Sequence
+from typing import Optional, Sequence
 
 import nbformat  # type: ignore
 
@@ -39,26 +37,6 @@ EXPECTED_CELL_METADATA = {
     "slideshow": {"slide_type": "skip"},
     "tags": ["remove-cell"],
 }
-
-
-class WrongCellContent(ValueError):
-    pass
-
-
-class WrongMetadata(ValueError):
-    pass
-
-
-def check_first_cell(filename: str, expected_content: str) -> None:
-    notebook = nbformat.read(filename, as_version=4)
-    first_cell = notebook.cells[0]
-    cell_content = "".join(first_cell.source)
-    cell_content = cell_content.strip("\n")
-    expected_cell_content = expected_content.strip("\n")
-    if cell_content != expected_cell_content:
-        raise WrongCellContent(filename)
-    if first_cell.metadata != EXPECTED_CELL_METADATA:
-        raise WrongMetadata(filename)
 
 
 def fix_first_cell(
@@ -87,11 +65,6 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         help="Additional packages to be installed through the first notebook cell",
     )
     parser.add_argument(
-        "--autofix",
-        action="store_true",
-        help="Automatically fix first cell in the notebook.",
-    )
-    parser.add_argument(
         "--replace",
         action="store_true",
         help="Replace first cell instead of prepending a new cell.",
@@ -104,37 +77,12 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         expected_cell_content += f"\n!{{sys.executable}} -m pip freeze | grep {package} || {{sys.executable}} -m pip install {package}"
 
     exit_code = 0
-    wrong_content_files: List[str] = []
-    wrong_metadata_files: List[str] = []
     for filename in args.filenames:
-        try:
-            check_first_cell(filename, expected_cell_content)
-        except ValueError as exception:
-            if args.autofix:
-                fix_first_cell(filename, expected_cell_content, args.replace)
-            if isinstance(exception, WrongCellContent):
-                wrong_content_files.append(filename)
-            if isinstance(exception, WrongMetadata):
-                wrong_metadata_files.append(filename)
-            exit_code = 1
-    if exit_code != 0 and not args.autofix:
-        if wrong_content_files or wrong_metadata_files:
-            print("First cells in notebooks should follow a certain standard.")
-            if wrong_content_files:
-                print("Cell content problems for notebooks:")
-                print(" ", *wrong_content_files, sep="\n ")
-                print("\nCell content should be:")
-                print(textwrap.indent(EXPECTED_CELL_CONTENT, prefix="  "))
-            if wrong_metadata_files:
-                print("Metadata problems for notebooks:")
-                print(" ", *wrong_metadata_files, sep="\n ")
-                print("\nMetadata should be:\n")
-                print(
-                    textwrap.indent(
-                        json.dumps(EXPECTED_CELL_METADATA, indent=2),
-                        prefix="  ",
-                    )
-                )
+        fix_first_cell(
+            filename,
+            new_content=expected_cell_content,
+            replace=args.replace,
+        )
     return exit_code
 
 

--- a/.pre-commit-hooks/fix_nbformat_version.py
+++ b/.pre-commit-hooks/fix_nbformat_version.py
@@ -1,0 +1,42 @@
+# cspell:ignore nargs
+"""Set nbformat minor version to 4.
+
+nbformat adds random cell ids since version 5.x. This is annoying for git
+diffs. The solution is to set the version to v4 and removes those cell ids.
+"""
+
+import argparse
+import sys
+from typing import Optional, Sequence
+
+import nbformat  # type: ignore
+
+
+def set_nbformat_version(filename: str) -> None:
+    notebook = nbformat.read(filename, as_version=nbformat.NO_CONVERT)
+    if notebook["nbformat_minor"] != 4:
+        notebook["nbformat_minor"] = 4
+        nbformat.write(notebook, filename)
+
+
+def remove_cell_ids(filename: str) -> None:
+    notebook = nbformat.read(filename, as_version=nbformat.NO_CONVERT)
+    for cell in notebook["cells"]:
+        if "id" in cell:
+            del cell["id"]
+    nbformat.write(notebook, filename)
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = argparse.ArgumentParser(__doc__)
+    parser.add_argument("filenames", nargs="*", help="Filenames to fix.")
+    args = parser.parse_args(argv)
+    exit_code = 0
+    for filename in args.filenames:
+        set_nbformat_version(filename)
+        remove_cell_ids(filename)
+    return exit_code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.pre-commit-hooks/set_first_cell.py
+++ b/.pre-commit-hooks/set_first_cell.py
@@ -1,0 +1,142 @@
+# cspell:ignore nargs
+"""Add install statements to first cell in a Jupyter notebook.
+
+Google Colaboratory does not install a package automatically, so this has to be
+done through a code cell. At the same time, this cell needs to be hidden from
+the documentation pages, when viewing through Jupyter Lab (Binder), and when
+viewing Jupyter slides.
+
+Additionally, this scripts sets the IPython InlineBackend.figure_formats option
+to SVG. This is because the Sphinx configuration can't set this externally.
+"""
+
+import argparse
+import configparser
+import json
+import sys
+import textwrap
+from typing import List, Optional, Sequence
+
+import nbformat  # type: ignore
+
+cfg = configparser.ConfigParser()
+cfg.read("setup.cfg")
+
+PACKAGE_NAME = cfg["metadata"]["name"]
+EXPECTED_CELL_CONTENT = f"""
+%%capture
+%config Completer.use_jedi = False
+%config InlineBackend.figure_formats = ['svg']
+
+# Install on Google Colab
+import sys  # noqa: F401
+
+!{{sys.executable}} -m pip freeze | grep {PACKAGE_NAME} || {{sys.executable}} -m pip install {PACKAGE_NAME}
+"""
+
+EXPECTED_CELL_METADATA = {
+    "jupyter": {"source_hidden": True},
+    "slideshow": {"slide_type": "skip"},
+    "tags": ["remove-cell"],
+}
+
+
+class WrongCellContent(ValueError):
+    pass
+
+
+class WrongMetadata(ValueError):
+    pass
+
+
+def check_first_cell(filename: str, expected_content: str) -> None:
+    notebook = nbformat.read(filename, as_version=4)
+    first_cell = notebook.cells[0]
+    cell_content = "".join(first_cell.source)
+    cell_content = cell_content.strip("\n")
+    expected_cell_content = expected_content.strip("\n")
+    if cell_content != expected_cell_content:
+        raise WrongCellContent(filename)
+    if first_cell.metadata != EXPECTED_CELL_METADATA:
+        raise WrongMetadata(filename)
+
+
+def fix_first_cell(
+    filename: str, new_content: str, replace: bool = False
+) -> None:
+    notebook = nbformat.read(filename, as_version=nbformat.NO_CONVERT)
+    new_cell = nbformat.v4.new_code_cell(
+        new_content,
+        metadata=EXPECTED_CELL_METADATA,
+    )
+    del new_cell["id"]  # following nbformat_minor = 4
+    if replace:
+        notebook["cells"][0] = new_cell
+    else:
+        notebook["cells"] = [new_cell] + notebook["cells"]
+    nbformat.validate(notebook)
+    nbformat.write(notebook, filename)
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = argparse.ArgumentParser(__doc__)
+    parser.add_argument("filenames", nargs="*", help="Filenames to check.")
+    parser.add_argument(
+        "--additional_packages",
+        type=str,
+        help="Additional packages to be installed through the first notebook cell",
+    )
+    parser.add_argument(
+        "--autofix",
+        action="store_true",
+        help="Automatically fix first cell in the notebook.",
+    )
+    parser.add_argument(
+        "--replace",
+        action="store_true",
+        help="Replace first cell instead of prepending a new cell.",
+    )
+    args = parser.parse_args(argv)
+
+    expected_cell_content = EXPECTED_CELL_CONTENT.strip("\n")
+    for package in args.additional_packages.split(","):
+        # pylint: disable=line-too-long
+        expected_cell_content += f"\n!{{sys.executable}} -m pip freeze | grep {package} || {{sys.executable}} -m pip install {package}"
+
+    exit_code = 0
+    wrong_content_files: List[str] = []
+    wrong_metadata_files: List[str] = []
+    for filename in args.filenames:
+        try:
+            check_first_cell(filename, expected_cell_content)
+        except ValueError as exception:
+            if args.autofix:
+                fix_first_cell(filename, expected_cell_content, args.replace)
+            if isinstance(exception, WrongCellContent):
+                wrong_content_files.append(filename)
+            if isinstance(exception, WrongMetadata):
+                wrong_metadata_files.append(filename)
+            exit_code = 1
+    if exit_code != 0 and not args.autofix:
+        if wrong_content_files or wrong_metadata_files:
+            print("First cells in notebooks should follow a certain standard.")
+            if wrong_content_files:
+                print("Cell content problems for notebooks:")
+                print(" ", *wrong_content_files, sep="\n ")
+                print("\nCell content should be:")
+                print(textwrap.indent(EXPECTED_CELL_CONTENT, prefix="  "))
+            if wrong_metadata_files:
+                print("Metadata problems for notebooks:")
+                print(" ", *wrong_metadata_files, sep="\n ")
+                print("\nMetadata should be:\n")
+                print(
+                    textwrap.indent(
+                        json.dumps(EXPECTED_CELL_METADATA, indent=2),
+                        prefix="  ",
+                    )
+                )
+    return exit_code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/usage.ipynb
+++ b/docs/usage.ipynb
@@ -7,6 +7,9 @@
     "jupyter": {
      "source_hidden": true
     },
+    "slideshow": {
+     "slide_type": "skip"
+    },
     "tags": [
      "remove-cell"
     ]
@@ -17,9 +20,11 @@
     "%config Completer.use_jedi = False\n",
     "%config InlineBackend.figure_formats = ['svg']\n",
     "\n",
+    "# Install on Google Colab\n",
     "import sys  # noqa: F401\n",
     "\n",
-    "!{sys.executable} -m pip freeze | grep expertsystem || {sys.executable} -m pip install expertsystem graphviz"
+    "!{sys.executable} -m pip freeze | grep expertsystem || {sys.executable} -m pip install expertsystem\n",
+    "!{sys.executable} -m pip freeze | grep graphviz || {sys.executable} -m pip install graphviz"
    ]
   },
   {

--- a/docs/usage/amplitude.ipynb
+++ b/docs/usage/amplitude.ipynb
@@ -7,6 +7,9 @@
     "jupyter": {
      "source_hidden": true
     },
+    "slideshow": {
+     "slide_type": "skip"
+    },
     "tags": [
      "remove-cell"
     ]
@@ -17,9 +20,11 @@
     "%config Completer.use_jedi = False\n",
     "%config InlineBackend.figure_formats = ['svg']\n",
     "\n",
+    "# Install on Google Colab\n",
     "import sys  # noqa: F401\n",
     "\n",
-    "!{sys.executable} -m pip freeze | grep expertsystem || {sys.executable} -m pip install expertsystem graphviz"
+    "!{sys.executable} -m pip freeze | grep expertsystem || {sys.executable} -m pip install expertsystem\n",
+    "!{sys.executable} -m pip freeze | grep graphviz || {sys.executable} -m pip install graphviz"
    ]
   },
   {

--- a/docs/usage/dynamics/custom.ipynb
+++ b/docs/usage/dynamics/custom.ipynb
@@ -7,6 +7,9 @@
     "jupyter": {
      "source_hidden": true
     },
+    "slideshow": {
+     "slide_type": "skip"
+    },
     "tags": [
      "remove-cell"
     ]
@@ -17,9 +20,11 @@
     "%config Completer.use_jedi = False\n",
     "%config InlineBackend.figure_formats = ['svg']\n",
     "\n",
+    "# Install on Google Colab\n",
     "import sys  # noqa: F401\n",
     "\n",
-    "!{sys.executable} -m pip freeze | grep expertsystem || {sys.executable} -m pip install expertsystem graphviz"
+    "!{sys.executable} -m pip freeze | grep expertsystem || {sys.executable} -m pip install expertsystem\n",
+    "!{sys.executable} -m pip freeze | grep graphviz || {sys.executable} -m pip install graphviz"
    ]
   },
   {

--- a/docs/usage/dynamics/lineshapes.ipynb
+++ b/docs/usage/dynamics/lineshapes.ipynb
@@ -7,6 +7,9 @@
     "jupyter": {
      "source_hidden": true
     },
+    "slideshow": {
+     "slide_type": "skip"
+    },
     "tags": [
      "remove-cell"
     ]
@@ -17,9 +20,11 @@
     "%config Completer.use_jedi = False\n",
     "%config InlineBackend.figure_formats = ['svg']\n",
     "\n",
+    "# Install on Google Colab\n",
     "import sys  # noqa: F401\n",
     "\n",
-    "!{sys.executable} -m pip freeze | grep expertsystem || {sys.executable} -m pip install expertsystem graphviz"
+    "!{sys.executable} -m pip freeze | grep expertsystem || {sys.executable} -m pip install expertsystem\n",
+    "!{sys.executable} -m pip freeze | grep graphviz || {sys.executable} -m pip install graphviz"
    ]
   },
   {

--- a/docs/usage/particle.ipynb
+++ b/docs/usage/particle.ipynb
@@ -7,6 +7,9 @@
     "jupyter": {
      "source_hidden": true
     },
+    "slideshow": {
+     "slide_type": "skip"
+    },
     "tags": [
      "remove-cell"
     ]
@@ -17,9 +20,11 @@
     "%config Completer.use_jedi = False\n",
     "%config InlineBackend.figure_formats = ['svg']\n",
     "\n",
+    "# Install on Google Colab\n",
     "import sys  # noqa: F401\n",
     "\n",
-    "!{sys.executable} -m pip freeze | grep expertsystem || {sys.executable} -m pip install expertsystem graphviz"
+    "!{sys.executable} -m pip freeze | grep expertsystem || {sys.executable} -m pip install expertsystem\n",
+    "!{sys.executable} -m pip freeze | grep graphviz || {sys.executable} -m pip install graphviz"
    ]
   },
   {

--- a/docs/usage/reaction.ipynb
+++ b/docs/usage/reaction.ipynb
@@ -7,6 +7,9 @@
     "jupyter": {
      "source_hidden": true
     },
+    "slideshow": {
+     "slide_type": "skip"
+    },
     "tags": [
      "remove-cell"
     ]
@@ -17,9 +20,11 @@
     "%config Completer.use_jedi = False\n",
     "%config InlineBackend.figure_formats = ['svg']\n",
     "\n",
+    "# Install on Google Colab\n",
     "import sys  # noqa: F401\n",
     "\n",
-    "!{sys.executable} -m pip freeze | grep expertsystem || {sys.executable} -m pip install expertsystem graphviz"
+    "!{sys.executable} -m pip freeze | grep expertsystem || {sys.executable} -m pip install expertsystem\n",
+    "!{sys.executable} -m pip freeze | grep graphviz || {sys.executable} -m pip install graphviz"
    ]
   },
   {

--- a/docs/usage/visualize.ipynb
+++ b/docs/usage/visualize.ipynb
@@ -7,6 +7,9 @@
     "jupyter": {
      "source_hidden": true
     },
+    "slideshow": {
+     "slide_type": "skip"
+    },
     "tags": [
      "remove-cell"
     ]
@@ -17,9 +20,11 @@
     "%config Completer.use_jedi = False\n",
     "%config InlineBackend.figure_formats = ['svg']\n",
     "\n",
+    "# Install on Google Colab\n",
     "import sys  # noqa: F401\n",
     "\n",
-    "!{sys.executable} -m pip freeze | grep expertsystem || {sys.executable} -m pip install expertsystem graphviz"
+    "!{sys.executable} -m pip freeze | grep expertsystem || {sys.executable} -m pip install expertsystem\n",
+    "!{sys.executable} -m pip freeze | grep graphviz || {sys.executable} -m pip install graphviz"
    ]
   },
   {


### PR DESCRIPTION
_Follow-up to https://github.com/ComPWA/expertsystem/pull/497_

Added some example scripts that automatically apply some more formatting to the jupyter notebooks as pre-commit hooks.

Note that it's better to host such scripts under a separate 'hook' repository, like [this one](https://github.com/pre-commit/pre-commit-hooks). But this would move in the direction of standardizing the dev environment through a third repository (like that PWA packes, if that were to have versioning).