### PR TITLE
feat: allow hiding initial state and resonance ids

### DIFF
--- a/docs/usage.ipynb
+++ b/docs/usage.ipynb
@@ -58,7 +58,64 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The {mod}`expertsystem` consists of three main components: {mod}`~.particle`, {mod}`~.reaction`, and {mod}`~.amplitude` that build on each other. Here's a small example of how to use them!"
+    "The {mod}`expertsystem` consists of three main components: {mod}`.particle`, {mod}`.reaction`, and {mod}`.amplitude` that build on each other. Here's a small example of how to use them!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### Investigate intermediate resonances"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import expertsystem as es\n",
+    "\n",
+    "result = es.reaction.generate(\n",
+    "    initial_state=\"J/psi(1S)\",\n",
+    "    final_state=[\"K0\", \"Sigma+\", \"p~\"],\n",
+    "    allowed_interaction_types=\"strong\",\n",
+    "    formalism_type=\"canonical-helicity\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import graphviz\n",
+    "\n",
+    "dot = es.io.asdot(result, collapse_graphs=True)\n",
+    "graphviz.Source(dot)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Next, you use the {mod}`.amplitude` module to convert these transitions into a mathematical description that you can use to fit your data and perform {doc}`Partial Wave Analysis <pwa:index>`!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    ":::{seealso}\n",
+    "\n",
+    "{doc}`usage/reaction` and {doc}`usage/amplitude`\n",
+    "\n",
+    ":::"
    ]
   },
   {
@@ -156,67 +213,10 @@
    },
    "outputs": [],
    "source": [
-    "import expertsystem as es\n",
-    "\n",
     "es.check_reaction_violations(\n",
     "    initial_state=\"pi0\",\n",
     "    final_state=[\"gamma\", \"gamma\", \"gamma\"],\n",
     ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "tags": []
-   },
-   "source": [
-    "### Investigate intermediate resonances"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "result = es.reaction.generate(\n",
-    "    initial_state=\"J/psi(1S)\",\n",
-    "    final_state=[\"K0\", \"Sigma+\", \"p~\"],\n",
-    "    allowed_interaction_types=\"strong\",\n",
-    "    formalism_type=\"canonical-helicity\",\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import graphviz\n",
-    "\n",
-    "dot = es.io.asdot(result, collapse_graphs=True)\n",
-    "graphviz.Source(dot)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Finally, you use the {mod}`.amplitude` module to convert these transitions into a mathematical description that you can use to fit your data and perform {doc}`Partial Wave Analysis <pwa:index>`!"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    ":::{seealso}\n",
-    "\n",
-    "{doc}`usage/reaction` and {doc}`usage/amplitude`\n",
-    "\n",
-    ":::"
    ]
   },
   {

--- a/docs/usage/visualize.ipynb
+++ b/docs/usage/visualize.ipynb
@@ -85,7 +85,7 @@
    "outputs": [],
    "source": [
     "topology = create_n_body_topology(2, 4)\n",
-    "graphviz.Source(io.asdot(topology))"
+    "graphviz.Source(io.asdot(topology, render_initial_state_id=True))"
    ]
   },
   {
@@ -129,7 +129,12 @@
    "outputs": [],
    "source": [
     "topologies = create_isobar_topologies(5)\n",
-    "dot = io.asdot(topologies[0], render_node=False, render_edge_id=False)\n",
+    "dot = io.asdot(\n",
+    "    topologies[0],\n",
+    "    render_final_state_id=False,\n",
+    "    render_edge_id=False,\n",
+    "    render_node=False,\n",
+    ")\n",
     "display(graphviz.Source(dot))"
    ]
   },
@@ -276,7 +281,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dot = es.io.asdot(result, collapse_graphs=True, render_node=False)\n",
+    "dot = es.io.asdot(\n",
+    "    result, collapse_graphs=True, render_edge_id=False, render_node=False\n",
+    ")\n",
     "graphviz.Source(dot)"
    ]
   }

--- a/docs/usage/visualize.ipynb
+++ b/docs/usage/visualize.ipynb
@@ -119,7 +119,14 @@
    "outputs": [],
    "source": [
     "topologies = create_isobar_topologies(3)\n",
-    "graphviz.Source(io.asdot(topologies, render_node=False, render_edge_id=True))"
+    "graphviz.Source(io.asdot(topologies, render_node=False))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "{func}`.asdot` provides other options as well:"
    ]
   },
   {
@@ -132,7 +139,7 @@
     "dot = io.asdot(\n",
     "    topologies[0],\n",
     "    render_final_state_id=False,\n",
-    "    render_edge_id=False,\n",
+    "    render_resonance_id=True,\n",
     "    render_node=False,\n",
     ")\n",
     "display(graphviz.Source(dot))"
@@ -210,7 +217,7 @@
     "import graphviz\n",
     "\n",
     "dot = es.io.asdot(\n",
-    "    result.transitions[::50][:3], render_edge_id=False, render_node=False\n",
+    "    result.transitions[::50][:3], render_node=False\n",
     ")  # just some selection\n",
     "graphviz.Source(dot)"
    ]
