### PR TITLE
fix: unconstrain _ElementType and unpin Pyright

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,8 +119,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r reqs/3.7/requirements-sty.txt
           pip install .
-          sudo npm install -g pyright@1.1.99
-        # https://github.com/ComPWA/expertsystem/issues/437
+          sudo npm install -g pyright
       - name: Perform style checks
         run: pre-commit run -a
       - name: Run pyright

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,8 +119,5 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r reqs/3.7/requirements-sty.txt
           pip install .
-          sudo npm install -g pyright
       - name: Perform style checks
         run: pre-commit run -a
-      - name: Run pyright
-        run: pyright

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -65,6 +65,11 @@ repos:
       - id: prettier
         language_version: 12.18.2 # prettier does not specify node correctly
 
+  - repo: https://github.com/ComPWA/mirrors-pyright
+    rev: v1.1.126
+    hooks:
+      - id: pyright
+
   # The following tools have to be install locally, because they can also be
   # used by code editors (e.g. linting and format-on-save).
 

--- a/src/expertsystem/reaction/argument_handling.py
+++ b/src/expertsystem/reaction/argument_handling.py
@@ -37,7 +37,7 @@ Scalar = Union[int, float]
 # InteractionRule = Union[EdgeQNConservationRule, ConservationRule]
 Rule = Union[GraphElementRule, EdgeQNConservationRule, ConservationRule]
 
-_ElementType = TypeVar("_ElementType", EdgeQuantumNumber, NodeQuantumNumber)
+_ElementType = TypeVar("_ElementType")
 
 GraphElementPropertyMap = Dict[Type[_ElementType], Scalar]
 GraphEdgePropertyMap = GraphElementPropertyMap[EdgeQuantumNumber]


### PR DESCRIPTION
Closes #437 

Unconstrain the `TypeVar` used in `GraphElementPropertyMap` so that Pyright can handle it. This allows upgrading Pyright to 1.1.100 and up, and therefore running it as a pre-commit hook.