### PR TITLE
feat: add Particle argument converters

### DIFF
--- a/docs/usage/particle.ipynb
+++ b/docs/usage/particle.ipynb
@@ -323,6 +323,44 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Of course, it's also possible to add any kind of custom {class}`.Particle`, as long as its quantum numbers comply with the {class}`.GellmannNishijima` rule:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from expertsystem.particle import Particle\n",
+    "\n",
+    "custom = Particle(\n",
+    "    name=\"custom\",\n",
+    "    pid=99999,\n",
+    "    latex=R\"p_\\mathrm{custom}\",\n",
+    "    spin=1.0,\n",
+    "    mass=1,\n",
+    "    charge=1,\n",
+    "    isospin=(1.5, 0.5),\n",
+    "    charmness=1,\n",
+    ")\n",
+    "custom"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "particle_db += custom\n",
+    "len(particle_db)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Loading custom definitions from a YAML file"
    ]
   },
@@ -391,6 +429,7 @@
     "output += particle_db[\"pi0\"]\n",
     "output += particle_db[\"pi+\"]\n",
     "output += particle_db[\"pi-\"]\n",
+    "output += particle_db[\"custom\"]\n",
     "io.write(output, \"particle_list_selection.yml\")\n",
     "output.names"
    ]

--- a/tests/unit/particle/test_particle.py
+++ b/tests/unit/particle/test_particle.py
@@ -155,7 +155,7 @@ class TestParticle:
                 width=0.1,
                 spin=1,
                 charge=0,
-                isospin=Spin(1, 0),
+                isospin=(1, 0),
             )
             test_state.charge = 1  # type: ignore
         with pytest.raises(ValueError):
@@ -165,10 +165,10 @@ class TestParticle:
                 mass=0.0,
                 spin=1,
                 charge=0,
-                parity=Parity(-1),
-                c_parity=Parity(-1),
-                g_parity=Parity(-1),
-                isospin=Spin(0.0, 0.0),
+                parity=-1,
+                c_parity=-1,
+                g_parity=-1,
+                isospin=(0, 0),
                 charmness=1,
             )
 
@@ -180,7 +180,7 @@ class TestParticle:
             mass=1.2,
             spin=1,
             charge=0,
-            isospin=Spin(1, 0),
+            isospin=(1, 0),
         )
         assert particle != Particle(
             name="MyParticle", pid=123, mass=1.5, width=0.2, spin=1
@@ -195,7 +195,7 @@ class TestParticle:
             mass=1.2,
             spin=1,
             charge=0,
-            isospin=Spin(1, 0),
+            isospin=(1, 0),
         )
         assert particle == different_labels
         assert hash(particle) == hash(different_labels)
@@ -272,7 +272,7 @@ class TestParticleCollection:
     @staticmethod
     def test_exceptions(particle_database: ParticleCollection):
         gamma = particle_database["gamma"]
-        with pytest.raises(KeyError):
+        with pytest.raises(ValueError):
             particle_database += create_particle(gamma, name="gamma_new")
         with pytest.raises(NotImplementedError):
             particle_database.find(3.14)  # type: ignore


### PR DESCRIPTION
This makes it easier to define a custom `Particle`, because it's not necessary to import and declare `Parity` and `Spin` instances first. For instance:

```python
Particle(
    name="custom",
    pid=99999,
    latex=R"p_\mathrm{custom}",
    spin=1.0,
    mass=1,
    charge=1,
    isospin=(1.5, 0.5),  # no need to use Spin
    charmness=1,
    parity=+1,  # no need to use Parity
)
```