@@ -251,11 +258,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dot = es.io.asdot(\n",
-    "    result.transitions[:3],\n",
-    "    render_edge_id=False,\n",
-    "    strip_spin=True,\n",
-    ")\n",
+    "dot = es.io.asdot(result.transitions[:3], strip_spin=True)\n",
     "graphviz.Source(dot)"
    ]
   },
@@ -281,9 +284,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dot = es.io.asdot(\n",
-    "    result, collapse_graphs=True, render_edge_id=False, render_node=False\n",
-    ")\n",
+    "dot = es.io.asdot(result, collapse_graphs=True, render_node=False)\n",
     "graphviz.Source(dot)"
    ]
   }

--- a/docs/usage/visualize.ipynb
+++ b/docs/usage/visualize.ipynb
@@ -109,7 +109,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This can be turned off with the arguments of {func}`.asdot`:"
+    "This can be turned on or off with the arguments of {func}`.asdot`:"
    ]
   },
   {
@@ -119,7 +119,7 @@
    "outputs": [],
    "source": [
     "topologies = create_isobar_topologies(3)\n",
-    "graphviz.Source(io.asdot(topologies, render_node=False))"
+    "graphviz.Source(io.asdot(topologies, render_node=False, render_edge_id=True))"
    ]
   },
   {

--- a/src/expertsystem/io/__init__.py
+++ b/src/expertsystem/io/__init__.py
@@ -62,10 +62,13 @@ __REQUIRED_TOPOLOGY_FIELDS = {
 
 def asdot(
     instance: object,
+    *,
     render_edge_id: bool = True,
     render_node: bool = True,
     strip_spin: bool = False,
     collapse_graphs: bool = False,
+    render_final_state_id: bool = True,
+    render_initial_state_id: bool = False,
 ) -> str:
     """Convert a `object` to a DOT language `str`.
 
@@ -79,6 +82,8 @@ def asdot(
             instance,
             render_edge_id=render_edge_id,
             render_node=render_node,
+            render_final_state_id=render_final_state_id,
+            render_initial_state_id=render_initial_state_id,
         )
     if isinstance(instance, (Result, abc.Sequence)):
         if isinstance(instance, Result):
@@ -89,6 +94,8 @@ def asdot(
             render_node=render_node,
             strip_spin=strip_spin,
             collapse_graphs=collapse_graphs,
+            render_final_state_id=render_final_state_id,
+            render_initial_state_id=render_initial_state_id,
         )
     raise NotImplementedError(
         f"Cannot convert a {instance.__class__.__name__} to DOT language"

--- a/src/expertsystem/io/__init__.py
+++ b/src/expertsystem/io/__init__.py
@@ -63,12 +63,12 @@ __REQUIRED_TOPOLOGY_FIELDS = {
 def asdot(
     instance: object,
     *,
-    render_edge_id: bool = False,
     render_node: bool = True,
+    render_final_state_id: bool = True,
+    render_resonance_id: bool = False,
+    render_initial_state_id: bool = False,
     strip_spin: bool = False,
     collapse_graphs: bool = False,
-    render_final_state_id: bool = True,
-    render_initial_state_id: bool = False,
 ) -> str:
     """Convert a `object` to a DOT language `str`.
 
@@ -80,9 +80,9 @@ def asdot(
     if isinstance(instance, (StateTransitionGraph, Topology)):
         return _dot.graph_to_dot(
             instance,
-            render_edge_id=render_edge_id,
             render_node=render_node,
             render_final_state_id=render_final_state_id,
+            render_resonance_id=render_resonance_id,
             render_initial_state_id=render_initial_state_id,
         )
     if isinstance(instance, (Result, abc.Sequence)):
@@ -90,12 +90,12 @@ def asdot(
             instance = instance.transitions
         return _dot.graph_list_to_dot(
             instance,
-            render_edge_id=render_edge_id,
             render_node=render_node,
+            render_final_state_id=render_final_state_id,
+            render_resonance_id=render_resonance_id,
+            render_initial_state_id=render_initial_state_id,
             strip_spin=strip_spin,
             collapse_graphs=collapse_graphs,
-            render_final_state_id=render_final_state_id,
-            render_initial_state_id=render_initial_state_id,
         )
     raise NotImplementedError(
         f"Cannot convert a {instance.__class__.__name__} to DOT language"

--- a/src/expertsystem/io/__init__.py
+++ b/src/expertsystem/io/__init__.py
@@ -63,7 +63,7 @@ __REQUIRED_TOPOLOGY_FIELDS = {
 def asdot(
     instance: object,
     *,
-    render_edge_id: bool = True,
+    render_edge_id: bool = False,
     render_node: bool = True,
     strip_spin: bool = False,
     collapse_graphs: bool = False,

--- a/src/expertsystem/io/_dot.py
+++ b/src/expertsystem/io/_dot.py
@@ -41,12 +41,12 @@ def embed_dot(func: Callable) -> Callable:
 def graph_list_to_dot(
     graphs: Sequence[StateTransitionGraph],
     *,
-    render_edge_id: bool,
     render_node: bool,
+    render_final_state_id: bool,
+    render_resonance_id: bool,
+    render_initial_state_id: bool,
     strip_spin: bool,
     collapse_graphs: bool,
-    render_final_state_id: bool,
-    render_initial_state_id: bool,
 ) -> str:
     if strip_spin and collapse_graphs:
         raise ValueError("Cannot both strip spin and collapse graphs")
@@ -59,9 +59,9 @@ def graph_list_to_dot(
         dot += __graph_to_dot_content(
             graph,
             prefix=f"g{i}_",
-            render_edge_id=render_edge_id,
             render_node=render_node,
             render_final_state_id=render_final_state_id,
+            render_resonance_id=render_resonance_id,
             render_initial_state_id=render_initial_state_id,
         )
     return dot
@@ -71,16 +71,16 @@ def graph_list_to_dot(
 def graph_to_dot(
     graph: StateTransitionGraph,
     *,
-    render_edge_id: bool,
     render_node: bool,
     render_final_state_id: bool,
+    render_resonance_id: bool,
     render_initial_state_id: bool,
 ) -> str:
     return __graph_to_dot_content(
         graph,
-        render_edge_id=render_edge_id,
         render_node=render_node,
         render_final_state_id=render_final_state_id,
+        render_resonance_id=render_resonance_id,
         render_initial_state_id=render_initial_state_id,
     )
 
@@ -89,9 +89,9 @@ def __graph_to_dot_content(  # pylint: disable=too-many-locals,too-many-branches
     graph: Union[StateTransitionGraph, Topology],
     prefix: str = "",
     *,
-    render_edge_id: bool,
     render_node: bool,
     render_final_state_id: bool,
+    render_resonance_id: bool,
     render_initial_state_id: bool,
 ) -> str:
     dot = ""
@@ -104,10 +104,9 @@ def __graph_to_dot_content(  # pylint: disable=too-many-locals,too-many-branches
     top = topology.incoming_edge_ids
     outs = topology.outgoing_edge_ids
     for edge_id in top | outs:
-        render = render_edge_id
         if edge_id in top:
             render = render_initial_state_id
-        if edge_id in outs:
+        else:
             render = render_final_state_id
         edge_label = __get_edge_label(graph, edge_id, render)
         dot += _DOT_DEFAULT_NODE.format(
@@ -126,7 +125,7 @@ def __graph_to_dot_content(  # pylint: disable=too-many-locals,too-many-branches
             dot += _DOT_LABEL_EDGE.format(
                 prefix + __node_name(i, k),
                 prefix + __node_name(i, j),
-                __get_edge_label(graph, i, render_edge_id),
+                __get_edge_label(graph, i, render_resonance_id),
             )
     if isinstance(graph, StateTransitionGraph):
         for node_id in topology.nodes:


### PR DESCRIPTION
Argument `render_edge_id` in `asdot` has been split into `render_final_state_id`, `render_resonance_id`, and `render_initial_state_id`.

Edges IDs of initial states and resonances are now hidden by default. They can be shown with the arguments of `asdot`:

```python
import expertsystem as es

es.io.asdot(
    graphs,
    render_node=True,
    render_final_state_id=True,
    render_resonance_id=True,
    render_initial_state_id=True,
    collapse_graphs=True,
)
```

Default view of a `StateTransitionGraph`:

<img src="https://user-images.githubusercontent.com/29308176/112755575-7cd9e380-8fe1-11eb-9414-13e973bad70c.png" width=500>
