### PR TITLE
refactor: decorate Parity and Spin with attrs

### DIFF
--- a/src/expertsystem/particle/__init__.py
+++ b/src/expertsystem/particle/__init__.py
@@ -24,6 +24,7 @@ from typing import (
     Iterator,
     Optional,
     Set,
+    SupportsFloat,
     Tuple,
     Union,
 )
@@ -70,65 +71,57 @@ class Parity(abc.Hashable):
         return self.__value
 
 
-class Spin(abc.Hashable):
+def _to_float(value: SupportsFloat) -> float:
+    float_value = float(value)
+    if float_value == -0.0:
+        float_value = 0.0
+    return float_value
+
+
+@attr.s(frozen=True, eq=False, hash=True)
+class Spin:
     """Safe, immutable data container for spin **with projection**."""
 
-    def __init__(self, magnitude: float, projection: float) -> None:
-        magnitude = float(magnitude)
-        projection = float(projection)
-        if magnitude % 0.5 != 0.0:
+    magnitude: float = attr.ib(converter=_to_float)
+    projection: float = attr.ib(converter=_to_float)
+
+    def __attrs_post_init__(self) -> None:
+        if self.magnitude % 0.5 != 0.0:
             raise ValueError(
-                f"Spin magnitude {magnitude} has to be a multitude of 0.5"
+                f"Spin magnitude {self.magnitude} has to be a multitude of 0.5"
             )
-        if abs(projection) > magnitude:
-            if magnitude < 0.0:
+        if abs(self.projection) > self.magnitude:
+            if self.magnitude < 0.0:
                 raise ValueError(
-                    "Spin magnitude has to be positive:\n" f" {magnitude}"
+                    "Spin magnitude has to be positive:\n" f" {self.magnitude}"
                 )
             raise ValueError(
                 "Absolute value of spin projection cannot be larger than its "
                 "magnitude:\n"
-                f" abs({projection}) > {magnitude}"
+                f" abs({self.projection}) > {self.magnitude}"
             )
-        if not (projection - magnitude).is_integer():
+        if not (self.projection - self.magnitude).is_integer():
             raise ValueError(
-                f"{self.__class__.__name__}{(magnitude, projection)}: "
+                f"{self.__class__.__name__}{(self.magnitude, self.projection)}: "
                 "(projection - magnitude) should be integer! "
             )
-        if projection == -0.0:
-            projection = 0.0
-        self.__magnitude = magnitude
-        self.__projection = projection
 
     def __eq__(self, other: object) -> bool:
         if isinstance(other, Spin):
             return (
-                self.__magnitude == other.magnitude
-                and self.__projection == other.projection
+                self.magnitude == other.magnitude
+                and self.projection == other.projection
             )
-        return self.__magnitude == other
+        return self.magnitude == other
 
     def __float__(self) -> float:
-        return self.__magnitude
+        return self.magnitude
 
     def __neg__(self) -> "Spin":
         return Spin(self.magnitude, -self.projection)
 
     def __repr__(self) -> str:
-        return (
-            f"{self.__class__.__name__}{(self.__magnitude, self.__projection)}"
-        )
-
-    @property
-    def magnitude(self) -> float:
-        return self.__magnitude
-
-    @property
-    def projection(self) -> float:
-        return self.__projection
-
-    def __hash__(self) -> int:
-        return hash(repr(self))
+        return f"{self.__class__.__name__}{(self.magnitude, self.projection)}"
 
 
 @attr.s(frozen=True, repr=True, kw_only=True)

--- a/src/expertsystem/reaction/_system_control.py
+++ b/src/expertsystem/reaction/_system_control.py
@@ -41,7 +41,7 @@ def create_edge_properties(
     }  # Note using attr.fields does not work here because init=False
     property_map: GraphEdgePropertyMap = {}
     isospin = None
-    for qn_name, value in attr.asdict(particle).items():
+    for qn_name, value in attr.asdict(particle, recurse=False).items():
         if isinstance(value, Parity):
             value = value.value
         if qn_name in edge_qn_mapping:

--- a/tests/unit/particle/test_particle.py
+++ b/tests/unit/particle/test_particle.py
@@ -360,6 +360,11 @@ class TestSpin:
         assert float(isospin) == 1.5
         assert isospin.magnitude == 1.5
         assert isospin.projection == -0.5
+        isospin = Spin(1, -0.0)
+        assert isinstance(isospin.magnitude, float)
+        assert isinstance(isospin.projection, float)
+        assert isospin.magnitude == 1.0
+        assert isospin.projection == 0.0
 
     @staticmethod
     def test_hash():

--- a/tests/unit/particle/test_particle.py
+++ b/tests/unit/particle/test_particle.py
@@ -115,8 +115,10 @@ class TestParity:
 
     @staticmethod
     def test_exceptions():
+        with pytest.raises(TypeError):
+            Parity(1.2)  # type: ignore
         with pytest.raises(ValueError):
-            Parity(1.2)
+            Parity(0)
 
 
 class TestParticle:


### PR DESCRIPTION
Makes the two classes easier to read and maintain. Also offers the possibility to add [converters](https://www.attrs.org/en/20.3.0/examples.html#conversion) and [validators](https://www.attrs.org/en/20.3.0/examples.html#validators).