### PR TITLE
fix: improve ParticleCollection.find exception

### DIFF
--- a/tests/unit/particle/test_particle.py
+++ b/tests/unit/particle/test_particle.py
@@ -236,12 +236,34 @@ class TestParticleCollection:
         assert phi.pid == 333
         assert pytest.approx(phi.width) == 0.004249
 
-    @pytest.mark.parametrize("search_term", [666, "non-existing"])
+    @pytest.mark.parametrize(
+        "search_term, expected",
+        [
+            (666, None),
+            ("non-existing", None),
+            # cspell:disable
+            ("gamm", "'gamma'"),
+            ("gama", "'gamma', 'Sigma0', 'Sigma-', 'Sigma+', 'Lambda'"),
+            (
+                "omega",
+                "'omega(782)', 'omega(1420)', 'omega(3)(1670)', 'omega(1650)'",
+            ),
+            ("p~~", "'p~'"),
+            ("~", "'p~', 'n~'"),
+            ("lambda", "'Lambda', 'Lambda~', 'Lambda(c)+', 'Lambda(b)0'"),
+            # cspell:enable
+        ],
+    )
     def test_find_fail(
-        self, particle_database: ParticleCollection, search_term
+        self, particle_database: ParticleCollection, search_term, expected
     ):
-        with pytest.raises(LookupError):
+        with pytest.raises(LookupError) as exception:
             particle_database.find(search_term)
+        if expected is not None:
+            message = str(exception.value.args[0])
+            message = message.strip("?")
+            message = message.strip("]")
+            assert message.endswith(expected)
 
     @staticmethod
     def test_filter(particle_database: ParticleCollection):

--- a/tests/unit/particle/test_particle.py
+++ b/tests/unit/particle/test_particle.py
@@ -370,18 +370,6 @@ class TestParticleCollection:
         with pytest.raises(NotImplementedError):
             pions.discard(111)  # type: ignore
 
-    @staticmethod
-    def test_key_error(particle_database: ParticleCollection):
-        try:
-            assert particle_database["omega"]
-        except LookupError as error:
-            assert error.args[-1] == [
-                "omega(782)",
-                "omega(1420)",
-                "omega(3)(1670)",
-                "omega(1650)",
-            ]
-
 
 class TestSpin:
     @staticmethod


### PR DESCRIPTION
Use [`diflib`](https://docs.python.org/3/library/difflib.html) to find more particle candidates in case [`startswith`](https://docs.python.org/3/library/stdtypes.html#str.startswith) fails to find any. For instance:

```python
>>> from expertsystem.particle import load_pdg
>>> pdg = load_pdg()
>>> pdg["lambda"]
Traceback (most recent call last):
...
KeyError: "No particle with name 'lambda' in the database. Did you mean one of these? ['Lambda', 'Lambda~', 'Lambda(c)+', 'Lambda(b)0']"
>>> pdg["gamm"]
Traceback (most recent call last):
...
KeyError: "No particle with name 'gamm' in the database. Did you mean 'gamma'?"
```