### PR TITLE
ci!: run cspell as pre-commit hook

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,11 +119,9 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r reqs/3.7/requirements-sty.txt
           pip install .
-          sudo npm install -g cspell pyright@1.1.99
+          sudo npm install -g pyright@1.1.99
         # https://github.com/ComPWA/expertsystem/issues/437
       - name: Perform style checks
         run: pre-commit run -a
-      - name: Check spelling
-        run: cspell --no-progress $(git ls-files)
       - name: Run pyright
         run: pyright

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,6 +28,11 @@ repos:
         args: ["--django"]
       - id: trailing-whitespace
 
+  - repo: https://github.com/ComPWA/mirrors-cspell
+    rev: v5.3.9
+    hooks:
+      - id: cspell
+
   - repo: https://github.com/igorshubovych/markdownlint-cli
     rev: v0.27.1
     hooks:

--- a/tox.ini
+++ b/tox.ini
@@ -118,7 +118,6 @@ allowlist_externals =
 commands =
     mypy src tests  # run separately because of potential caching problems
     pre-commit run {posargs} -a
-    - bash -ec "cspell --no-progress $(git ls-files)"
 
 [testenv:test]
 description =


### PR DESCRIPTION
[cSpell](https://github.com/streetsidesoftware/cspell) is now enforced through [`pre-commit`](https://github.com/ComPWA/mirrors-cspell). This means that there is no need anymore to install cSpell through `npm` and that spelling is checked upon committing :tada: 

For more info, see [github.com/ComPWA/mirrors-cspell](https://github.com/ComPWA/mirrors-cspell).